### PR TITLE
chore(internal): Adding Internal Responses

### DIFF
--- a/Sources/socktainer/Models/InternalServerResponse.swift
+++ b/Sources/socktainer/Models/InternalServerResponse.swift
@@ -1,0 +1,19 @@
+import Vapor
+
+struct AppleContainerNotSupported {
+    static func respond(_ feature: String) -> Response {
+        let json = "{\"message\": \"\(feature) is not supported in Apple container\"}"
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "application/json")
+        return Response(status: .internalServerError, headers: headers, body: .init(string: json))
+    }
+}
+
+struct NotImplemented {
+    static func respond(_ endpoint: String, _ method: String) -> Response {
+        let json = "{\"message\": \"Method \(method) to \(endpoint) is not implemented by socktainer at the moment\"}"
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "application/json")
+        return Response(status: .internalServerError, headers: headers, body: .init(string: json))
+    }
+}

--- a/Sources/socktainer/Routes/InfoRoute.swift
+++ b/Sources/socktainer/Routes/InfoRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct InfoRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "info", use: InfoRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/info", "GET")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmInitRoute.swift
+++ b/Sources/socktainer/Routes/SwarmInitRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmInitRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "swarm", "init", use: SwarmInitRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmJoinRoute.swift
+++ b/Sources/socktainer/Routes/SwarmJoinRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmJoinRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "swarm", "join", use: SwarmJoinRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmLeaveRoute.swift
+++ b/Sources/socktainer/Routes/SwarmLeaveRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmLeaveRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "swarm", "leave", use: SwarmLeaveRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmRoute.swift
+++ b/Sources/socktainer/Routes/SwarmRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "swarm", use: SwarmRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmUnlockKeyRoute.swift
+++ b/Sources/socktainer/Routes/SwarmUnlockKeyRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmUnlockKeyRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "swarm", "unlockkey", use: SwarmUnlockKeyRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmUnlockRoute.swift
+++ b/Sources/socktainer/Routes/SwarmUnlockRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmUnlockRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "swarm", "unlock", use: SwarmUnlockRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SwarmUpdateRoute.swift
+++ b/Sources/socktainer/Routes/SwarmUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SwarmUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "swarm", "update", use: SwarmUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -8,6 +8,9 @@ func configure(_ app: Application) async throws {
     // /_ping
     try app.register(collection: HealthCheckPingRoute(client: healthCheckClient))
 
+    // /info
+    try app.register(collection: InfoRoute())
+
     // /events
     try app.register(collection: EventsRoute(client: healthCheckClient))
 
@@ -29,6 +32,15 @@ func configure(_ app: Application) async throws {
 
     // /volumes
     try app.register(collection: VolumeListRoute())
+
+    // /swarm
+    try app.register(collection: SwarmRoute())
+    try app.register(collection: SwarmInitRoute())
+    try app.register(collection: SwarmJoinRoute())
+    try app.register(collection: SwarmLeaveRoute())
+    try app.register(collection: SwarmUpdateRoute())
+    try app.register(collection: SwarmUnlockKeyRoute())
+    try app.register(collection: SwarmUnlockRoute())
 
     // Initialize broadcaster
     let broadcaster = EventBroadcaster()


### PR DESCRIPTION
Adding two types of internal responses that can be returned to clients:
- AppleContainerNotSupported - Capability is not supported
- NotImplemented - Capability is not implemented at the moment

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
