### PR TITLE
chore(routes): Stub Docker Engine API v1.51 Endpoints

### DIFF
--- a/Sources/socktainer/Routes/AuthRoute.swift
+++ b/Sources/socktainer/Routes/AuthRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct AuthRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "auth", use: AuthRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/auth", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/BuildPruneRoute.swift
+++ b/Sources/socktainer/Routes/BuildPruneRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct BuildPruneRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "build", "prune", use: BuildPruneRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/build/prune", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/BuildRoute.swift
+++ b/Sources/socktainer/Routes/BuildRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct BuildRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "build", use: BuildRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/build", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/CommitRoute.swift
+++ b/Sources/socktainer/Routes/CommitRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct CommitRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "commit", use: CommitRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/commit", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ConfigsCreateRoute.swift
+++ b/Sources/socktainer/Routes/ConfigsCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ConfigsCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "configs", "create", use: ConfigsCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ConfigsIdRoute.swift
+++ b/Sources/socktainer/Routes/ConfigsIdRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ConfigsIdRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "configs", ":id", use: ConfigsIdRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ConfigsIdUpdateRoute.swift
+++ b/Sources/socktainer/Routes/ConfigsIdUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ConfigsIdUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "configs", ":id", "update", use: ConfigsIdUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ConfigsRoute.swift
+++ b/Sources/socktainer/Routes/ConfigsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ConfigsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "configs", use: ConfigsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ContainerArchiveRoute.swift
+++ b/Sources/socktainer/Routes/ContainerArchiveRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerArchiveRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "archive", use: ContainerArchiveRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/archive", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/ContainerAttachRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerAttachRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "attach", use: ContainerAttachRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/attach", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/ContainerAttachWSRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerAttachWSRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "attach", "ws", use: ContainerAttachWSRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/attach/ws", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerChangesRoute.swift
+++ b/Sources/socktainer/Routes/ContainerChangesRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerChangesRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "changes", use: ContainerChangesRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/changes", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", "create", use: ContainerCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/create", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerExportRoute.swift
+++ b/Sources/socktainer/Routes/ContainerExportRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerExportRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "export", use: ContainerExportRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/export", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerKillRoute.swift
+++ b/Sources/socktainer/Routes/ContainerKillRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerKillRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "kill", use: ContainerKillRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/kill", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerPauseRoute.swift
+++ b/Sources/socktainer/Routes/ContainerPauseRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerPauseRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "pause", use: ContainerPauseRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/pause", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerPruneRoute.swift
+++ b/Sources/socktainer/Routes/ContainerPruneRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerPruneRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", "prune", use: ContainerPruneRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/prune", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerRenameRoute.swift
+++ b/Sources/socktainer/Routes/ContainerRenameRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerRenameRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "rename", use: ContainerRenameRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/rename", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerResizeRoute.swift
+++ b/Sources/socktainer/Routes/ContainerResizeRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerResizeRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "resize", use: ContainerResizeRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/resize", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/ContainerRestartRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerRestartRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "restart", use: ContainerRestartRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/restart", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerStatsRoute.swift
+++ b/Sources/socktainer/Routes/ContainerStatsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerStatsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "stats", use: ContainerStatsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/stats", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerTopRoute.swift
+++ b/Sources/socktainer/Routes/ContainerTopRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerTopRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "containers", ":id", "top", use: ContainerTopRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/top", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerUnpauseRoute.swift
+++ b/Sources/socktainer/Routes/ContainerUnpauseRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerUnpauseRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "unpause", use: ContainerUnpauseRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/unpause", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerUpdateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "update", use: ContainerUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/update", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/ContainerWaitRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ContainerWaitRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "wait", use: ContainerWaitRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/containers/{id}/wait", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/DistributionJsonRoute.swift
+++ b/Sources/socktainer/Routes/DistributionJsonRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct DistributionJsonRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "distribution", ":name", "json", use: DistributionJsonRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/distribution/{name}/json", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImageGetRoute.swift
+++ b/Sources/socktainer/Routes/ImageGetRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImageGetRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "images", ":name", "get", use: ImageGetRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/{name}/get", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/ImageHistoryRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImageHistoryRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "images", ":name", "history", use: ImageHistoryRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/{name}/history", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImagePruneRoute.swift
+++ b/Sources/socktainer/Routes/ImagePruneRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImagePruneRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "images", "prune", use: ImagePruneRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/prune", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImagePushRoute.swift
+++ b/Sources/socktainer/Routes/ImagePushRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImagePushRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "images", ":name", "push", use: ImagePushRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/{name}/push", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImageSearchRoute.swift
+++ b/Sources/socktainer/Routes/ImageSearchRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImageSearchRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "images", "search", use: ImageSearchRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/search", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImageSummaryRoute.swift
+++ b/Sources/socktainer/Routes/ImageSummaryRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImageSummaryRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "images", ":name", "json", use: ImageSummaryRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/{name}/json", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImageTagRoute.swift
+++ b/Sources/socktainer/Routes/ImageTagRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImageTagRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "images", ":name", "tag", use: ImageTagRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/{name}/tag", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/ImagesGetRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImagesGetRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "images", "get", use: ImagesGetRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/get", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/ImagesLoadRoute.swift
+++ b/Sources/socktainer/Routes/ImagesLoadRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ImagesLoadRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "images", "load", use: ImagesLoadRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/images/load", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/InfoRoute.swift
+++ b/Sources/socktainer/Routes/InfoRoute.swift
@@ -6,6 +6,6 @@ struct InfoRoute: RouteCollection {
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/info", "GET")
+        NotImplemented.respond("/info", req.method.rawValue)
     }
 }

--- a/Sources/socktainer/Routes/NetworkConnectRoute.swift
+++ b/Sources/socktainer/Routes/NetworkConnectRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkConnectRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "networks", ":id", "connect", use: NetworkConnectRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks/{id}/connect", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/NetworkCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "networks", "create", use: NetworkCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks/create", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NetworkDisconnectRoute.swift
+++ b/Sources/socktainer/Routes/NetworkDisconnectRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkDisconnectRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "networks", ":id", "disconnect", use: NetworkDisconnectRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks/{id}/disconnect", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NetworkInspectRoute.swift
+++ b/Sources/socktainer/Routes/NetworkInspectRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkInspectRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "networks", ":id", use: NetworkInspectRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks/{id}", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NetworkListRoute.swift
+++ b/Sources/socktainer/Routes/NetworkListRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkListRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "networks", use: NetworkListRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NetworkPruneRoute.swift
+++ b/Sources/socktainer/Routes/NetworkPruneRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NetworkPruneRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "networks", "prune", use: NetworkPruneRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/networks/prune", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/NodesIdRoute.swift
+++ b/Sources/socktainer/Routes/NodesIdRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NodesIdRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "nodes", ":id", use: NodesIdRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/NodesIdUpdateRoute.swift
+++ b/Sources/socktainer/Routes/NodesIdUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NodesIdUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "nodes", ":id", "update", use: NodesIdUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/NodesRoute.swift
+++ b/Sources/socktainer/Routes/NodesRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct NodesRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "nodes", use: NodesRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/PluginsCreateRoute.swift
+++ b/Sources/socktainer/Routes/PluginsCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", "create", use: PluginsCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/create", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameDisableRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameDisableRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameDisableRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", ":name", "disable", use: PluginsNameDisableRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/disable", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameEnableRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameEnableRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameEnableRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", ":name", "enable", use: PluginsNameEnableRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/enable", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameJsonRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameJsonRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameJsonRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "plugins", ":name", "json", use: PluginsNameJsonRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/json", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNamePushRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNamePushRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNamePushRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", ":name", "push", use: PluginsNamePushRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/push", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "plugins", ":name", use: PluginsNameRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameSetRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameSetRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameSetRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", ":name", "set", use: PluginsNameSetRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/set", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsNameUpgradeRoute.swift
+++ b/Sources/socktainer/Routes/PluginsNameUpgradeRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsNameUpgradeRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", ":name", "upgrade", use: PluginsNameUpgradeRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/{name}/upgrade", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsPrivilegesRoute.swift
+++ b/Sources/socktainer/Routes/PluginsPrivilegesRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsPrivilegesRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "plugins", "privileges", use: PluginsPrivilegesRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/privileges", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsPullRoute.swift
+++ b/Sources/socktainer/Routes/PluginsPullRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsPullRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "plugins", "pull", use: PluginsPullRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins/pull", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/PluginsRoute.swift
+++ b/Sources/socktainer/Routes/PluginsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct PluginsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "plugins", use: PluginsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/plugins", req.method.string)
+    }
+}

--- a/Sources/socktainer/Routes/SecretsCreateRoute.swift
+++ b/Sources/socktainer/Routes/SecretsCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SecretsCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "secrets", "create", use: SecretsCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SecretsIdRoute.swift
+++ b/Sources/socktainer/Routes/SecretsIdRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SecretsIdRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "secrets", ":id", use: SecretsIdRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SecretsIdUpdateRoute.swift
+++ b/Sources/socktainer/Routes/SecretsIdUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SecretsIdUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "secrets", ":id", "update", use: SecretsIdUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SecretsRoute.swift
+++ b/Sources/socktainer/Routes/SecretsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SecretsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "secrets", use: SecretsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ServicesCreateRoute.swift
+++ b/Sources/socktainer/Routes/ServicesCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ServicesCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "services", "create", use: ServicesCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ServicesIdLogsRoute.swift
+++ b/Sources/socktainer/Routes/ServicesIdLogsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ServicesIdLogsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "services", ":id", "logs", use: ServicesIdLogsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ServicesIdRoute.swift
+++ b/Sources/socktainer/Routes/ServicesIdRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ServicesIdRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "services", ":id", use: ServicesIdRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ServicesIdUpdateRoute.swift
+++ b/Sources/socktainer/Routes/ServicesIdUpdateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ServicesIdUpdateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "services", ":id", "update", use: ServicesIdUpdateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/ServicesRoute.swift
+++ b/Sources/socktainer/Routes/ServicesRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct ServicesRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "services", use: ServicesRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/SessionRoute.swift
+++ b/Sources/socktainer/Routes/SessionRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SessionRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "session", use: SessionRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Interactive session")
+    }
+}

--- a/Sources/socktainer/Routes/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/SystemDFRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct SystemDFRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "system", "df", use: SystemDFRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/system/df", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/TasksIdLogsRoute.swift
+++ b/Sources/socktainer/Routes/TasksIdLogsRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct TasksIdLogsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "tasks", ":id", "logs", use: TasksIdLogsRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/TasksIdRoute.swift
+++ b/Sources/socktainer/Routes/TasksIdRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct TasksIdRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "tasks", ":id", use: TasksIdRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/TasksRoute.swift
+++ b/Sources/socktainer/Routes/TasksRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct TasksRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "tasks", use: TasksRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        AppleContainerNotSupported.respond("Swarm")
+    }
+}

--- a/Sources/socktainer/Routes/VersionRoute.swift
+++ b/Sources/socktainer/Routes/VersionRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct VersionRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("version", use: VersionRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/version", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/VolumeCreateRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct VolumeCreateRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "volumes", "create", use: VolumeCreateRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/volumes/create", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/VolumeNameRoute.swift
+++ b/Sources/socktainer/Routes/VolumeNameRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct VolumeNameRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "volumes", ":name", use: VolumeNameRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/volumes/{name}", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/Routes/VolumePruneRoute.swift
+++ b/Sources/socktainer/Routes/VolumePruneRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct VolumePruneRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "volumes", "prune", use: VolumePruneRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        NotImplemented.respond("/volumes/prune", req.method.rawValue)
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -18,29 +18,122 @@ func configure(_ app: Application) async throws {
     try app.register(collection: ExecRoute(client: containerClient))
 
     // /containers
-    try app.register(collection: ContainerListRoute(client: containerClient))
-    try app.register(collection: ContainerInspectRoute(client: containerClient))
-    try app.register(collection: ContainerLogsRoute(client: containerClient))
-    try app.register(collection: ContainerStartRoute(client: containerClient))
-    try app.register(collection: ContainerStopRoute(client: containerClient))
+    try app.register(collection: ContainerArchiveRoute())
+    try app.register(collection: ContainerAttachRoute())
+    try app.register(collection: ContainerAttachWSRoute())
+    try app.register(collection: ContainerChangesRoute())
+    try app.register(collection: ContainerCreateRoute())
     try app.register(collection: ContainerDeleteRoute(client: containerClient))
+    try app.register(collection: ContainerExportRoute())
+    try app.register(collection: ContainerInspectRoute(client: containerClient))
+    try app.register(collection: ContainerKillRoute())
+    try app.register(collection: ContainerListRoute(client: containerClient))
+    try app.register(collection: ContainerLogsRoute(client: containerClient))
+    try app.register(collection: ContainerPauseRoute())
+    try app.register(collection: ContainerPruneRoute())
+    try app.register(collection: ContainerRenameRoute())
+    try app.register(collection: ContainerResizeRoute())
+    try app.register(collection: ContainerRestartRoute())
+    try app.register(collection: ContainerStartRoute(client: containerClient))
+    try app.register(collection: ContainerStatsRoute())
+    try app.register(collection: ContainerStopRoute(client: containerClient))
+    try app.register(collection: ContainerTopRoute())
+    try app.register(collection: ContainerUnpauseRoute())
+    try app.register(collection: ContainerUpdateRoute())
+    try app.register(collection: ContainerWaitRoute())
 
     // /images
-    try app.register(collection: ImageListRoute(client: imageClient))
     try app.register(collection: ImageDeleteRoute(client: imageClient))
+    try app.register(collection: ImageGetRoute())
+    try app.register(collection: ImageHistoryRoute())
+    try app.register(collection: ImageListRoute(client: imageClient))
+    try app.register(collection: ImagePruneRoute())
     try app.register(collection: ImagePullRoute(client: imageClient))
+    try app.register(collection: ImagePushRoute())
+    try app.register(collection: ImageSearchRoute())
+    try app.register(collection: ImageSummaryRoute())
+    try app.register(collection: ImageTagRoute())
+    try app.register(collection: ImagesGetRoute())
+    try app.register(collection: ImagesLoadRoute())
 
     // /volumes
+    try app.register(collection: VolumeCreateRoute())
     try app.register(collection: VolumeListRoute())
+    try app.register(collection: VolumeNameRoute())
+    try app.register(collection: VolumePruneRoute())
 
     // /swarm
-    try app.register(collection: SwarmRoute())
     try app.register(collection: SwarmInitRoute())
     try app.register(collection: SwarmJoinRoute())
     try app.register(collection: SwarmLeaveRoute())
-    try app.register(collection: SwarmUpdateRoute())
+    try app.register(collection: SwarmRoute())
     try app.register(collection: SwarmUnlockKeyRoute())
     try app.register(collection: SwarmUnlockRoute())
+    try app.register(collection: SwarmUpdateRoute())
+
+    // --- network routes ---
+    try app.register(collection: NetworkConnectRoute())
+    try app.register(collection: NetworkCreateRoute())
+    try app.register(collection: NetworkDisconnectRoute())
+    try app.register(collection: NetworkInspectRoute())
+    try app.register(collection: NetworkListRoute())
+    try app.register(collection: NetworkPruneRoute())
+
+    // --- build/distribution routes ---
+    try app.register(collection: BuildPruneRoute())
+    try app.register(collection: BuildRoute())
+    try app.register(collection: DistributionJsonRoute())
+
+    // --- plugin routes ---
+    try app.register(collection: PluginsCreateRoute())
+    try app.register(collection: PluginsNameDisableRoute())
+    try app.register(collection: PluginsNameEnableRoute())
+    try app.register(collection: PluginsNameJsonRoute())
+    try app.register(collection: PluginsNamePushRoute())
+    try app.register(collection: PluginsNameRoute())
+    try app.register(collection: PluginsNameSetRoute())
+    try app.register(collection: PluginsNameUpgradeRoute())
+    try app.register(collection: PluginsPrivilegesRoute())
+    try app.register(collection: PluginsPullRoute())
+    try app.register(collection: PluginsRoute())
+
+    // --- swarm node routes ---
+    try app.register(collection: NodesIdRoute())
+    try app.register(collection: NodesIdUpdateRoute())
+    try app.register(collection: NodesRoute())
+
+    // --- swarm service routes ---
+    try app.register(collection: ServicesCreateRoute())
+    try app.register(collection: ServicesIdLogsRoute())
+    try app.register(collection: ServicesIdRoute())
+    try app.register(collection: ServicesIdUpdateRoute())
+    try app.register(collection: ServicesRoute())
+
+    // --- swarm task routes ---
+    try app.register(collection: TasksIdLogsRoute())
+    try app.register(collection: TasksIdRoute())
+    try app.register(collection: TasksRoute())
+
+    // --- Swarm secret routes ---
+    try app.register(collection: SecretsCreateRoute())
+    try app.register(collection: SecretsIdRoute())
+    try app.register(collection: SecretsIdUpdateRoute())
+    try app.register(collection: SecretsRoute())
+
+    // --- swarm config routes ---
+    try app.register(collection: ConfigsCreateRoute())
+    try app.register(collection: ConfigsIdRoute())
+    try app.register(collection: ConfigsIdUpdateRoute())
+    try app.register(collection: ConfigsRoute())
+
+    // --- session route ---
+    try app.register(collection: SessionRoute())
+
+    // --- miscellaneous ---
+    try app.register(collection: AuthRoute())
+    try app.register(collection: CommitRoute())
+    try app.register(collection: SystemDFRoute())
+    try app.register(collection: VersionRoute())
 
     // Initialize broadcaster
     let broadcaster = EventBroadcaster()


### PR DESCRIPTION
Stub all endpoints exposed by Docker engine v1.51 API.

Supported capabilities by Apple container will return `NotImplemented`.

Docker exclusive capabilities will return `AppleContainerNotSupported`.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
