### PR TITLE
feat(routes): Implement `/info` and `/version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ MACOS_MAJOR := $(shell echo $(MACOS_VERSION) | cut -d. -f1)
 export BUILD_VERSION := $(shell git describe --tags --exact-match HEAD 2>/dev/null || echo "0.0.0-dev")
 export BUILD_GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 export BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Build information - docker engine API versions
+export DOCKER_ENGINE_API_MIN_VERSION := v1.32
+export DOCKER_ENGINE_API_MAX_VERSION := v1.51
 
 SUDO ?= sudo
 .DEFAULT_GOAL := all
@@ -48,6 +51,8 @@ version:
 	@echo "Version: $(BUILD_VERSION)"
 	@echo "Commit: $(BUILD_GIT_COMMIT)"
 	@echo "Build Time: $(BUILD_TIME)"
+	@echo "Docker Engine API Min version: $(DOCKER_ENGINE_API_MIN_VERSION)"
+	@echo "Docker Engine API Max version: $(DOCKER_ENGINE_API_MAX_VERSION)"
 
 .PHONY: test
 test:

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/container.git", from: "0.4.1"),
+        .package(url: "https://github.com/apple/containerization.git", from: "0.5.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.116.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.1"),
@@ -22,6 +23,7 @@ let package = Package(
             name: "socktainer",
             dependencies: [
                 .product(name: "ContainerClient", package: "container"),
+                .product(name: "Containerization", package: "containerization"),
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,8 @@ import PackageDescription
 let buildGitCommit = ProcessInfo.processInfo.environment["BUILD_GIT_COMMIT"] ?? "unspecified"
 let buildVersion = ProcessInfo.processInfo.environment["BUILD_VERSION"] ?? "unspecified"
 let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
+let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "unspecified"
+let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "unspecified"
 
 let package = Package(
     name: "socktainer",
@@ -13,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/container.git", from: "0.4.1"),
-        .package(url: "https://github.com/apple/containerization.git", from: "0.5.0"),
+        .package(url: "https://github.com/apple/containerization.git", from: "0.6.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.116.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.1"),
@@ -42,6 +44,8 @@ let package = Package(
                 .define("BUILD_GIT_COMMIT", to: "\"\(buildGitCommit)\""),
                 .define("BUILD_VERSION", to: "\"\(buildVersion)\""),
                 .define("BUILD_TIME", to: "\"\(buildTime)\""),
+                .define("DOCKER_ENGINE_API_MIN_VERSION", to: "\"\(dockerEngineApiMinVersion)\""),
+                .define("DOCKER_ENGINE_API_MAX_VERSION", to: "\"\(dockerEngineApiMaxVersion)\""),
             ]
         ),
 

--- a/Sources/BuildInfo/BuildInfo.c
+++ b/Sources/BuildInfo/BuildInfo.c
@@ -11,3 +11,11 @@ const char* get_build_git_commit(void) {
 const char* get_build_time(void) {
     return BUILD_TIME;
 }
+
+const char* get_docker_engine_api_min_version(void) {
+    return DOCKER_ENGINE_API_MIN_VERSION;
+}
+
+const char* get_docker_engine_api_max_version(void) {
+    return DOCKER_ENGINE_API_MAX_VERSION;
+}

--- a/Sources/BuildInfo/include/BuildInfo.h
+++ b/Sources/BuildInfo/include/BuildInfo.h
@@ -10,14 +10,6 @@
 #define BUILD_TIME "unspecified"
 #endif
 
-#ifndef DOCKER_ENGINE_API_MIN_VERSION
-#define DOCKER_ENGINE_API_MIN_VERSION "1.51"
-#endif
-
-#ifndef DOCKER_ENGINE_API_MAX_VERSION
-#define DOCKER_ENGINE_API_MAX_VERSION "1.51"
-#endif
-
 const char* get_build_version();
 
 const char* get_build_git_commit();

--- a/Sources/BuildInfo/include/BuildInfo.h
+++ b/Sources/BuildInfo/include/BuildInfo.h
@@ -10,8 +10,20 @@
 #define BUILD_TIME "unspecified"
 #endif
 
+#ifndef DOCKER_ENGINE_API_MIN_VERSION
+#define DOCKER_ENGINE_API_MIN_VERSION "1.51"
+#endif
+
+#ifndef DOCKER_ENGINE_API_MAX_VERSION
+#define DOCKER_ENGINE_API_MAX_VERSION "1.51"
+#endif
+
 const char* get_build_version();
 
 const char* get_build_git_commit();
 
 const char* get_build_time();
+
+const char* get_docker_engine_api_min_version();
+
+const char* get_docker_engine_api_max_version();

--- a/Sources/socktainer/Models/ServerInfo.swift
+++ b/Sources/socktainer/Models/ServerInfo.swift
@@ -31,16 +31,18 @@ struct SystemInfo: Content {
     var Labels: [String]?
     var ExperimentalBuild: Bool
     var ServerVersion: String
-    var Runtimes: [String: Runtime]
-    var DefaultRuntime: String
+    // NOTE: In Apple container, each container uses a dedicated runtime
+    // var Runtimes: [String: Runtime]
+    // var DefaultRuntime: String
     var ProductLicense: String
     var SystemTime: String
     var Warnings: [String]
 }
 
-struct Runtime: Content {
-    var path: String
-}
+// NOTE: In Apple container, each container uses a dedicated runtime
+// struct Runtime: Content {
+//     var path: String
+// }
 
 // NOTE: Doesn't attempt to mimic fully the schema
 // https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemVersion

--- a/Sources/socktainer/Models/ServerInfo.swift
+++ b/Sources/socktainer/Models/ServerInfo.swift
@@ -1,0 +1,69 @@
+import Vapor
+
+// NOTE: Doesn't attempt to mimic fully the schema
+//       https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemAuth
+//       Things that should be revisited in the future
+//       - Driver + Driver Status (storage)
+//       - Plugins
+//       - Registry config
+//       - Init binary + commit
+//       - Default network address pool
+struct SystemInfo: Content {
+    var Containers: Int
+    var ContainersRunning: Int
+    /// NOTE: Apple container doesn't support pausing containers
+    var ContainersPaused: Int
+    var ContainersStopped: Int
+    var Images: Int
+    var DockerRootDir: String
+    var Debug: Bool
+    var KernelVersion: String
+    var OSVersion: String?
+    var OSType: String
+    var Architecture: String
+    var NCPU: Int
+    var MemTotal: Int64
+    var HttpProxy: String?
+    var HttpsProxy: String?
+    var NoProxy: String?
+    var Name: String
+    // NOTE: Consider enabling user to define labels
+    var Labels: [String]?
+    var ExperimentalBuild: Bool
+    var ServerVersion: String
+    var Runtimes: [String: Runtime]
+    var DefaultRuntime: String
+    var ProductLicense: String
+    var SystemTime: String
+    var Warnings: [String]
+}
+
+struct Runtime: Content {
+    var path: String
+}
+
+// NOTE: Doesn't attempt to mimic fully the schema
+// https://docs.docker.com/reference/api/engine/version/v1.51/#tag/System/operation/SystemVersion
+struct VersionInfo: Content {
+    var Platform: ServerPlatform
+    var Components: [Component]
+    var Version: String
+    var ApiVersion: String
+    var MinAPIVersion: String
+    var GitCommit: String
+    var Os: String
+    var Arch: String
+    var KernelVersion: String
+    var Experimental: Bool
+    var BuildTime: String
+
+}
+
+struct ServerPlatform: Content {
+    var Name: String
+}
+
+struct Component: Content {
+    var Name: String
+    var Version: String
+}

--- a/Sources/socktainer/Routes/ContainerPauseRoute.swift
+++ b/Sources/socktainer/Routes/ContainerPauseRoute.swift
@@ -6,6 +6,6 @@ struct ContainerPauseRoute: RouteCollection {
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/pause", req.method.rawValue)
+        AppleContainerNotSupported.respond("Pausing container")
     }
 }

--- a/Sources/socktainer/Routes/InfoRoute.swift
+++ b/Sources/socktainer/Routes/InfoRoute.swift
@@ -1,3 +1,4 @@
+import ContainerClient
 import Vapor
 
 struct InfoRoute: RouteCollection {
@@ -6,6 +7,47 @@ struct InfoRoute: RouteCollection {
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/info", req.method.rawValue)
+        do {
+            let containerClient = ClientContainerService()
+            let allContainers = try await containerClient.list(showAll: true)
+
+            let info = SystemInfo(
+                Containers: allContainers.count,
+                ContainersRunning: allContainers.filter { $0.status == .running }.count,
+                // Apple container doesn't support pausing containers
+                ContainersPaused: 0,
+                ContainersStopped: allContainers.filter { $0.status == .stopped }.count,
+                Images: try await ClientImageService().list().count,
+                DockerRootDir: try await ClientHealthCheck.ping().appRoot.path,
+                Debug: isDebug(),
+                KernelVersion: try await getLinuxDefaultKernelName(),
+                OSVersion: currentPlatform().osVersion ?? nil,
+                OSType: currentPlatform().os,
+                Architecture: currentPlatform().architecture,
+                NCPU: hostCPUCoreCount(),
+                MemTotal: Int64(hostPhysicalMemory()),
+                HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,
+                HttpsProxy: ProcessInfo.processInfo.environment["HTTPS_PROXY"] ?? nil,
+                NoProxy: ProcessInfo.processInfo.environment["NO_PROXY"] ?? nil,
+                Name: hostName(),
+                ExperimentalBuild: true,
+                ServerVersion: try await ClientHealthCheck.ping().apiServerVersion,
+                // TODO: Derive this dynamically somehow
+                Runtimes: [
+                    "container-runtime-linux": Runtime(
+                        path: "/usr/local/libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux")
+                ],
+                DefaultRuntime: "container-runtime-linux",
+                ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
+                SystemTime: currentTime(),
+                Warnings: ["WARNING: Apple container system info may differ"],
+            )
+            return try await info.encodeResponse(for: req)
+        } catch {
+            let response = Response(status: .internalServerError)
+            response.headers.add(name: .contentType, value: "application/json")
+            response.body = .init(string: "{\"message\": \"Failed to generate system information\"}\n")
+            return response
+        }
     }
 }

--- a/Sources/socktainer/Routes/InfoRoute.swift
+++ b/Sources/socktainer/Routes/InfoRoute.swift
@@ -32,15 +32,12 @@ struct InfoRoute: RouteCollection {
                 Name: hostName(),
                 ExperimentalBuild: true,
                 ServerVersion: try await ClientHealthCheck.ping().apiServerVersion,
-                // TODO: Derive this dynamically somehow
-                Runtimes: [
-                    "container-runtime-linux": Runtime(
-                        path: "/usr/local/libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux")
-                ],
-                DefaultRuntime: "container-runtime-linux",
                 ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
                 SystemTime: currentTime(),
-                Warnings: ["WARNING: Apple container system info may differ"],
+                Warnings: [
+                    "WARNING: Apple container system info may differ",
+                    "NOTE: socktainer is still under active development and considered experimental!",
+                ],
             )
             return try await info.encodeResponse(for: req)
         } catch {

--- a/Sources/socktainer/Routes/VersionRoute.swift
+++ b/Sources/socktainer/Routes/VersionRoute.swift
@@ -11,9 +11,13 @@ struct VersionRoute: RouteCollection {
         do {
             let version = VersionInfo(
                 Platform: ServerPlatform(Name: "socktainer"),
-                // NOTE: Empty for the time being, could be populated with additional information
-                Components: [],
-                Version: getBuildVersion(),
+                // NOTE: For the time being, we will report socktainer's version as a component
+                //       https://github.com/socktainer/socktainer/pull/28#issuecomment-3318209340
+                Components: [Component(Name: "socktainer", Version: getBuildVersion())],
+                // NOTE: Some libraries may require a higher SemVer version compared to Socktainer's actual version
+                //       https://github.com/testcontainers/testcontainers-java/blob/51219646dca72ad267e575bf25d0b60208c60b42/core/src/main/java/org/testcontainers/DockerClientFactory.java#L272
+                //       As a workaround, set the version as the highest supported Docker Engine API version
+                Version: getDockerEngineApiMaxVersion(),
                 ApiVersion: getDockerEngineApiMaxVersion(),
                 MinAPIVersion: getDockerEngineApiMinVersion(),
                 GitCommit: getBuildGitCommit(),

--- a/Sources/socktainer/Routes/VersionRoute.swift
+++ b/Sources/socktainer/Routes/VersionRoute.swift
@@ -2,10 +2,32 @@ import Vapor
 
 struct VersionRoute: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
+        routes.get(":version", "version", use: VersionRoute.handler)
+        // also handle without version prefix
         routes.get("version", use: VersionRoute.handler)
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/version", req.method.rawValue)
+        do {
+            let version = VersionInfo(
+                Platform: ServerPlatform(Name: "socktainer"),
+                Components: [],
+                Version: ProcessInfo.processInfo.environment["SOCKTAINER_VERSION"] ?? "unknown",
+                ApiVersion: "v1.51",
+                MinAPIVersion: "v1.51",
+                GitCommit: ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unknown",
+                Os: "macOS",
+                Arch: "arm64",
+                KernelVersion: getKernel(),
+                Experimental: isDebug(),
+                BuildTime: ProcessInfo.processInfo.environment["SOCKTAINER_BUILD_TIME"] ?? "unknown",
+            )
+            return try await version.encodeResponse(for: req)
+        } catch {
+            let response = Response(status: .internalServerError)
+            response.headers.add(name: .contentType, value: "application/json")
+            response.body = .init(string: "{\"message\": \"Failed to generate version information\"}\n")
+            return response
+        }
     }
 }

--- a/Sources/socktainer/Routes/VersionRoute.swift
+++ b/Sources/socktainer/Routes/VersionRoute.swift
@@ -11,16 +11,17 @@ struct VersionRoute: RouteCollection {
         do {
             let version = VersionInfo(
                 Platform: ServerPlatform(Name: "socktainer"),
+                // NOTE: Empty for the time being, could be populated with additional information
                 Components: [],
-                Version: ProcessInfo.processInfo.environment["SOCKTAINER_VERSION"] ?? "unknown",
-                ApiVersion: "v1.51",
-                MinAPIVersion: "v1.51",
-                GitCommit: ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unknown",
+                Version: getBuildVersion(),
+                ApiVersion: getDockerEngineApiMaxVersion(),
+                MinAPIVersion: getDockerEngineApiMinVersion(),
+                GitCommit: getBuildGitCommit(),
                 Os: "macOS",
                 Arch: "arm64",
                 KernelVersion: getKernel(),
-                Experimental: isDebug(),
-                BuildTime: ProcessInfo.processInfo.environment["SOCKTAINER_BUILD_TIME"] ?? "unknown",
+                Experimental: true,
+                BuildTime: getBuildTime(),
             )
             return try await version.encodeResponse(for: req)
         } catch {

--- a/Sources/socktainer/Utilitites/AppleContainerUtility.swift
+++ b/Sources/socktainer/Utilitites/AppleContainerUtility.swift
@@ -1,0 +1,10 @@
+import ContainerClient
+import Containerization
+import Foundation
+
+public func getLinuxDefaultKernelName() async throws -> String {
+    let kernel = try await ClientKernel.getDefaultKernel(for: SystemPlatform.current)
+    let pathString = kernel.path.path
+    let components = pathString.split(separator: "/")
+    return components.last.map(String.init) ?? pathString
+}

--- a/Sources/socktainer/Utilitites/BuildInfoHelper.swift
+++ b/Sources/socktainer/Utilitites/BuildInfoHelper.swift
@@ -13,3 +13,11 @@ public func getBuildGitCommit() -> String {
 public func getBuildTime() -> String {
     String(cString: get_build_time())
 }
+
+public func getDockerEngineApiMinVersion() -> String {
+    String(cString: get_docker_engine_api_min_version())
+}
+
+public func getDockerEngineApiMaxVersion() -> String {
+    String(cString: get_docker_engine_api_max_version())
+}

--- a/Sources/socktainer/Utilitites/HostUtility.swift
+++ b/Sources/socktainer/Utilitites/HostUtility.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public func isDebug() -> Bool {
+    #if DEBUG
+    return true
+    #else
+    return false
+    #endif
+}
+
+public func hostCPUCoreCount() -> Int {
+    ProcessInfo.processInfo.processorCount
+}
+
+public func hostPhysicalMemory() -> UInt64 {
+    ProcessInfo.processInfo.physicalMemory
+}
+
+public func hostName() -> String {
+    var hostname = [CChar](repeating: 0, count: Int(MAXHOSTNAMELEN))
+    gethostname(&hostname, Int(MAXHOSTNAMELEN))
+    let length = hostname.firstIndex(of: 0) ?? hostname.count
+    let bytes = hostname[..<length].map { UInt8(bitPattern: $0) }
+    return String(decoding: bytes, as: UTF8.self)
+}
+
+public func currentTime() -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: Date())
+}
+
+public func getKernel() -> String {
+    var uts = utsname()
+    uname(&uts)
+    let release = withUnsafePointer(to: &uts.release) {
+        $0.withMemoryRebound(to: CChar.self, capacity: Int(_SYS_NAMELEN)) {
+            String(cString: $0)
+        }
+    }
+    return release
+}

--- a/Sources/socktainer/Utilitites/PlatformUtility.swift
+++ b/Sources/socktainer/Utilitites/PlatformUtility.swift
@@ -1,3 +1,5 @@
+import ContainerClient
+import Containerization
 import ContainerizationOCI
 import Foundation
 


### PR DESCRIPTION
Initial implementation for the following routes:
- `/info` - returns container-related information.
- `/version` - returns information about the server.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
