### PR TITLE
feat(route): Implement `/networks` and `/networks/id`

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -215,3 +215,31 @@ jobs:
           echo "Image ID: $IMAGE_ID"
           # Check and fail if it doesn't start with sha256:
           [[ $IMAGE_ID == sha256:* ]] || { echo "Error: Image ID does not start with sha256:"; exit 1; }
+
+      # NOTE: Disabling tests for now.
+      #       Most likely calling some internal function that fails
+      #       on CI host.
+      # - name: check system info was returned by socktainer
+      #   run: |
+      #     # expect specific content returned via `/info` endpoint
+      #     sudo docker info | grep 'container-apiserver'
+      #     sudo docker info | grep 'com.apple.container'
+      #     sudo docker info | grep 'socktainer'
+
+      - name: check version info was returned by socktainer
+        run: |
+          # expect specific content returned via `/version` endpoint
+          sudo docker version | grep 'socktainer'
+          # expect specific Docker engine API versions
+          sudo docker version | grep 'v1.32'
+          sudo docker version | grep 'v1.51'
+
+      - name: check network with socktainer
+        run: |
+          # expect default network to be present
+          sudo docker network ls | grep default
+          # inspect the default network
+          NETWORK_ID=$(sudo docker network inspect default | jq -r '.[].Id')
+          echo "Network ID: ${NETWORK_ID}"
+          # Check and fail if it doesn't match 'default':
+          [[ ${NETWORK_ID} == default ]] || { echo "Error: Network ID does not match 'default'"; exit 1; }

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
             name: "socktainer",
             dependencies: [
                 .product(name: "ContainerClient", package: "container"),
+                .product(name: "ContainerNetworkService", package: "container"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Logging", package: "swift-log"),

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -1,0 +1,161 @@
+import ContainerClient
+import ContainerNetworkService
+import Foundation
+import Logging
+
+protocol ClientNetworkProtocol: Sendable {
+    func list(filters: String?, logger: Logger) async throws -> [RESTNetworkSummary]
+    func getNetwork(id: String, logger: Logger) async throws -> RESTNetworkSummary?
+}
+
+struct ClientNetworkService: ClientNetworkProtocol {
+    func list(filters: String? = nil, logger: Logger) async throws -> [RESTNetworkSummary] {
+        let networksList = try await ClientNetwork.list()
+        var allNetworks = networksList.map { RESTNetworkSummary(networkState: $0) }
+        let containerClient = ClientContainerService()
+        let allContainers = try await containerClient.list(showAll: true)
+
+        // Map containers to networks
+        for i in 0..<allNetworks.count {
+            let network = allNetworks[i]
+            var containersForNetwork: [String: NetworkContainer] = [:]
+            for container in allContainers {
+                for attachment in container.networks {
+                    if attachment.network == network.Id || attachment.network == network.Name {
+                        let nc = NetworkContainer(
+                            Name: container.id,
+                            EndpointID: nil,  // Apple container doesn't have a matching field
+                            MacAddress: nil,  // Apple container doesn't have a matching field
+                            IPv4Address: attachment.address,
+                            IPv6Address: nil
+                        )
+                        containersForNetwork[container.id] = nc
+                        logger.debug("Container \(container.id) attached to network \(network.Name) (ID: \(network.Id))")
+                    }
+                }
+            }
+            if !containersForNetwork.isEmpty {
+                allNetworks[i] = RESTNetworkSummary(
+                    Name: network.Name,
+                    Id: network.Id,
+                    Created: network.Created,
+                    Scope: network.Scope,
+                    Driver: network.Driver,
+                    EnableIPv4: network.EnableIPv4,
+                    EnableIPv6: network.EnableIPv6,
+                    Internal: network.Internal,
+                    Attachable: network.Attachable,
+                    Ingress: network.Ingress,
+                    IPAM: network.IPAM,
+                    Options: network.Options,
+                    Containers: containersForNetwork,
+                    ConfigFrom: network.ConfigFrom,
+                    Labels: network.Labels,
+                    Subnet: network.Subnet,
+                    Gateway: network.Gateway
+                )
+            }
+        }
+
+        guard let filters = filters, let data = filters.data(using: .utf8) else { return allNetworks }
+        guard let filtersDict = try? JSONDecoder().decode([String: [String]].self, from: data) else { return allNetworks }
+        return allNetworks.filter { network in
+            var excludedReason: String? = nil
+            if let danglingArr = filtersDict["dangling"], let danglingStr = danglingArr.first {
+                let isDangling = (network.Containers == nil || network.Containers?.isEmpty == true)
+                if (danglingStr == "true" && !isDangling) || (danglingStr == "false" && isDangling) {
+                    excludedReason = "dangling mismatch"
+                }
+            }
+            if let driverArr = filtersDict["driver"], let driver = driverArr.first {
+                if network.Driver.caseInsensitiveCompare(driver) != .orderedSame { excludedReason = "driver mismatch" }
+            }
+            if let idArr = filtersDict["id"], let id = idArr.first {
+                if !network.Id.localizedCaseInsensitiveContains(id) { excludedReason = "id mismatch" }
+            }
+            if let labels = filtersDict["label"] {
+                for label in labels {
+                    if label.contains("=") {
+                        let parts = label.split(separator: "=", maxSplits: 1)
+                        let key = String(parts[0])
+                        let value = String(parts[1])
+                        if network.Labels[key] != value { excludedReason = "label key=value mismatch" }
+                    } else {
+                        if network.Labels[label] == nil { excludedReason = "label key missing" }
+                    }
+                }
+            }
+            if let nameArr = filtersDict["name"], let name = nameArr.first {
+                if !network.Name.localizedCaseInsensitiveContains(name) { excludedReason = "name mismatch" }
+            }
+            if let scopeArr = filtersDict["scope"], let scope = scopeArr.first {
+                if !network.Scope.localizedCaseInsensitiveContains(scope) { excludedReason = "scope mismatch" }
+            }
+            if let typeArr = filtersDict["type"], let type = typeArr.first {
+                let isCustom = network.Driver != "bridge" && network.Driver != "host" && network.Driver != "null"
+                if type == "custom" && !isCustom { excludedReason = "type custom mismatch" }
+                if type == "builtin" && isCustom { excludedReason = "type builtin mismatch" }
+            }
+            if let reason = excludedReason {
+                logger.debug("Excluding network \(network.Name) (ID: \(network.Id)) due to: \(reason)")
+                return false
+            }
+            return true
+        }
+    }
+
+    func getNetwork(id: String, logger: Logger) async throws -> RESTNetworkSummary? {
+        let networks = try await list(logger: logger)
+        return networks.first { $0.Id == id || $0.Name == id }
+    }
+}
+
+extension RESTNetworkSummary {
+    init(networkState: NetworkState) {
+        let id: String
+        let driver: String
+        let options: [String: String] = [:]  // Not provided by Apple container
+        let labels: [String: String] = [:]  // Not provided by Apple container
+        var subnet: String? = nil
+        var gateway: String? = nil
+
+        switch networkState {
+        case .created(let config):
+            id = config.id
+            driver = String(describing: config.mode)
+            subnet = config.subnet
+        case .running(let config, let status):
+            id = config.id
+            driver = String(describing: config.mode)
+            subnet = config.subnet ?? status.address
+            gateway = status.gateway
+        }
+
+        self.init(
+            Name: id,
+            Id: id,
+            // NOTE: Apple container doesn't return creation timestamp
+            //       https://github.com/apple/container/issues/665
+            Created: "1970-01-01T00:00:00Z",  // Default to epoch time
+            Scope: "local",  // We will always use "local", other modes are not available
+            Driver: driver,
+            EnableIPv4: true,
+            // NOTE: IPv6 is not used in Apple container
+            //       https://github.com/apple/container/issues/460
+            EnableIPv6: false,
+            // NOTE: IPv6 is not used in Apple container
+            //       https://github.com/apple/container/issues/460
+            // NOTE: Apple container has no mechanism to set networks as internal
+            Internal: false,
+            Attachable: false,
+            Ingress: false,  // Only applicable for Swarm
+            IPAM: NetworkIPAM(Driver: "", Config: []),  // Currently, there are no IPAM capabilities
+            Options: options,
+            Containers: nil,
+            ConfigFrom: nil,
+            Labels: labels,
+            Subnet: subnet,
+            Gateway: gateway
+        )
+    }
+}

--- a/Sources/socktainer/Models/RESTConfig.swift
+++ b/Sources/socktainer/Models/RESTConfig.swift
@@ -232,12 +232,22 @@ struct TmpfsOptions: Content {
     let Mode: Int?
 }
 
-struct NetworkingConfig: Content {
-    let EndpointsConfig: [String: EndpointSettings]?
+struct ContainerNetworkSettings: Content {
+    let Bridge: String?
+    let SandboxID: String?
+    let Ports: [String: [PortBinding]]?
+    let SandboxKey: String?
+    let Networks: [String: ContainerEndpointSettings]?
 }
 
-struct EndpointSettings: Content {
-    let IPAMConfig: IPAMConfig?
+/// Address type for SecondaryIPAddresses and SecondaryIPv6Addresses
+struct Address: Content {
+    let Addr: String?
+    let PrefixLen: Int?
+}
+
+struct ContainerEndpointSettings: Content {
+    let IPAMConfig: ContainerIPAMConfig?
     let Links: [String]?
     let Aliases: [String]?
     let NetworkID: String?
@@ -252,7 +262,7 @@ struct EndpointSettings: Content {
     let DriverOpts: [String: String]?
 }
 
-struct IPAMConfig: Content {
+struct ContainerIPAMConfig: Content {
     let IPv4Address: String?
     let IPv6Address: String?
     let LinkLocalIPs: [String]?
@@ -264,6 +274,31 @@ struct ContainerConfig: Content {
 
 }
 
-struct NetworkSettings: Content {
-    let Ports: [String: [PortBinding]]?
+// `/networks` related
+public struct NetworkConfigReference: Codable, Sendable {
+    public let Network: String
+}
+
+public struct NetworkContainer: Codable, Sendable {
+    public let Name: String
+    public let EndpointID: String?
+    public let MacAddress: String?
+    public let IPv4Address: String
+    public let IPv6Address: String?
+}
+
+public struct NetworkLabel: Codable {
+    public let Name: String
+}
+
+public struct NetworkIPAMConfig: Codable, Sendable {
+    public let Subnet: String?
+    public let IPRange: String?
+    public let Gateway: String?
+    public let AuxiliaryAddresses: [String: String]?
+}
+
+public struct NetworkIPAM: Codable, Sendable {
+    public let Driver: String
+    public let Config: [NetworkIPAMConfig]
 }

--- a/Sources/socktainer/Models/RESTContainerSummary.swift
+++ b/Sources/socktainer/Models/RESTContainerSummary.swift
@@ -30,7 +30,8 @@ struct RESTContainerInspect: Content {
     let State: ContainerState
     let Config: ContainerConfig
     let HostConfig: HostConfig
-    let NetworkSettings: NetworkSettings
+    // NOTE: Details information about ports it not exposed by Apple container
+    let NetworkSettings: ContainerNetworkSettings
 }
 
 struct RESTContainerListQuery: Content {

--- a/Sources/socktainer/Models/RESTNetworkSummary.swift
+++ b/Sources/socktainer/Models/RESTNetworkSummary.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Vapor
+
+public struct RESTNetworkSummary: Content {
+    public let Name: String
+    public let Id: String
+    public let Created: String
+    public let Scope: String
+    public let Driver: String
+    public let EnableIPv4: Bool
+    public let EnableIPv6: Bool
+    public let Internal: Bool
+    public let Attachable: Bool
+    public let Ingress: Bool
+    public let IPAM: NetworkIPAM
+    public let Options: [String: String]
+    public let Containers: [String: NetworkContainer]?
+    public let ConfigFrom: NetworkConfigReference?
+    public let Labels: [String: String]
+    public let Subnet: String?
+    public let Gateway: String?
+}

--- a/Sources/socktainer/Routes/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerCreateRoute.swift
@@ -48,7 +48,7 @@ struct CreateContainerRequest: Content {
     let HostConfig: HostConfig?
     let Labels: [String: String]?
     let Shell: [String]?
-    let NetworkingConfig: NetworkingConfig?
+    let NetworkingConfig: ContainerNetworkSettings?
 }
 
 extension ContainerCreateRoute {

--- a/Sources/socktainer/Routes/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/ContainerInspectRoute.swift
@@ -33,11 +33,34 @@ extension ContainerInspectRoute {
                 ExposedPorts: exposedPorts,
             )
             // add network settings
-            let networkSettings: NetworkSettings = NetworkSettings(
+            let networkSettings = ContainerNetworkSettings(
+                Bridge: nil,
+                SandboxID: nil,
                 Ports: Dictionary(grouping: container.configuration.publishedPorts, by: { "\($0.hostPort)/\($0.proto.rawValue)" })
                     .mapValues { bindings in
                         bindings.map { PortBinding(HostIp: "\($0.hostAddress)", HostPort: "\($0.hostPort)") }
+                    },
+                SandboxKey: nil,
+                Networks: Dictionary(
+                    uniqueKeysWithValues: container.networks.map { attachment in
+                        let endpoint = ContainerEndpointSettings(
+                            IPAMConfig: nil,
+                            Links: nil,
+                            Aliases: nil,
+                            NetworkID: attachment.network,
+                            EndpointID: nil,
+                            Gateway: attachment.gateway,
+                            IPAddress: attachment.address,
+                            IPPrefixLen: nil,
+                            IPv6Gateway: nil,
+                            GlobalIPv6Address: nil,
+                            GlobalIPv6PrefixLen: nil,
+                            MacAddress: nil,
+                            DriverOpts: nil
+                        )
+                        return (attachment.network, endpoint)
                     }
+                )
             )
 
             let hostConfig: HostConfig = HostConfig()

--- a/Sources/socktainer/Routes/NetworkInspectRoute.swift
+++ b/Sources/socktainer/Routes/NetworkInspectRoute.swift
@@ -1,11 +1,29 @@
 import Vapor
 
+struct RESTNetworkInspectQuery: Content {
+    let verbose: Bool?
+    let scope: Bool
+}
+
 struct NetworkInspectRoute: RouteCollection {
+    let client: ClientNetworkProtocol
+
     func boot(routes: RoutesBuilder) throws {
-        routes.get(":version", "networks", ":id", use: NetworkInspectRoute.handler)
+        routes.get(":version", "networks", ":id", use: NetworkInspectRoute.handler(client: client))
+        // Optionally, add route without version prefix
+        routes.get("networks", ":id", use: NetworkInspectRoute.handler(client: client))
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks/{id}", req.method.rawValue)
+    static func handler(client: ClientNetworkProtocol) -> @Sendable (Request) async throws -> RESTNetworkSummary {
+        { req in
+            guard let id = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing network ID")
+            }
+            let logger = req.logger
+            guard let network = try await client.getNetwork(id: id, logger: logger) else {
+                throw Abort(.notFound, reason: "Network not found")
+            }
+            return network
+        }
     }
 }

--- a/Sources/socktainer/Routes/NetworkListRoute.swift
+++ b/Sources/socktainer/Routes/NetworkListRoute.swift
@@ -1,11 +1,83 @@
 import Vapor
 
+struct RESTNetworksListQuery: Content {
+    let dangling: String?
+    let driver: String?
+    let id: String?
+    let label: String?
+    let name: String?
+    let scope: String?
+    let type: String?
+}
+
+public struct NetworkListFilters {
+    public let dangling: Bool?
+    public let driver: String?
+    public let id: String?
+    public let label: [String]?
+    public let name: String?
+    public let scope: String?
+    public let type: String?
+
+    public init(
+        dangling: Bool? = nil,
+        driver: String? = nil,
+        id: String? = nil,
+        label: [String]? = nil,
+        name: String? = nil,
+        scope: String? = nil,
+        type: String? = nil
+    ) {
+        self.dangling = dangling
+        self.driver = driver
+        self.id = id
+        self.label = label
+        self.name = name
+        self.scope = scope
+        self.type = type
+    }
+}
+
 struct NetworkListRoute: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         routes.get(":version", "networks", use: NetworkListRoute.handler)
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks", req.method.rawValue)
+        let networkClient = ClientNetworkService()
+        let filtersParam = try? req.query.get(String.self, at: "filters")
+
+        var filters: [String: Any] = [:]
+        var parsedFilters: [String: [String]] = [:]
+        if let filtersParam = filtersParam, let data = filtersParam.data(using: .utf8) {
+            if let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                filters = decoded
+                for (key, value) in filters {
+                    if let dict = value as? [String: Any] {
+                        let keys = dict.compactMap { (key, value) in
+                            (value as? Bool == true) ? key : nil
+                        }
+                        if !keys.isEmpty {
+                            parsedFilters[key] = keys
+                        }
+                    } else if let arr = value as? [String] {
+                        parsedFilters[key] = arr
+                    }
+                }
+                req.logger.debug("Decoded filters: \(parsedFilters)")
+            } else {
+                req.logger.warning("Failed to decode filters")
+            }
+        }
+
+        let filtersJSON = try JSONEncoder().encode(parsedFilters)
+        let filtersJSONString = String(data: filtersJSON, encoding: .utf8)
+
+        do {
+            let networks = try await networkClient.list(filters: filtersJSONString, logger: req.logger)
+            return Response(status: .ok, body: .init(data: try JSONEncoder().encode(networks)))
+        } catch {
+            return Response(status: .internalServerError, body: .init(string: "Failed to list networks: \(error)"))
+        }
     }
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -4,6 +4,7 @@ func configure(_ app: Application) async throws {
     let containerClient = ClientContainerService()
     let imageClient = ClientImageService()
     let healthCheckClient = ClientHealthCheckService()
+    let networkClient = ClientNetworkService()
 
     // /_ping
     try app.register(collection: HealthCheckPingRoute(client: healthCheckClient))
@@ -75,7 +76,7 @@ func configure(_ app: Application) async throws {
     try app.register(collection: NetworkConnectRoute())
     try app.register(collection: NetworkCreateRoute())
     try app.register(collection: NetworkDisconnectRoute())
-    try app.register(collection: NetworkInspectRoute())
+    try app.register(collection: NetworkInspectRoute(client: networkClient))
     try app.register(collection: NetworkListRoute())
     try app.register(collection: NetworkPruneRoute())
 


### PR DESCRIPTION
Adding the following routes:
- `/networks` - List the configured networks from Apple container.
- `/networks/id` - Inspect a configured network.

Updating container inspect to return attached networks.

Updating CI to include tests for additional endpoints.

Resolves #43.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
