### PR TITLE
feat(routes): Implement Additional Network Routes

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -31,7 +31,6 @@ env:
   SWIFT_VERSION: 6.2-snapshot
 
 jobs:
-
   build:
     name: build
     runs-on: macos-26
@@ -73,7 +72,6 @@ jobs:
         with:
           name: socktainer
           path: ./.build/arm64-apple-macosx/release/socktainer
-
 
   tests-lint-format:
     name: formatters & tests
@@ -161,7 +159,7 @@ jobs:
           # Send Apple Container commands automatically
           tmate -S /tmp/tmate.sock send-keys "echo 'Starting Apple Container...'" C-m
           tmate -S /tmp/tmate.sock send-keys "sudo container system start --enable-kernel-install | tee /tmp/container.log" C-m
-          
+
           # Loop until 'container system status' returns exit code 1 or timeout (60s)
           START=$SECONDS
           TIMEOUT=60
@@ -196,7 +194,7 @@ jobs:
         run: |
           sudo container image pull hello-world
           sudo container images ls
-        
+
       - name: install docker cli
         run: |
           brew install docker
@@ -249,3 +247,15 @@ jobs:
           echo "Network ID: ${NETWORK_ID}"
           # Check and fail if it doesn't match 'default':
           [[ ${NETWORK_ID} == default ]] || { echo "Error: Network ID does not match 'default'"; exit 1; }
+          # create networks
+          sudo docker network create test1
+          sudo docker network create test2
+          sudo docker network create test3
+          sudo docker network create test4
+          sudo docker network create foo
+          # delete network
+          sudo docker network rm foo
+          # prune networks using filter
+          sudo docker network prune --filter 'name=test' --force
+          # ensure only default is left
+          sudo docker network ls | grep 'default'

--- a/Sources/socktainer/Models/RestNetworkCreate.swift
+++ b/Sources/socktainer/Models/RestNetworkCreate.swift
@@ -1,0 +1,6 @@
+import Vapor
+
+public struct RESTNetworkCreate: Content {
+    public let Id: String
+    public let Warning: String
+}

--- a/Sources/socktainer/Routes/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/NetworkCreateRoute.swift
@@ -1,11 +1,34 @@
 import Vapor
 
+struct NetworksCreateQuery: Content {
+    let Name: String
+    // NOTE: All fields are optional and are not supported or used
+    //       by Apple container. This should be revisited in the future.
+    let Driver: String?
+    let scope: String?
+    let Internal: Bool?
+    let Attachable: Bool?
+    let ingress: Bool?
+    let ConfigOnly: Bool?
+    let ConfigFrom: NetworkConfigReference?
+    let IPAM: NetworkIPAM?
+    let EnableIPv4: Bool?
+    let EnableIPv6: Bool?
+    let Options: [String: String]?
+    let Labels: [String: String]?
+}
+
 struct NetworkCreateRoute: RouteCollection {
+    let client: ClientNetworkProtocol
     func boot(routes: RoutesBuilder) throws {
-        routes.post(":version", "networks", "create", use: NetworkCreateRoute.handler)
+        routes.post(":version", "networks", "create", use: self.handler)
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks/create", req.method.rawValue)
+    func handler(_ req: Request) async throws -> Response {
+        let logger = req.logger
+        let query = try req.content.decode(NetworksCreateQuery.self)
+        // only pass network name
+        let response = try await client.create(name: query.Name, logger: logger)
+        return try await response.encodeResponse(for: req)
     }
 }

--- a/Sources/socktainer/Routes/NetworkDeleteRoute.swift
+++ b/Sources/socktainer/Routes/NetworkDeleteRoute.swift
@@ -1,0 +1,26 @@
+import Vapor
+
+struct NetworkDeletetRoute: RouteCollection {
+    let client: ClientNetworkProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        routes.delete(":version", "networks", ":id", use: self.handler)
+    }
+
+    func handler(_ req: Request) async throws -> Response {
+        let logger = req.logger
+        guard let id = req.parameters.get("id") else {
+            logger.warning("Missing network id parameter")
+            throw Abort(.badRequest, reason: "Missing network id parameter")
+        }
+        do {
+            try await client.delete(id: id, logger: logger)
+            return Response(status: .noContent)
+        } catch {
+            if error.localizedDescription.contains("not found") {
+                throw Abort(.notFound, reason: "Network not found")
+            }
+            throw Abort(.internalServerError, reason: "Network deletion failed: \(error)")
+        }
+    }
+}

--- a/Sources/socktainer/Routes/NetworkPruneRoute.swift
+++ b/Sources/socktainer/Routes/NetworkPruneRoute.swift
@@ -1,11 +1,47 @@
 import Vapor
 
 struct NetworkPruneRoute: RouteCollection {
+    let client: ClientNetworkProtocol
     func boot(routes: RoutesBuilder) throws {
         routes.post(":version", "networks", "prune", use: NetworkPruneRoute.handler)
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks/prune", req.method.rawValue)
+        let networkClient = ClientNetworkService()
+        let query = try req.query.decode(RESTNetworksListQuery.self)
+        let filtersParam = query.filters
+
+        // Use utility to parse filters (default to dangling)
+        let parsedFilters = DockerNetworkFilterUtility.parseNetworkFilters(filtersParam: filtersParam, defaultDangling: true, logger: req.logger)
+
+        let filtersJSON = try JSONEncoder().encode(parsedFilters)
+        let filtersJSONString = String(data: filtersJSON, encoding: .utf8)
+
+        var deletedNetworks: [String] = []
+        var errors: [String: String] = [:]
+        do {
+            let networks = try await networkClient.list(filters: filtersJSONString, logger: req.logger)
+            for network in networks {
+                if network.Name == "default" {
+                    req.logger.info("Skipping deletion of default network: \(network.Id)")
+                    continue
+                }
+                do {
+                    try await networkClient.delete(id: network.Id, logger: req.logger)
+                    deletedNetworks.append(network.Id)
+                } catch {
+                    errors[network.Id] = String(describing: error)
+                    req.logger.error("Failed to delete network \(network.Id): \(error)")
+                }
+            }
+            let responseBody: [String: Any] = [
+                "NetworksDeleted": deletedNetworks,
+                "Errors": errors,
+            ]
+            let responseData = try JSONSerialization.data(withJSONObject: responseBody, options: [])
+            return Response(status: .ok, body: .init(data: responseData))
+        } catch {
+            return Response(status: .internalServerError, body: .init(string: "Failed to prune networks: \(error)"))
+        }
     }
 }

--- a/Sources/socktainer/Utilitites/DockerNetworkFilterUtility.swift
+++ b/Sources/socktainer/Utilitites/DockerNetworkFilterUtility.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Vapor
+
+// utility for parsing network filters from query string
+struct DockerNetworkFilterUtility {
+    // parses network filters from a query string, optionally defaulting to dangling only
+    // dangling networks are networks with no containers are attached to them
+    static func parseNetworkFilters(filtersParam: String?, defaultDangling: Bool, logger: Logger) -> [String: [String]] {
+        var filters: [String: Any] = [:]
+        var parsedFilters: [String: [String]] = [:]
+        if let filtersParam = filtersParam, let data = filtersParam.data(using: .utf8) {
+            if let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                filters = decoded
+                for (key, value) in filters {
+                    if let dict = value as? [String: Any] {
+                        let keys = dict.compactMap { (key, value) in
+                            (value as? Bool == true) ? key : nil
+                        }
+                        if !keys.isEmpty {
+                            parsedFilters[key] = keys
+                        }
+                    } else if let arr = value as? [String] {
+                        parsedFilters[key] = arr
+                    }
+                }
+                logger.debug("Decoded filters: \(parsedFilters)")
+            } else {
+                logger.warning("Failed to decode filters")
+            }
+        } else if defaultDangling {
+            parsedFilters["dangling"] = ["true"]
+            logger.debug("No filters provided, defaulting to prune only dangling networks.")
+        }
+        return parsedFilters
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -74,11 +74,12 @@ func configure(_ app: Application) async throws {
 
     // --- network routes ---
     try app.register(collection: NetworkConnectRoute())
-    try app.register(collection: NetworkCreateRoute())
+    try app.register(collection: NetworkCreateRoute(client: networkClient))
     try app.register(collection: NetworkDisconnectRoute())
     try app.register(collection: NetworkInspectRoute(client: networkClient))
     try app.register(collection: NetworkListRoute())
-    try app.register(collection: NetworkPruneRoute())
+    try app.register(collection: NetworkPruneRoute(client: networkClient))
+    try app.register(collection: NetworkDeletetRoute(client: networkClient))
 
     // --- build/distribution routes ---
     try app.register(collection: BuildPruneRoute())


### PR DESCRIPTION
Implementing the following routes:
- `DELETE /networks/{id}` - Allows deleting networks (#49).
- `POST /networks/create` - Allow creating networks (#51).
- `POST /networks/prune` - Allow pruning networks using filters (#50).

Removing obsolete struct(s) from `NetworkListRoute.swift`.

Consolidating docker network filters into
`DockerNetworkFilterUtility.swift`.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
