### PR TITLE
refactor(routes): Extend `/containers` Routes

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -2,7 +2,7 @@ import ContainerClient
 import Foundation
 
 protocol ClientContainerProtocol: Sendable {
-    func list(showAll: Bool) async throws -> [ClientContainer]
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ClientContainer]
     func getContainer(id: String) async throws -> ClientContainer?
     func enforceContainerRunning(container: ClientContainer) throws
 
@@ -17,12 +17,102 @@ enum ClientContainerError: Error {
 }
 
 struct ClientContainerService: ClientContainerProtocol {
-    func list(showAll: Bool) async throws -> [ClientContainer] {
-        // if showAll return all the list, else return only started containers
-        guard showAll else {
-            return try await ClientContainer.list().filter { $0.status == .running }
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ClientContainer] {
+        let allContainers = try await ClientContainer.list()
+        var containers = allContainers
+        if !showAll {
+            containers = containers.filter { $0.status == .running }
         }
-        return try await ClientContainer.list()
+        for (key, values) in filters {
+            switch key {
+            case "status":
+                containers = containers.filter { values.contains($0.status.rawValue) }
+            case "exited":
+                containers = containers.filter { container in
+                    guard container.status == .stopped else { return false }
+                    return values.contains("0") || values.isEmpty
+                }
+            case "label":
+                containers = containers.filter { container in
+                    let labels = container.configuration.labels
+                    return values.allSatisfy { labelFilter in
+                        guard let eqIdx = labelFilter.firstIndex(of: "=") else {
+                            return labels.keys.contains(labelFilter)
+                        }
+                        let k = String(labelFilter.prefix(upTo: eqIdx))
+                        let v = String(labelFilter.suffix(from: labelFilter.index(after: eqIdx)))
+                        return labels[k] == v
+                    }
+                }
+            case "name":
+                containers = containers.filter { values.contains($0.id) }
+            case "id":
+                containers = containers.filter { values.contains($0.id) }
+            case "ancestor":
+                containers = containers.filter { values.contains($0.configuration.image.reference) }
+            case "before":
+                containers = containers.filter { container in
+                    for beforeId in values {
+                        if let beforeContainer = allContainers.first(where: { $0.id == beforeId || $0.id.hasPrefix(beforeId) }) {
+                            return container.id < beforeContainer.id
+                        }
+                    }
+                    return false
+                }
+            case "since":
+                containers = containers.filter { container in
+                    for sinceId in values {
+                        if let sinceContainer = allContainers.first(where: { $0.id == sinceId || $0.id.hasPrefix(sinceId) }) {
+                            return container.id > sinceContainer.id
+                        }
+                    }
+                    return false
+                }
+            case "health":
+                containers = containers.filter { container in
+                    let healthStatus = container.status == .running ? "healthy" : "unhealthy"
+                    return values.contains(healthStatus)
+                }
+            case "volume":
+                containers = containers.filter { container in
+                    values.contains("volume-filter-not-implemented")
+                }
+            case "expose":
+                containers = containers.filter { container in
+                    let exposedPorts = container.configuration.publishedPorts.map { "\($0.containerPort)/\($0.proto.rawValue)" }
+                    return values.allSatisfy { port in
+                        exposedPorts.contains { $0.contains(port) }
+                    }
+                }
+            case "isolation":
+                containers = containers.filter { container in
+                    let isolation = container.configuration.platform.os == "linux" ? "process" : "hyperv"
+                    return values.contains(isolation)
+                }
+            case "is-task":
+                containers = containers.filter { container in
+                    let isTask = container.configuration.labels["com.docker.swarm.task.id"] != nil
+                    return values.contains(isTask ? "true" : "false")
+                }
+            case "network":
+                containers = containers.filter { container in
+                    let networkNames = container.networks.map { $0.network }
+                    return values.allSatisfy { networkName in
+                        networkNames.contains(networkName)
+                    }
+                }
+            case "publish":
+                containers = containers.filter { container in
+                    let publishedPorts = container.configuration.publishedPorts.map { "\($0.hostPort):\($0.containerPort)" }
+                    return values.allSatisfy { portMapping in
+                        publishedPorts.contains { $0.contains(portMapping) }
+                    }
+                }
+            default:
+                continue
+            }
+        }
+        return containers
     }
 
     func getContainer(id: String) async throws -> ClientContainer? {
@@ -45,7 +135,6 @@ struct ClientContainerService: ClientContainerProtocol {
 
         let process = try await container.bootstrap(stdio: stdio)
         try await process.start()
-
     }
 
     func stop(id: String) async throws {

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -15,7 +15,7 @@ struct ClientNetworkService: ClientNetworkProtocol {
         let networksList = try await ClientNetwork.list()
         var allNetworks = networksList.map { RESTNetworkSummary(networkState: $0) }
         let containerClient = ClientContainerService()
-        let allContainers = try await containerClient.list(showAll: true)
+        let allContainers = try await containerClient.list(showAll: true, filters: [:])
 
         // Map containers to networks
         for i in 0..<allNetworks.count {

--- a/Sources/socktainer/Models/RESTConfig.swift
+++ b/Sources/socktainer/Models/RESTConfig.swift
@@ -1,5 +1,7 @@
 import Vapor
 
+// TODO: Sort out this file into logical sections
+
 struct EmptyObject: Content {
     // Empty struct to represent {} in JSON
 }
@@ -238,6 +240,7 @@ struct ContainerNetworkSettings: Content {
     let Ports: [String: [PortBinding]]?
     let SandboxKey: String?
     let Networks: [String: ContainerEndpointSettings]?
+    let EndpointsConfig: [String: ContainerEndpointSettings]?
 }
 
 /// Address type for SecondaryIPAddresses and SecondaryIPv6Addresses
@@ -269,9 +272,31 @@ struct ContainerIPAMConfig: Content {
 }
 
 struct ContainerConfig: Content {
-    let Image: String
+    let Hostname: String?
+    let Domainname: String?
+    let User: String?
+    let AttachStdin: Bool?
+    let AttachStdout: Bool?
+    let AttachStderr: Bool?
     let ExposedPorts: [String: EmptyObject]?
-
+    let Tty: Bool?
+    let OpenStdin: Bool?
+    let StdinOnce: Bool?
+    let Env: [String]?
+    let Cmd: [String]?
+    let Healthcheck: HealthcheckConfig?
+    let ArgsEscaped: Bool?
+    let Image: String
+    let Volumes: [String: EmptyObject]?
+    let WorkingDir: String?
+    let Entrypoint: [String]?
+    let NetworkDisabled: Bool?
+    let MacAddress: String?
+    let OnBuild: [String]?
+    let Labels: [String: String]?
+    let StopSignal: String?
+    let StopTimeout: Int?
+    let Shell: [String]?
 }
 
 // `/networks` related
@@ -345,4 +370,75 @@ struct VolumeInfo: Content {
     let Scope: String
     let Status: [String: String]?  // we do not report any status from the underlying driver at the moment
     let UsageData: VolumeUsageData?
+}
+
+// image related
+
+struct ImageOCIDescriptor: Content {
+    let mediaType: String
+    let digest: String
+    let size: Int64
+    let urls: [String]?
+    let annotations: [String: String]?
+    let platform: ImageOCIPlatform?
+}
+
+struct ImageOCIPlatform: Content {
+    let architecture: String
+    let os: String
+    let osVersion: String?
+    let osFeatures: [String]?
+    let variant: String?
+}
+
+// container related
+
+struct ContainerDriverData: Content {
+    let Name: String
+    let Data: [String: String]
+}
+
+struct ContainerMountPoint: Content {
+    let type: String
+    let name: String?
+    let source: String
+    let destination: String
+    let driver: String?
+    let mode: String
+    let rw: Bool
+    let propagation: String
+
+    enum CodingKeys: String, CodingKey {
+        case type = "Type"
+        case name = "Name"
+        case source = "Source"
+        case destination = "Destination"
+        case driver = "Driver"
+        case mode = "Mode"
+        case rw = "RW"
+        case propagation = "Propagation"
+    }
+}
+
+struct ContainerPort: Content {
+    let IP: String?
+    let PrivatePort: Int
+    let PublicPort: Int?
+    let type: String
+
+    enum CodingKeys: String, CodingKey {
+        case IP
+        case PrivatePort
+        case PublicPort
+        case type = "Type"
+    }
+}
+
+struct ContainerHostConfig: Content {
+    let NetworkMode: String
+    let Annotations: [String: String]?
+}
+
+struct ContainerNetworkSummary: Content {
+    let Networks: [String: ContainerEndpointSettings]?
 }

--- a/Sources/socktainer/Models/RESTContainerSummary.swift
+++ b/Sources/socktainer/Models/RESTContainerSummary.swift
@@ -19,18 +19,47 @@ struct RESTContainerSummary: Content {
     let Names: [String]
     let Image: String
     let ImageID: String
+    let ImageManifestDescriptor: ImageOCIDescriptor?
+    let Command: String
+    let Created: Int64
+    let Ports: [ContainerPort]
+    let SizeRw: Int64?
+    let SizeRootFs: Int64?
+    let Labels: [String: String]
     let State: String
+    let Status: String
+    let HostConfig: ContainerHostConfig
+    let NetworkSettings: ContainerNetworkSummary
+    let Mounts: [ContainerMountPoint]
+    let Platform: String
 }
 
 struct RESTContainerInspect: Content {
     let Id: String
-    let Names: [String]
-    let Image: String
-    let ImageID: String
+    let Created: String?
+    let Path: String
+    let Args: [String]
     let State: ContainerState
-    let Config: ContainerConfig
+    let Image: String
+    let ResolvConfPath: String
+    let HostnamePath: String
+    let HostsPath: String
+    let LogPath: String?
+    let Name: String
+    let RestartCount: Int
+    let Driver: String
+    let Platform: String
+    let ImageManifestDescriptor: ImageOCIDescriptor?
+    let MountLabel: String
+    let ProcessLabel: String
+    let AppArmorProfile: String
+    let ExecIDs: [String]?
     let HostConfig: HostConfig
-    // NOTE: Details information about ports it not exposed by Apple container
+    let GraphDriver: ContainerDriverData
+    let SizeRw: Int64?
+    let SizeRootFs: Int64?
+    let Mounts: [ContainerMountPoint]
+    let Config: ContainerConfig
     let NetworkSettings: ContainerNetworkSettings
 }
 

--- a/Sources/socktainer/Routes/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerCreateRoute.swift
@@ -11,7 +11,6 @@ struct ContainerCreateRoute: RouteCollection {
         routes.post(":version", "containers", ":id", use: ContainerCreateRoute.handler(client: client))
         // also handle without version prefix
         routes.post("containers", ":id", use: ContainerCreateRoute.handler(client: client))
-
     }
 
 }
@@ -54,7 +53,6 @@ struct CreateContainerRequest: Content {
 extension ContainerCreateRoute {
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerCreate {
         { req in
-
             let query = try req.query.decode(ContainerCreateQuery.self)
 
             let containerName = query.name
@@ -64,6 +62,7 @@ extension ContainerCreateRoute {
 
             // body contains the Image
             let body = try req.content.decode(CreateContainerRequest.self)
+            req.logger.info("Creating container for image: \(body.Image)")
 
             let id = Utility.createContainerID(name: containerName)
             try Utility.validEntityName(id)
@@ -80,6 +79,7 @@ extension ContainerCreateRoute {
             try await img.getCreateSnapshot(
                 platform: requestedPlatform
             )
+
             let kernel = try await ClientKernel.getDefaultKernel(for: .current)
 
             let initImage = try await ClientImage.fetch(
@@ -105,36 +105,104 @@ extension ContainerCreateRoute {
             // merge environment variables, with request taking precedence
             let mergedEnv = try Parser.allEnv(imageEnvs: imageConfigEnvironment, envFiles: [], envs: requestedEnvironment)
 
-            let publishedPorts: [PublishPort] = convertPortBindings(
-                from: body.HostConfig?.PortBindings ?? [:]
-            )
-
-            // create full command line by appending imageConfig.entrypoint and imageConfig.cmd
-            var fullCommand: [String] = []
-            if let entrypoint = imageConfig?.entrypoint {
-                fullCommand.append(contentsOf: entrypoint)
+            let publishedPorts: [PublishPort]
+            do {
+                publishedPorts = try convertPortBindings(
+                    from: body.HostConfig?.PortBindings ?? [:]
+                )
+            } catch {
+                req.logger.error("Failed to allocate ports: \(error)")
+                throw Abort(.internalServerError, reason: "Failed to allocate ports: \(error)")
             }
-            if let cmd = imageConfig?.cmd {
-                fullCommand.append(contentsOf: cmd)
+
+            // Handle Entrypoint and Cmd from request, falling back to image config
+            var commandLine: [String] = []
+            if let requestEntrypoint = body.Entrypoint, !requestEntrypoint.isEmpty {
+                commandLine.append(contentsOf: requestEntrypoint)
+            } else if let imageEntrypoint = imageConfig?.entrypoint {
+                commandLine.append(contentsOf: imageEntrypoint)
+            }
+
+            if let requestCmd = body.Cmd, !requestCmd.isEmpty {
+                commandLine.append(contentsOf: requestCmd)
+            } else if let imageCmd = imageConfig?.cmd {
+                commandLine.append(contentsOf: imageCmd)
+            }
+
+            // Use working directory from request if provided, otherwise from image config
+            let finalWorkingDirectory = body.WorkingDir ?? workingDirectory
+
+            // Handle user from request if provided
+            let finalUser: ProcessConfiguration.User = {
+                if let requestUser = body.User {
+                    return .raw(userString: requestUser)
+                }
+                return defaultUser
+            }()
+
+            // Ensure we have a valid executable
+            guard let executable = commandLine.first, !executable.isEmpty else {
+                req.logger.error("No executable specified for container")
+                throw Abort(.badRequest, reason: "No executable specified for container. Image must specify ENTRYPOINT or CMD, or request must provide Entrypoint or Cmd.")
             }
 
             let processConfig = ProcessConfiguration(
-                executable: fullCommand.first ?? "",
-                arguments: fullCommand.dropFirst().map { String($0) },
+                executable: executable,
+                arguments: commandLine.dropFirst().map { String($0) },
                 environment: mergedEnv,
-                workingDirectory: workingDirectory,
-                terminal: false,
-                user: defaultUser,
+                workingDirectory: finalWorkingDirectory,
+                terminal: body.Tty ?? false,
+                user: finalUser,
             )
 
             var containerConfiguration = ContainerConfiguration(id: id, image: img.description, process: processConfig)
             containerConfiguration.platform = requestedPlatform
 
-            containerConfiguration.networks = [AttachmentConfiguration(network: "default", options: AttachmentOptions(hostname: id))]
+            // Handle hostname from request - ensure uniqueness to avoid collision
+            let hostname = (body.Hostname?.isEmpty == false) ? body.Hostname! : "\(id)-\(UUID().uuidString.lowercased())"
+
+            // Handle networking configuration from request
+            if let networkingConfig = body.NetworkingConfig,
+                let endpointsConfig = networkingConfig.EndpointsConfig,
+                !endpointsConfig.isEmpty
+            {
+                // Use networking config from request if provided
+                containerConfiguration.networks = endpointsConfig.map { (networkName, _) in
+                    let options = AttachmentOptions(hostname: hostname)
+                    return AttachmentConfiguration(network: networkName, options: options)
+                }
+            } else if let networkingConfig = body.NetworkingConfig,
+                let networks = networkingConfig.Networks,
+                !networks.isEmpty
+            {
+                // Fallback to Networks field for backward compatibility
+                containerConfiguration.networks = networks.map { (networkName, _) in
+                    let options = AttachmentOptions(hostname: hostname)
+                    return AttachmentConfiguration(network: networkName, options: options)
+                }
+            } else if let hostConfig = body.HostConfig,
+                let networkMode = hostConfig.NetworkMode,
+                !networkMode.isEmpty
+            {
+                // Use NetworkMode from HostConfig
+                containerConfiguration.networks = [AttachmentConfiguration(network: networkMode, options: AttachmentOptions(hostname: hostname))]
+            } else {
+                // Fall back to default network if no networking config provided
+                containerConfiguration.networks = [AttachmentConfiguration(network: "default", options: AttachmentOptions(hostname: hostname))]
+            }
+
             containerConfiguration.publishedPorts = publishedPorts
+            containerConfiguration.labels = body.Labels ?? [:]
 
             let options = ContainerCreateOptions(autoRemove: false)
-            let container = try await ClientContainer.create(configuration: containerConfiguration, options: options, kernel: kernel)
+            let container: ClientContainer
+            do {
+                container = try await ClientContainer.create(configuration: containerConfiguration, options: options, kernel: kernel)
+                req.logger.debug("Container created successfully with ID: \(container.id)")
+            } catch {
+                req.logger.error("Failed to create container: \(error)")
+                throw Abort(.internalServerError, reason: "Failed to create container: \(error)")
+            }
 
             return RESTContainerCreate(
                 Id: container.id,
@@ -143,7 +211,6 @@ extension ContainerCreateRoute {
         }
     }
 }
-
 // Function to convert PortBindings from HostConfig to PublishedPorts
 /*
 
@@ -168,7 +235,7 @@ extension ContainerCreateRoute {
         }
       ],
 */
-func convertPortBindings(from portBindings: [String: [PortBinding]]) -> [PublishPort] {
+func convertPortBindings(from portBindings: [String: [PortBinding]]) throws -> [PublishPort] {
     var publishedPorts: [PublishPort] = []
 
     for (portSpec, bindings) in portBindings {
@@ -189,7 +256,14 @@ func convertPortBindings(from portBindings: [String: [PortBinding]]) -> [Publish
         for binding in bindings {
             // Use default values if not specified
             let hostAddress = binding.HostIp?.isEmpty == false ? binding.HostIp! : "0.0.0.0"
-            let hostPort = binding.HostPort?.isEmpty == false ? (Int(binding.HostPort!) ?? containerPort) : containerPort
+
+            // If HostPort is empty/nil, find an available port
+            let hostPort: Int
+            if let hostPortString = binding.HostPort, !hostPortString.isEmpty {
+                hostPort = try Int(hostPortString) ?? findAvailablePort()
+            } else {
+                hostPort = try findAvailablePort()
+            }
 
             let publishPort = PublishPort(
                 hostAddress: hostAddress,

--- a/Sources/socktainer/Routes/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/ContainerInspectRoute.swift
@@ -1,3 +1,5 @@
+import ContainerClient
+import Containerization
 import Vapor
 
 struct ContainerInspectRoute: RouteCollection {
@@ -11,6 +13,15 @@ struct ContainerInspectRoute: RouteCollection {
 }
 
 extension ContainerInspectRoute {
+    private static func getUserString(from user: ProcessConfiguration.User) -> String? {
+        switch user {
+        case .raw(let userString):
+            return userString.isEmpty ? nil : userString
+        case .id(let uid, let gid):
+            return "\(uid):\(gid)"
+        }
+    }
+
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerInspect {
         { req in
             guard let id = req.parameters.get("id") else {
@@ -29,16 +40,82 @@ extension ContainerInspectRoute {
             )
 
             let containerConfig: ContainerConfig = ContainerConfig(
+                Hostname: container.id,  // Use container ID as hostname since hostName property doesn't exist
+                Domainname: container.configuration.dns?.domain,
+                User: getUserString(from: container.configuration.initProcess.user),
+                AttachStdin: false,  // no mechanism to derive this value
+                AttachStdout: true,  // no mechanism to derive this value
+                AttachStderr: true,  // no mechanism to derive this value
+                ExposedPorts: exposedPorts.isEmpty ? nil : exposedPorts,
+                Tty: container.configuration.initProcess.terminal,
+                OpenStdin: false,  // no mechanism to derive this value
+                StdinOnce: false,  // no mechanism to derive this value
+                Env: container.configuration.initProcess.environment.isEmpty ? nil : container.configuration.initProcess.environment,
+                Cmd: container.configuration.initProcess.arguments.isEmpty ? nil : container.configuration.initProcess.arguments,
+                Healthcheck: nil,  // Apple containers don't have a healthcheck
+                ArgsEscaped: false,  // no mechanism to derive this value
                 Image: container.configuration.image.reference,
-                ExposedPorts: exposedPorts,
+                Volumes: nil,  // Could be derived from mounts if needed
+                WorkingDir: container.configuration.initProcess.workingDirectory.isEmpty ? nil : container.configuration.initProcess.workingDirectory,
+                Entrypoint: [container.configuration.initProcess.executable],
+                NetworkDisabled: container.networks.isEmpty,
+                MacAddress: nil,  // no mechanism to derive this value
+                OnBuild: nil,  // no mechanism to derive this value
+                Labels: container.configuration.labels.isEmpty ? nil : container.configuration.labels,
+                StopSignal: nil,  // no mechanism to derive this value
+                StopTimeout: nil,  // no mechanism to derive this value
+                Shell: nil  // no mechanism to derive this value
             )
-            // add network settings
+
+            let mounts = container.configuration.mounts.map { mount in
+                let mountType: String
+                let mountName: String?
+                let driver: String?
+
+                switch mount.type {
+                case .block(_, _, _):
+                    mountType = "bind"
+                    mountName = nil
+                    driver = nil
+                case .volume(let name, _, _, _):
+                    mountType = "volume"
+                    mountName = name
+                    driver = "local"
+                case .virtiofs:
+                    mountType = "bind"
+                    mountName = nil
+                    driver = nil
+                case .tmpfs:
+                    mountType = "tmpfs"
+                    mountName = nil
+                    driver = nil
+                }
+
+                let isReadonly = mount.options.readonly
+                let mode = isReadonly ? "ro" : "rw"
+
+                return ContainerMountPoint(
+                    type: mountType,
+                    name: mountName,
+                    source: mount.source,
+                    destination: mount.destination,
+                    driver: nil,  // we do not take into account any storage driver at this time
+                    mode: mode,
+                    rw: !isReadonly,
+                    propagation: ""
+                )
+            }
+
+            // Create enhanced HostConfig - using default initializer since struct has many optional fields
+            let hostConfig: HostConfig = HostConfig()
+
+            // Enhanced network settings with proper port mapping
             let networkSettings = ContainerNetworkSettings(
                 Bridge: nil,
                 SandboxID: nil,
-                Ports: Dictionary(grouping: container.configuration.publishedPorts, by: { "\($0.hostPort)/\($0.proto.rawValue)" })
+                Ports: Dictionary(grouping: container.configuration.publishedPorts, by: { "\($0.containerPort)/\($0.proto.rawValue)" })
                     .mapValues { bindings in
-                        bindings.map { PortBinding(HostIp: "\($0.hostAddress)", HostPort: "\($0.hostPort)") }
+                        bindings.map { PortBinding(HostIp: $0.hostAddress, HostPort: "\($0.hostPort)") }
                     },
                 SandboxKey: nil,
                 Networks: Dictionary(
@@ -60,33 +137,71 @@ extension ContainerInspectRoute {
                         )
                         return (attachment.network, endpoint)
                     }
+                ),
+                EndpointsConfig: Dictionary(
+                    uniqueKeysWithValues: container.networks.map { attachment in
+                        let endpoint = ContainerEndpointSettings(
+                            IPAMConfig: nil,
+                            Links: nil,
+                            Aliases: nil,
+                            NetworkID: attachment.network,
+                            EndpointID: nil,
+                            Gateway: attachment.gateway,
+                            IPAddress: attachment.address,
+                            IPPrefixLen: nil,
+                            IPv6Gateway: nil,
+                            GlobalIPv6Address: nil,
+                            GlobalIPv6PrefixLen: nil,
+                            MacAddress: nil,
+                            DriverOpts: nil
+                        )
+                        return (attachment.network, endpoint)
+                    }
                 )
             )
 
-            let hostConfig: HostConfig = HostConfig()
+            // Enhanced container state with better timestamp handling
 
             let containerState: ContainerState = ContainerState(
                 Status: container.status.rawValue,
                 Running: container.status == .running,
-                Paused: false,
+                Paused: false,  // Apple containers don't have a paused state like Docker
                 Restarting: false,
                 OOMKilled: false,
                 Dead: container.status == .stopped,
-                Pid: 0,
-                ExitCode: 0,
+                Pid: 0,  // we have no mechanism to derive PID in Apple container
+                ExitCode: container.status == .stopped ? 0 : 0,
                 Error: "",
-                StartedAt: "",
-                FinishedAt: ""
+                StartedAt: container.status == .running ? "1970-01-01T00:00:00.000000000Z" : "",
+                FinishedAt: container.status == .stopped ? "1970-01-01T00:00:00.000000000Z" : ""
             )
 
             return RESTContainerInspect(
                 Id: container.id,
-                Names: ["/" + container.id],
-                Image: container.configuration.image.reference,
-                ImageID: container.configuration.image.digest,
+                Created: "1970-01-01T00:00:00.000000000Z",  // Default to epoch time for Apple containers
+                Path: container.configuration.initProcess.executable,
+                Args: container.configuration.initProcess.arguments,
                 State: containerState,
-                Config: containerConfig,
+                Image: container.configuration.image.reference,
+                ResolvConfPath: "/etc/resolv.conf",
+                HostnamePath: "/etc/hostname",
+                HostsPath: "/etc/hosts",
+                LogPath: nil,  // Apple containers don't have a log path
+                Name: "/" + container.id,
+                RestartCount: 0,
+                Driver: "",
+                Platform: "linux",
+                ImageManifestDescriptor: nil,
+                MountLabel: "",
+                ProcessLabel: "",
+                AppArmorProfile: "",
+                ExecIDs: nil,
                 HostConfig: hostConfig,
+                GraphDriver: ContainerDriverData(Name: "", Data: [:]),
+                SizeRw: nil,
+                SizeRootFs: nil,
+                Mounts: mounts,
+                Config: containerConfig,
                 NetworkSettings: networkSettings
             )
         }

--- a/Sources/socktainer/Routes/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/ContainerListRoute.swift
@@ -2,6 +2,7 @@ import Vapor
 
 struct ContainerListQuery: Content {
     var all: Bool?
+    var filters: String?
 }
 
 struct ContainerListRoute: RouteCollection {
@@ -20,15 +21,99 @@ extension ContainerListRoute {
             let query = try req.query.decode(ContainerListQuery.self)
             let showAll = query.all ?? false
 
-            let containers = try await client.list(showAll: showAll)
+            let parsedFilters = try DockerContainerFilterUtility.parseContainerFilters(filtersParam: query.filters, logger: req.logger)
+            let containers = try await client.list(showAll: showAll, filters: parsedFilters)
 
-            return containers.map {
-                RESTContainerSummary(
-                    Id: $0.id,
-                    Names: ["/" + $0.id],
-                    Image: $0.configuration.image.reference,
-                    ImageID: $0.configuration.image.digest,
-                    State: $0.status.rawValue
+            return containers.map { container in
+                let ports = container.configuration.publishedPorts.map { port in
+                    ContainerPort(
+                        IP: port.hostAddress,
+                        PrivatePort: Int(port.containerPort),
+                        PublicPort: Int(port.hostPort),
+                        type: port.proto.rawValue
+                    )
+                }
+
+                let networkMode = container.networks.first?.network ?? "default"
+
+                let networkSettings = Dictionary(
+                    uniqueKeysWithValues: container.networks.map { attachment in
+                        let endpoint = ContainerEndpointSettings(
+                            IPAMConfig: nil,
+                            Links: nil,
+                            Aliases: nil,
+                            NetworkID: attachment.network,
+                            EndpointID: nil,
+                            Gateway: attachment.gateway,
+                            IPAddress: attachment.address,
+                            IPPrefixLen: nil,
+                            IPv6Gateway: nil,
+                            GlobalIPv6Address: nil,
+                            GlobalIPv6PrefixLen: nil,
+                            MacAddress: nil,
+                            DriverOpts: nil
+                        )
+                        return (attachment.network, endpoint)
+                    }
+                )
+
+                let mounts = container.configuration.mounts.map { mount in
+                    let mountType: String
+                    let mountName: String?
+                    let driver: String?
+
+                    switch mount.type {
+                    case .block(_, _, _):
+                        mountType = "bind"
+                        mountName = nil
+                        driver = nil
+                    case .volume(let name, _, _, _):
+                        mountType = "volume"
+                        mountName = name
+                        driver = "local"
+                    case .virtiofs:
+                        mountType = "bind"
+                        mountName = nil
+                        driver = nil
+                    case .tmpfs:
+                        mountType = "tmpfs"
+                        mountName = nil
+                        driver = nil
+                    }
+
+                    let isReadOnly = mount.options.readonly
+                    let mode = isReadOnly ? "ro" : "rw"
+
+                    return ContainerMountPoint(
+                        type: mountType,
+                        name: mountName,
+                        source: mount.source,
+                        destination: mount.destination,
+                        driver: driver,
+                        mode: mode,
+                        rw: !isReadOnly,
+                        propagation: ""
+                    )
+                }
+
+                return RESTContainerSummary(
+                    Id: container.id,
+                    Names: ["/" + container.id],
+                    Image: container.configuration.image.reference,
+                    ImageID: container.configuration.image.digest,
+                    ImageManifestDescriptor: nil,
+                    Command: ([container.configuration.initProcess.executable] + container.configuration.initProcess.arguments).joined(separator: " "),
+                    Created: 0,  // Default to epoch time for Apple containers
+                    Ports: ports,
+                    SizeRw: nil,  // there is no mechanism to retrieve this value from apple container
+                    SizeRootFs: nil,  // there is no mechanism to retrieve this value from apple container
+                    Labels: container.configuration.labels,
+                    State: container.status.rawValue,
+                    Status: container.status.rawValue,
+                    HostConfig: ContainerHostConfig(NetworkMode: networkMode, Annotations: nil),
+                    NetworkSettings: ContainerNetworkSummary(Networks: networkSettings.isEmpty ? nil : networkSettings),
+                    Mounts: mounts,
+                    Platform: "linux"  // Apple containers always run linux platform
                 )
             }
         }

--- a/Sources/socktainer/Routes/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/ContainerStartRoute.swift
@@ -15,7 +15,13 @@ extension ContainerStartRoute {
             guard let id = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
-            try await client.start(id: id, detach: true)
+
+            do {
+                try await client.start(id: id, detach: true)
+            } catch {
+                req.logger.error("Failed to start container \(id): \(error)")
+                throw Abort(.internalServerError, reason: "Failed to start container: \(error)")
+            }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
 

--- a/Sources/socktainer/Routes/InfoRoute.swift
+++ b/Sources/socktainer/Routes/InfoRoute.swift
@@ -9,14 +9,14 @@ struct InfoRoute: RouteCollection {
     static func handler(_ req: Request) async throws -> Response {
         do {
             let containerClient = ClientContainerService()
-            let allContainers = try await containerClient.list(showAll: true)
+            let allContainers = try await containerClient.list(showAll: true, filters: [:])
 
             let info = SystemInfo(
                 Containers: allContainers.count,
-                ContainersRunning: allContainers.filter { $0.status == .running }.count,
+                ContainersRunning: allContainers.filter { $0.status == RuntimeStatus.running }.count,
                 // Apple container doesn't support pausing containers
                 ContainersPaused: 0,
-                ContainersStopped: allContainers.filter { $0.status == .stopped }.count,
+                ContainersStopped: allContainers.filter { $0.status == RuntimeStatus.stopped }.count,
                 Images: try await ClientImageService().list().count,
                 DockerRootDir: try await ClientHealthCheck.ping().appRoot.path,
                 Debug: isDebug(),

--- a/Sources/socktainer/Utilitites/HostUtility.swift
+++ b/Sources/socktainer/Utilitites/HostUtility.swift
@@ -40,3 +40,42 @@ public func getKernel() -> String {
     }
     return release
 }
+
+func findAvailablePort() throws -> Int {
+    let sock = socket(AF_INET, SOCK_STREAM, 0)
+    guard sock >= 0 else {
+        throw NSError(domain: "PortAllocation", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create socket"])
+    }
+
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_addr.s_addr = INADDR_ANY
+    addr.sin_port = 0  // Let system choose port
+
+    let bindResult = withUnsafePointer(to: addr) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            bind(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+
+    guard bindResult == 0 else {
+        close(sock)
+        throw NSError(domain: "PortAllocation", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to bind socket"])
+    }
+
+    var actualAddr = sockaddr_in()
+    var addrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let getsocknameResult = withUnsafeMutablePointer(to: &actualAddr) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            getsockname(sock, $0, &addrLen)
+        }
+    }
+
+    close(sock)
+
+    guard getsocknameResult == 0 else {
+        throw NSError(domain: "PortAllocation", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to get socket name"])
+    }
+
+    return Int(CFSwapInt16BigToHost(actualAddr.sin_port))
+}


### PR DESCRIPTION
The following improvements were done to the routes:
- `POST /conatiners/{id}`:
   - Now accepts most parameters passed from `CreateContainerRequest`.
   - Enhanced port mapping logic.
- `GET /containers/json`
   - `RESTContainerSummary` was extended to return more details.
   - Add support for filters.
- `GET /containers/{id}/json`
   - `RESTContainerInspect` was extended to return more details.

Updating Utility files with additional methods.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
