### PR TITLE
feat(routes): Update Container Routes

### DIFF
--- a/Sources/socktainer/Models/RESTConfig.swift
+++ b/Sources/socktainer/Models/RESTConfig.swift
@@ -442,3 +442,7 @@ struct ContainerHostConfig: Content {
 struct ContainerNetworkSummary: Content {
     let Networks: [String: ContainerEndpointSettings]?
 }
+
+public struct ContainerWaitExitError: Codable, Sendable {
+    public let Message: String?
+}

--- a/Sources/socktainer/Models/RESTContainerWait.swift
+++ b/Sources/socktainer/Models/RESTContainerWait.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Vapor
+
+public struct RESTContainerWait: Content {
+    public let StatusCode: Int64
+    public let Error: ContainerWaitExitError?
+    public init(statusCode: Int64, error: ContainerWaitExitError? = nil) {
+
+        self.StatusCode = statusCode
+        self.Error = error
+
+    }
+}

--- a/Sources/socktainer/Routes/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/ContainerDeleteRoute.swift
@@ -22,7 +22,7 @@ extension ContainerDeleteRoute {
             if let container = try await client.getContainer(id: id),
                 container.status == .running
             {
-                try await client.stop(id: id)
+                try await client.stop(id: id, signal: nil, timeout: nil)
             }
             try await client.delete(id: id)
 

--- a/Sources/socktainer/Routes/ContainerKillRoute.swift
+++ b/Sources/socktainer/Routes/ContainerKillRoute.swift
@@ -1,11 +1,40 @@
+import ContainerClient
 import Vapor
 
-struct ContainerKillRoute: RouteCollection {
-    func boot(routes: RoutesBuilder) throws {
-        routes.post(":version", "containers", ":id", "kill", use: ContainerKillRoute.handler)
-    }
+struct ContainerKillQuery: Content {
+    let signal: String?
+}
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/kill", req.method.rawValue)
+struct ContainerKillRoute: RouteCollection {
+    let client: ClientContainerService
+    func boot(routes: RoutesBuilder) throws {
+        routes.post(":version", "containers", ":id", "kill", use: ContainerKillRoute.handler(client: client))
+    }
+}
+
+extension ContainerKillRoute {
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+
+            let query = try req.query.decode(ContainerKillQuery.self)
+
+            guard let containerId = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Container ID is required")
+            }
+
+            let signal = query.signal ?? nil
+
+            do {
+                try await client.kill(id: containerId, signal: signal)
+                return Response(status: .noContent)
+            } catch ClientContainerError.notFound {
+                return Response(status: .notFound, body: .init(string: "container \(containerId) not found"))
+            } catch ClientContainerError.notRunning {
+                return Response(status: .conflict, body: .init(string: "container \(containerId) is not running"))
+            } catch {
+                req.logger.error("Failed to kill container \(containerId): \(error)")
+                return Response(status: .internalServerError, body: .init(string: "Failed to kill container: \(error)"))
+            }
+        }
     }
 }

--- a/Sources/socktainer/Routes/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/ContainerRestartRoute.swift
@@ -1,11 +1,46 @@
 import Vapor
 
 struct ContainerRestartRoute: RouteCollection {
+    let client: ClientContainerProtocol
     func boot(routes: RoutesBuilder) throws {
-        routes.post(":version", "containers", ":id", "restart", use: ContainerRestartRoute.handler)
+        routes.post(":version", "containers", ":id", "restart", use: ContainerRestartRoute.handler(client: client))
+        // also handle without version prefix
+        routes.post("containers", ":id", "restart", use: ContainerRestartRoute.handler(client: client))
     }
+}
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/restart", req.method.rawValue)
+struct ContainerRestartQuery: Content {
+    let signal: String?
+    let t: Int?/// Number of seconds to wait before killing the container
+}
+
+extension ContainerRestartRoute {
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> HTTPStatus {
+        { req in
+            guard let id = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing container ID")
+            }
+
+            let query = try req.query.decode(ContainerRestartQuery.self)
+            let signal = query.signal
+            let timeout = query.t
+
+            do {
+                try await client.restart(id: id, signal: signal, timeout: timeout)
+            } catch ClientContainerError.notFound {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch {
+                req.logger.error("Failed to restart container \(id): \(error)")
+                throw Abort(.internalServerError, reason: "Failed to restart container: \(error)")
+            }
+
+            let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+
+            // Broadcast restart event (or both stop and start events)
+            let restartEvent = DockerEvent.simpleEvent(id: id, type: "container", status: "restart")
+            await broadcaster.broadcast(restartEvent)
+
+            return .noContent
+        }
     }
 }

--- a/Sources/socktainer/Routes/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/ContainerStartRoute.swift
@@ -9,15 +9,25 @@ struct ContainerStartRoute: RouteCollection {
     }
 }
 
+struct ContainerStartQuery: Content {
+    /// Override the key sequence for detaching a container
+    let detachKeys: String?
+}
+
 extension ContainerStartRoute {
+    // TODO: Update logic to parse stdin from request.
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> HTTPStatus {
         { req in
+
             guard let id = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
+            let query = try req.query.decode(ContainerStartQuery.self)
+            let detachKeys = query.detachKeys
+
             do {
-                try await client.start(id: id, detach: true)
+                try await client.start(id: id, detachKeys: detachKeys)
             } catch {
                 req.logger.error("Failed to start container \(id): \(error)")
                 throw Abort(.internalServerError, reason: "Failed to start container: \(error)")

--- a/Sources/socktainer/Routes/ContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/ContainerStopRoute.swift
@@ -10,13 +10,23 @@ struct ContainerStopRoute: RouteCollection {
     }
 }
 
+struct ContainerStopQuery: Content {
+    let signal: String?
+    let t: Int?/// Number of seconds to wait before stopping the container
+}
+
 extension ContainerStopRoute {
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> HTTPStatus {
         { req in
             guard let id = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
-            try await client.stop(id: id)
+
+            let query = try req.query.decode(ContainerStopQuery.self)
+            let signal = query.signal
+            let timeout = query.t
+
+            try await client.stop(id: id, signal: signal, timeout: timeout)
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
 
@@ -24,7 +34,7 @@ extension ContainerStopRoute {
 
             await broadcaster.broadcast(event)
 
-            return .ok
+            return .noContent
         }
     }
 }

--- a/Sources/socktainer/Routes/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/ContainerWaitRoute.swift
@@ -1,11 +1,44 @@
 import Vapor
 
+public enum ContainerWaitCondition: String, CaseIterable, Codable, Sendable {
+    case notRunning = "not-running"
+    case nextExit = "next-exit"
+    case removed = "removed"
+
+    public static let `default`: ContainerWaitCondition = .notRunning
+}
+
 struct ContainerWaitRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
     func boot(routes: RoutesBuilder) throws {
-        routes.post(":version", "containers", ":id", "wait", use: ContainerWaitRoute.handler)
+        routes.post(":version", "containers", ":id", "wait", use: ContainerWaitRoute.handler(client: client))
+        routes.post("containers", ":id", "wait", use: ContainerWaitRoute.handler(client: client))
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/wait", req.method.rawValue)
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerWait {
+        { req in
+            guard let containerId = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing container ID")
+            }
+
+            let conditionString = req.query["condition"] as String?
+            let condition: ContainerWaitCondition
+
+            if let conditionString = conditionString {
+                condition = ContainerWaitCondition(rawValue: conditionString) ?? ContainerWaitCondition.default
+            } else {
+                condition = ContainerWaitCondition.default
+            }
+
+            do {
+                let waitResponse = try await client.wait(id: containerId, condition: condition)
+                return waitResponse
+            } catch ClientContainerError.notFound(let id) {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch {
+                throw Abort(.internalServerError, reason: "Failed to wait for container: \(error)")
+            }
+        }
     }
 }

--- a/Sources/socktainer/Utilitites/HostUtility.swift
+++ b/Sources/socktainer/Utilitites/HostUtility.swift
@@ -79,3 +79,42 @@ func findAvailablePort() throws -> Int {
 
     return Int(CFSwapInt16BigToHost(actualAddr.sin_port))
 }
+
+public func parseSignal(_ signal: String) throws -> Int32 {
+    let signalUpper = signal.uppercased()
+    switch signalUpper {
+    case "SIGTERM", "TERM", "15":
+        return SIGTERM
+    case "SIGKILL", "KILL", "9":
+        return SIGKILL
+    case "SIGINT", "INT", "2":
+        return SIGINT
+    case "SIGHUP", "HUP", "1":
+        return SIGHUP
+    case "SIGQUIT", "QUIT", "3":
+        return SIGQUIT
+    case "SIGABRT", "ABRT", "6":
+        return SIGABRT
+    case "SIGSTOP", "STOP", "19":
+        return SIGSTOP
+    case "SIGCONT", "CONT", "18":
+        return SIGCONT
+    case "SIGUSR1", "USR1", "10":
+        return SIGUSR1
+    case "SIGUSR2", "USR2", "12":
+        return SIGUSR2
+    case "SIGWINCH", "WINCH", "28":
+        return SIGWINCH
+    case "SIGTSTP", "TSTP", "20":
+        return SIGTSTP
+    case "SIGTTIN", "TTIN", "21":
+        return SIGTTIN
+    case "SIGTTOU", "TTOU", "22":
+        return SIGTTOU
+    default:
+        if let signalNum = Int32(signalUpper) {
+            return signalNum
+        }
+        throw NSError(domain: "SignalParsing", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid signal: \(signal)"])
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -1,6 +1,7 @@
 import Vapor
 
 func configure(_ app: Application) async throws {
+
     let containerClient = ClientContainerService()
     let imageClient = ClientImageService()
     let healthCheckClient = ClientHealthCheckService()
@@ -28,21 +29,21 @@ func configure(_ app: Application) async throws {
     try app.register(collection: ContainerDeleteRoute(client: containerClient))
     try app.register(collection: ContainerExportRoute())
     try app.register(collection: ContainerInspectRoute(client: containerClient))
-    try app.register(collection: ContainerKillRoute())
+    try app.register(collection: ContainerKillRoute(client: containerClient))
     try app.register(collection: ContainerListRoute(client: containerClient))
     try app.register(collection: ContainerLogsRoute(client: containerClient))
     try app.register(collection: ContainerPauseRoute())
     try app.register(collection: ContainerPruneRoute(client: containerClient))
     try app.register(collection: ContainerRenameRoute())
     try app.register(collection: ContainerResizeRoute())
-    try app.register(collection: ContainerRestartRoute())
+    try app.register(collection: ContainerRestartRoute(client: containerClient))
     try app.register(collection: ContainerStartRoute(client: containerClient))
     try app.register(collection: ContainerStatsRoute())
     try app.register(collection: ContainerStopRoute(client: containerClient))
     try app.register(collection: ContainerTopRoute())
     try app.register(collection: ContainerUnpauseRoute())
     try app.register(collection: ContainerUpdateRoute())
-    try app.register(collection: ContainerWaitRoute())
+    try app.register(collection: ContainerWaitRoute(client: containerClient))
 
     // /images
     try app.register(collection: ImageDeleteRoute(client: imageClient))


### PR DESCRIPTION
Implementing the following routes:
- `POST /containers/{id}/kill`
  Sends a stop signal to container
  (Resolves #76).
- `POST /containers/{id}/restart
  Restart a container.
  (Resolves #77).
- `POST /containers/{id}/wait`
  Waits for container termination.
  (Resolves #79).

Fixes:
- Update `/containers/start` to use the query parameters
  described in the OpenAPI spec.
- Update `/containers/stop` to use the query parameters
  described in the OpenAPI spec.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
