### PR TITLE
feat: create named volume if it does not exists

### DIFF
--- a/Sources/socktainer/Routes/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerCreateRoute.swift
@@ -292,6 +292,7 @@ extension ContainerCreateRoute {
                         volume = existing
                     } else {
                         // Volume doesn't exist, create it automatically (Docker behavior)
+                        // might be revisited if https://github.com/apple/container/issues/690 is closed
                         req.logger.debug("Volume '\(parsed.name)' not found, creating it automatically")
                         volume = try await ClientVolume.create(
                             name: parsed.name,


### PR DESCRIPTION
fixes https://github.com/socktainer/socktainer/issues/100


example:

```
docker run -v foobar:/foobar --rm -it fedora
```

then check volume exists (no error reported)
