### PR TITLE
chore: use latest-stable as 26.0.0 is no longer available on CI

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0.0
+          xcode-version: latest-stable
 
 
       - name: Run Build

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,9 +27,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  SWIFT_VERSION: 6.2-snapshot
-
 jobs:
   build:
     name: build
@@ -48,7 +45,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0.0
+          xcode-version: latest-stable
 
       - name: Display swift version
         run: |
@@ -89,7 +86,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0.0
+          xcode-version: latest-stable
 
       - name: Display swift version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0.0
+          xcode-version: latest-stable
 
       - name: Display swift version
         run: |


### PR DESCRIPTION
try to use keyword rather than a fixed version