### PR TITLE
chore(deps): updates apple container dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "45d2f80bdfac213cf7f9bb99ee9907ad196d4a20294a75724d6f3471348990d7",
+  "originHash" : "fac29bb081d94b807bc2b2b890b316c260a3b8e2f0206edb895a9e8bc5ad2beb",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "48230f380499efecd663fdc6749a2cbaf2f8ed76",
-        "version" : "0.5.0"
+        "revision" : "a23bcf0061090c43f3835505f49f490a251818a1",
+        "version" : "0.6.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "992ed9f5aa3b0e875ef8ac6b605a4c352218463b",
-        "version" : "0.9.1"
+        "revision" : "c7af5b8222551f07dc0b65b8488d5e6a386ba49a",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/container.git", from: "0.5.0"),
-        .package(url: "https://github.com/apple/containerization.git", from: "0.9.1"),
+        .package(url: "https://github.com/apple/container.git", from: "0.6.0"),
+        .package(url: "https://github.com/apple/containerization.git", from: "0.12.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.116.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.1"),

--- a/Sources/socktainer/Routes/BuildRoute.swift
+++ b/Sources/socktainer/Routes/BuildRoute.swift
@@ -413,7 +413,7 @@ extension BuildRoute {
             noCache: noCache,
             platforms: [Platform](platforms),
             terminal: nil,  // No terminal for API
-            tag: imageName,
+            tags: [imageName],
             target: target,
             quiet: quiet,
             exports: exports,


### PR DESCRIPTION
Updates dependencies.

Reason:
- with the latest version the API was no longer working as the route route is a bit different.

Tested:
- I don't have the Testing framework installed ( I don't do swift generally ), so please run make test if you don't have CI yet.
- I tried with the latest docker CLI and it works well.