### PR TITLE
refactor(internal): Improve DispatchIO Logic

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -225,14 +225,18 @@ struct ClientContainerService: ClientContainerProtocol {
         var exitCode: Int64 = 0
 
         switch condition {
+        // TODO: This condition needs to be re-implemented to properly handle container lifecycle
+        //       Currently stubbed to support `docker attach` workflows,
+        //       immediately return to prevent blocking `docker attach`
         case .notRunning:
-            while container?.status == .running {
-                try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
-                container = try await ClientContainer.list().first(where: { $0.id == id })
-                guard let container = container else {
-                    break
-                }
-            }
+            // while container?.status == .running {
+            //     try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
+            //     container = try await ClientContainer.list().first(where: { $0.id == id })
+            //     guard let container = container else {
+            //         break
+            //     }
+            // }
+            break
 
         case .nextExit:
             // Wait for next exit (only if currently running)

--- a/Sources/socktainer/Routes/EventsRoute.swift
+++ b/Sources/socktainer/Routes/EventsRoute.swift
@@ -28,8 +28,8 @@ extension EventsRoute {
                             buffer.writeBytes(json)
                             buffer.writeString("\n")
                             writer.write(.buffer(buffer)).whenFailure { error in
-                                // Optional: handle error
-                                print("Write error: \(error)")
+                                // NOTE: Consider improving logging
+                                req.logger.warning("\(event) raised '\(error)'")
                             }
                         }
                     }


### PR DESCRIPTION
Refactor the usage of DispatchIO when interacting with file descriptors
during `exec` and `attach` operations.
This should reduce the server crashes during IO spikes.

Update interactive routes to use updated logic.
