### PR TITLE
chore(routes): Update Image Inspect And History

### DIFF
--- a/Sources/socktainer/Models/RESTImageInspect.swift
+++ b/Sources/socktainer/Models/RESTImageInspect.swift
@@ -1,9 +1,98 @@
 import Vapor
 
+struct OCIDescriptor: Content {
+    let mediaType: String?
+    let digest: String?
+    let size: Int64?
+    let urls: [String]?
+    let annotations: [String: String]?
+    let platform: OCIPlatform?
+
+    struct OCIPlatform: Content {
+        let architecture: String?
+        let os: String?
+        let osVersion: String?
+        let osFeatures: [String]?
+        let variant: String?
+    }
+}
+
+struct ImageManifestSummary: Content {
+    let Descriptor: OCIDescriptor?
+    let Available: Bool?
+    let Kind: String?
+    let Size: ImageManifestSize?
+
+    struct ImageManifestSize: Content {
+        let Total: Int64?
+        let Content: Int64?
+    }
+}
+
+struct ImageConfig: Content {
+    let User: String?
+    let ExposedPorts: [String: [String: String]]?
+    let Env: [String]?
+    let Cmd: [String]?
+    let Healthcheck: HealthConfig?
+    let ArgsEscaped: Bool?
+    let Volumes: [String: [String: String]]?
+    let WorkingDir: String?
+    let Entrypoint: [String]?
+    let OnBuild: [String]?
+    let Labels: [String: String]?
+    let StopSignal: String?
+    let Shell: [String]?
+}
+
+struct HealthConfig: Content {
+    let Test: [String]?
+    let Interval: Int64?
+    let Timeout: Int64?
+    let Retries: Int?
+    let StartPeriod: Int64?
+    let StartInterval: Int64?
+}
+
+struct DriverData: Content {
+    let Name: String
+    let Data: [String: String]
+}
+
+struct RootFS: Content {
+    // Using custom CodingKeys to map Swift property name to JSON key
+    enum CodingKeys: String, CodingKey {
+        case rootfsType = "Type"
+        case Layers
+    }
+
+    let rootfsType: String
+    let Layers: [String]?
+}
+
+struct ImageMetadata: Content {
+    let LastTagTime: String?
+}
+
 struct RESTImageInspect: Content {
     let Id: String
+    let Descriptor: OCIDescriptor?
+    let Manifests: [ImageManifestSummary]?
     let RepoTags: [String]
     let RepoDigests: [String]
-    let Created: String
+    let Parent: String?
+    let Comment: String?
+    let Created: String?
+    let DockerVersion: String?
+    let Author: String?
+    let Config: ImageConfig?
+    let Architecture: String?
+    let Variant: String?
+    let Os: String?
+    let OsVersion: String?
     let Size: Int64
+    let VirtualSize: Int64?
+    let GraphDriver: DriverData?
+    let RootFS: RootFS?
+    let Metadata: ImageMetadata?
 }

--- a/Sources/socktainer/Routes/ImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/ImageHistoryRoute.swift
@@ -2,9 +2,12 @@ import Vapor
 
 struct ImageHistoryRoute: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        routes.get(":version", "images", ":name", "history", use: ImageHistoryRoute.handler)
+        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/history", use: ImageHistoryRoute.handler)
     }
 
+}
+
+extension ImageHistoryRoute {
     static func handler(_ req: Request) async throws -> Response {
         NotImplemented.respond("/images/{name}/history", req.method.rawValue)
     }

--- a/Sources/socktainer/Routes/ImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/ImageInspectRoute.swift
@@ -110,12 +110,52 @@ extension ImageInspectRoute {
                         }
                         let size = descriptor.size + manifest.config.size + manifest.layers.reduce(0, { (l, r) in l + r.size })
 
+                        let imageConfig: ImageConfig? = config.config.map { ociConfig in
+                            ImageConfig(
+                                User: ociConfig.user,
+                                ExposedPorts: nil,  // Not available in OCI config
+                                Env: ociConfig.env,
+                                Cmd: ociConfig.cmd,
+                                Healthcheck: nil,  // Not available in OCI config
+                                ArgsEscaped: nil,
+                                Volumes: nil,  // Not available in OCI config
+                                WorkingDir: ociConfig.workingDir,
+                                Entrypoint: ociConfig.entrypoint,
+                                OnBuild: nil,  // Not available in OCI config
+                                Labels: ociConfig.labels,
+                                StopSignal: ociConfig.stopSignal,
+                                Shell: nil  // Not available in OCI config
+                            )
+                        }
+
+                        // Build RootFS from manifest layers
+                        let rootFS = RootFS(
+                            rootfsType: config.rootfs.type,
+                            Layers: config.rootfs.diffIDs
+                        )
+
                         let summary = RESTImageInspect(
                             Id: image.digest,
+                            Descriptor: nil,  // Not readily available
+                            Manifests: nil,  // Not readily available
                             RepoTags: [details.name],
-                            RepoDigests: [],
-                            Created: iso8601Formatter.string(from: date),
-                            Size: size, )
+                            RepoDigests: [],  // Would need registry information
+                            Parent: nil,  // Not available from OCI format
+                            Comment: nil,  // Not available from OCI format
+                            Created: config.created,
+                            DockerVersion: nil,  // Not available from OCI format
+                            Author: config.author,
+                            Config: imageConfig,
+                            Architecture: config.architecture,
+                            Variant: config.variant,
+                            Os: config.os,
+                            OsVersion: config.osVersion,
+                            Size: size,
+                            VirtualSize: size,  // Same as Size for compatibility
+                            GraphDriver: nil,  // Storage driver info not available
+                            RootFS: rootFS,
+                            Metadata: nil  // Local metadata not available
+                        )
 
                         return summary
                     }


### PR DESCRIPTION
Updating `/images/{name}/json` (inspect) route to return more metadata to
match API spec.

Stubbing `images/{name}/history` route.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
