### PR TITLE
feat(routes): Add `/images/{name}/tag`

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -225,6 +225,9 @@ jobs:
           # https://github.com/socktainer/socktainer/issues/47
           # check image is present
           sudo docker image ls | grep 'quay.io/podman/hello'
+          # Tag images
+          sudo docker image tag httpd test
+          sudo docker image inspect test
 
       # NOTE: Disabling tests for now.
       #       Most likely calling some internal function that fails

--- a/Sources/socktainer/Routes/ImageTagRoute.swift
+++ b/Sources/socktainer/Routes/ImageTagRoute.swift
@@ -1,11 +1,49 @@
+import ContainerClient
 import Vapor
 
 struct ImageTagRoute: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        routes.post(":version", "images", ":name", "tag", use: ImageTagRoute.handler)
+        try routes.registerVersionedRoute(.POST, pattern: "/images/{name:.*}/tag", use: ImageTagRoute.handler)
     }
+}
 
+struct RESTImageTagQuery: Vapor.Content {
+    let repo: String?
+    let tag: String?
+}
+
+extension ImageTagRoute {
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/images/{name}/tag", req.method.rawValue)
+        guard let sourceImageName = req.parameters.get("name") else {
+            throw Abort(.badRequest, reason: "Missing image name parameter")
+        }
+
+        let query = try req.query.decode(RESTImageTagQuery.self)
+
+        guard let repo = query.repo, !repo.isEmpty else {
+            throw Abort(.badRequest, reason: "repo parameter is required")
+        }
+
+        let targetReference: String
+        if let tag = query.tag, !tag.isEmpty {
+            targetReference = "\(repo):\(tag)"
+        } else {
+            targetReference = "\(repo):latest"
+        }
+
+        let sourceImage: ClientImage
+        do {
+            sourceImage = try await ClientImage.get(reference: sourceImageName)
+        } catch {
+            throw Abort(.notFound, reason: "No such image: \(sourceImageName)")
+        }
+
+        do {
+            _ = try await sourceImage.tag(new: targetReference)
+            return Response(status: .created)
+        } catch {
+            req.logger.error("Failed to tag image: \(error)")
+            throw Abort(.internalServerError, reason: "Failed to tag image: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
Adding a route which allows tagging a container image.

Resolves #125.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
