### PR TITLE
chore(workaround): Add Creation Timestamps

### DIFF
--- a/Sources/socktainer/Routes/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/ContainerCreateRoute.swift
@@ -217,7 +217,12 @@ extension ContainerCreateRoute {
             }
 
             containerConfiguration.publishedPorts = publishedPorts
-            containerConfiguration.labels = body.Labels ?? [:]
+
+            var labels = body.Labels ?? [:]
+            // NOTE: [WORKAROUND] to include creation timestamp since it is not handled by Apple Container
+            //       https://github.com/apple/container/issues/302
+            labels["io.github.socktainer.creation-timestamp"] = String(Date().timeIntervalSince1970)
+            containerConfiguration.labels = labels
 
             var resolvedMounts: [Filesystem] = []
 

--- a/Sources/socktainer/Routes/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/ContainerListRoute.swift
@@ -96,6 +96,15 @@ extension ContainerListRoute {
                     )
                 }
 
+                let createdTimestamp: Int64
+                if let timestampStr = container.configuration.labels["io.github.socktainer.creation-timestamp"],
+                    let timestamp = Double(timestampStr)
+                {
+                    createdTimestamp = Int64(timestamp)
+                } else {
+                    createdTimestamp = 0
+                }
+
                 return RESTContainerSummary(
                     Id: container.id,
                     Names: ["/" + container.id],
@@ -103,7 +112,7 @@ extension ContainerListRoute {
                     ImageID: container.configuration.image.digest,
                     ImageManifestDescriptor: nil,
                     Command: ([container.configuration.initProcess.executable] + container.configuration.initProcess.arguments).joined(separator: " "),
-                    Created: 0,  // Default to epoch time for Apple containers
+                    Created: createdTimestamp,
                     Ports: ports,
                     SizeRw: nil,  // there is no mechanism to retrieve this value from apple container
                     SizeRootFs: nil,  // there is no mechanism to retrieve this value from apple container


### PR DESCRIPTION
A workaround to support creation timestamps using a custom label passed
to containers and networks when they are created by `socktainer`.

Resolves #109.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>