### PR TITLE
Ignore platform value when empty

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -57,7 +57,7 @@ extension ContainerCreateRoute {
             let containerName = query.name
 
             // use platform "" if not provided
-            let containerPlatform = query.platform ?? "linux/\(Arch.hostArchitecture().rawValue)"
+            let containerPlatform = (query.platform?.isEmpty == false) ? query.platform! : "linux/\(Arch.hostArchitecture().rawValue)"
 
             let bodyData = try await req.body.collect().get()!
             let body = try JSONDecoder().decode(CreateContainerRequest.self, from: bodyData.getData(at: 0, length: bodyData.readableBytes)!)


### PR DESCRIPTION
I ran into an issue using socktainer with the Rust crate, [Bollard](https://crates.io/crates/bollard).

When the platform value is an empty string, the container creation will err:

> invalidArgument: "Missing OS in "

The Docker CLI will never send an empty string but [the Docker Engine API specifies `default: ""`](https://github.com/moby/moby/blob/v28.5.2/api/swagger.yaml#L7741-L7762). The Docker Engine itself [will only attempt to parse non-empty values](https://github.com/moby/moby/blob/v28.5.2/api/server/router/container/container_routes.go#L549-L558).

So, for parity with Docker Engine, it seems ideal to ignore empty strings.

The proposed change follows the pattern established in the same file:

https://github.com/socktainer/socktainer/blob/cebe01370beee0c46fb3f21d7b6d6db1a003dcde/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift#L152
https://github.com/socktainer/socktainer/blob/cebe01370beee0c46fb3f21d7b6d6db1a003dcde/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift#L185