### PR TITLE
fix: enable rosetta for amd64 emulation

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -181,6 +181,11 @@ extension ContainerCreateRoute {
             var containerConfiguration = ContainerConfiguration(id: id, image: img.description, process: processConfig)
             containerConfiguration.platform = requestedPlatform
 
+            // Enable Rosetta when running amd64 images if on arm64 host
+            if Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64" {
+                containerConfiguration.rosetta = true
+            }
+
             // Handle hostname from request - ensure uniqueness to avoid collision
             let hostname = (body.Hostname?.isEmpty == false) ? body.Hostname! : "\(id)-\(UUID().uuidString.lowercased())"
 


### PR DESCRIPTION
fixes https://github.com/socktainer/socktainer/issues/157

```
$ docker run --rm -it --platform=linux/amd64 ubuntu

root@cc747d0d-575f-45af-a238-cdc0b3b82394:/# uname -a
Linux cc747d0d-575f-45af-a238-cdc0b3b82394 6.12.28 #1 SMP Tue May 20 15:19:05 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```