### PR TITLE
fix(events): handle client disconnections

### DIFF
--- a/Sources/socktainer/Routes/Server/EventsRoute.swift
+++ b/Sources/socktainer/Routes/Server/EventsRoute.swift
@@ -1,4 +1,5 @@
 import ContainerClient
+import NIOCore
 import Vapor
 
 struct EventsRoute: RouteCollection {
@@ -28,6 +29,12 @@ extension EventsRoute {
                             buffer.writeString("\n")
                             do {
                                 try await writer.write(.buffer(buffer))
+                            } catch is IOError {
+                                req.logger.debug("Client disconnected (broken pipe)")
+                                break
+                            } catch let error as ChannelError where error == .ioOnClosedChannel {
+                                req.logger.debug("Client disconnected (closed channel)")
+                                break
                             } catch {
                                 // NOTE: Consider improving logging
                                 req.logger.warning("\(event) raised '\(error)'")


### PR DESCRIPTION
Once a client disconnects from the `GET /events` endpoint, each event is going to produce one of two warnings:

```
[ WARNING ] DockerEvent(...) raised 'writev(descriptor:iovecs:): Broken pipe) (errno: 32)'
```
```
[ WARNING ] DockerEvent(...) raised 'I/O on closed channel'
```

Repeat this with a number of clients and the log becomes incredibly noisy.

If the client disconnects, we want to terminate the task and then [clean up after ourselves](https://github.com/socktainer/socktainer/blob/d4c5f454f9d8fc23c018c914909ebb72046428e8/Sources/socktainer/Events/EventBroadcaster.swift#L72-L77). So, let's catch these errors and handle them.