### PR TITLE
Fix crash by reordering close calls

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -405,6 +405,7 @@ extension ContainerAttachRoute {
                                 fileDescriptor: stdoutHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
                             ) { error in
+                                continuation.resume()
                             }
 
                             dispatchIO.setLimit(lowWater: 1)
@@ -416,7 +417,6 @@ extension ContainerAttachRoute {
                                 if state.shouldStop() {
                                     state.finish {
                                         dispatchIO.close()
-                                        continuation.resume()
                                     }
                                     return
                                 }
@@ -442,7 +442,6 @@ extension ContainerAttachRoute {
                                     if done || error != 0 {
                                         state.finish {
                                             dispatchIO.close()
-                                            continuation.resume()
                                         }
                                     } else if !state.shouldStop() {
                                         DispatchQueue.global(qos: .userInteractive).async {
@@ -467,6 +466,7 @@ extension ContainerAttachRoute {
                                 fileDescriptor: stderrHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
                             ) { error in
+                                continuation.resume()
                             }
 
                             dispatchIO.setLimit(lowWater: 1)
@@ -478,7 +478,6 @@ extension ContainerAttachRoute {
                                 if state.shouldStop() {
                                     state.finish {
                                         dispatchIO.close()
-                                        continuation.resume()
                                     }
                                     return
                                 }
@@ -504,7 +503,6 @@ extension ContainerAttachRoute {
                                     if done || error != 0 {
                                         state.finish {
                                             dispatchIO.close()
-                                            continuation.resume()
                                         }
                                     } else if !state.shouldStop() {
                                         DispatchQueue.global(qos: .userInteractive).async {


### PR DESCRIPTION
I ran into a crash when attaching to a container through the API:

```
Thread 3 crashed:

  0 0x000000018e7d8d2c _dispatch_source_merge_evt.cold.1 + 84 in libdispatch.dylib
  1 0x000000018e7b7e98 _dispatch_source_merge_evt + 176 in libdispatch.dylib
  2 0x000000018e7c3ad8 _dispatch_event_loop_merge + 148 in libdispatch.dylib
  3 0x000000018e7b3d4c _dispatch_workloop_worker_thread + 660 in libdispatch.dylib
  4 0x000000018e959e4c _pthread_wqthread + 292 in libsystem_pthread.dylib
```

I traced this to a race condition. The `withCheckedContinuation` block exits by calling both `dispatchIO.close()` and `continuation.resume()`. The code immediately after this block calls `try? stdoutHandle.close()` which seems to interfere with the Dispatch I/O internals.

I can reproduce this consistently with code I can't share. I tried unsuccessfully to find a minimal example that will reproduce this behavior.

~Anyway, the first commit, 2f4c20d7201b5376e71a1b280b7a583a4ab1fdc3, fixes this by closing the stream handle from inside the clean-up handler. Dispatch I/O will then always complete its work first.~

~The second commit, f83ccfb0d1742485db17304d4621dd45036c8167, moves the `dispatchIO.close()` outside the closure. It's then closed at the same level where it's initialized which also guarantees that all paths eventually leads to cleaning up properly.~

See [my later comment](https://github.com/socktainer/socktainer/pull/165#issuecomment-3674256068) for the revised approach.