### PR TITLE
Fix read behavior

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -414,13 +414,6 @@ extension ContainerAttachRoute {
                             let state = DockerConnectionState()
 
                             @Sendable func readNextChunk() {
-                                if state.shouldStop() {
-                                    state.finish {
-                                        dispatchIO.close()
-                                    }
-                                    return
-                                }
-
                                 dispatchIO.read(
                                     offset: off_t.max,
                                     length: 8192,
@@ -490,13 +483,6 @@ extension ContainerAttachRoute {
                             let state = DockerConnectionState()
 
                             @Sendable func readNextChunk() {
-                                if state.shouldStop() {
-                                    state.finish {
-                                        dispatchIO.close()
-                                    }
-                                    return
-                                }
-
                                 dispatchIO.read(
                                     offset: off_t.max,
                                     length: 8192,


### PR DESCRIPTION
This addresses an issue where [the Dispatch I/O `read` method](https://developer.apple.com/documentation/dispatch/dispatchio/read(offset:length:queue:iohandler:)) is being used incorrectly.

In the current implementation, each `done` callback causes the stream to be closed. Similarly, each successful non-empty callback causes a new read operation to be enqueued.

This is different from what the documentation says:

> **ioHandler**
> The closure to use to process the data read from the channel. This block may be queued multiple times to process a given data request. Each time the block is queued, the data parameter passed to the handler contains the most recently read chunk of data.

> This function reads the specified data and submits the handler block to queue to process the data. If the done parameter of the handler is set to false, it means that only part of the data was read. If the done parameter is [`true`](https://developer.apple.com/documentation/Swift/true), it means the read operation is complete and the handler will not be submitted again. If an unrecoverable error occurs on the channel’s file descriptor, the done parameter is set to true and an appropriate error value is reported in the handler’s error parameter.

As each partial read will enqueue a new read operation, we end up receiving many additional callbacks which is what necessitated this early return:

https://github.com/socktainer/socktainer/blob/9637f517b766ea56a577ee1ebbfa7b16ecf85274/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift#L416-L422

That is no longer necessary because now at most one read operation is executing at a time.

~Until #165 is merged, this pull request can more easily be reviewed by looking at https://github.com/tt/socktainer/compare/fix-crash-by-reordering-close-calls...fix-read-behavior.~