### PR TITLE
refactor(routes): Update Image Routes

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -8,10 +8,10 @@ import TerminalProgress
 protocol ClientImageProtocol: Sendable {
     func list() async throws -> [ClientImage]
     func delete(id: String) async throws
-    func pull(image: String, tag: String?, platform: Platform, registryAuth: AuthConfig?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> AsyncThrowingStream<
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     >
-    func push(reference: String, platform: Platform?, registryAuth: AuthConfig?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> AsyncThrowingStream<
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     >
     func prune(filters: [String: [String]], logger: Logger) async throws -> (deletedImages: [String], spaceReclaimed: Int64)
@@ -24,6 +24,41 @@ enum ClientImageError: Error {
 }
 
 struct ClientImageService: ClientImageProtocol {
+    // Workaround for narrowing an unspecified push from all platforms to a single platform available.
+    // This avoids container push failures caused by missing blobs for non local platforms.
+    private func resolvedPushPlatform(for image: ClientImage, requestedPlatform: Platform?, logger: Logger) async throws -> Platform? {
+        guard requestedPlatform == nil else {
+            return requestedPlatform
+        }
+
+        let manifests = try await image.index().manifests
+        var availablePlatforms: [Platform] = []
+
+        for descriptor in manifests {
+            if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
+                referenceType == "attestation-manifest"
+            {
+                continue
+            }
+
+            guard let platform = descriptor.platform else {
+                continue
+            }
+
+            do {
+                _ = try await image.manifest(for: platform)
+                availablePlatforms.append(platform)
+            } catch {
+                logger.debug("Skipping unavailable platform \(platform.description) for push of \(image.reference): \(error)")
+            }
+        }
+
+        if availablePlatforms.count == 1 {
+            return availablePlatforms[0]
+        }
+
+        return nil
+    }
 
     func list() async throws -> [ClientImage] {
         let allImages = try await ClientImage.list()
@@ -48,75 +83,61 @@ struct ClientImageService: ClientImageProtocol {
         try await ClientImage.delete(reference: id, garbageCollect: false)
     }
 
-    func pull(image: String, tag: String?, platform: Platform, registryAuth: AuthConfig?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> AsyncThrowingStream<
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let normalizedImage = ContainerImageUtility.normalizeImageReference(image)
-        let reference: String
-        if let tag = tag, !tag.isEmpty {
-            if tag.starts(with: "sha256:") {
-                reference = "\(normalizedImage)@\(tag)"
-            } else {
-                reference = "\(normalizedImage):\(tag)"
+        let reference = try {
+            guard let tag, !tag.isEmpty else {
+                return try ClientImage.normalizeReference(image)
             }
-        } else {
-            reference = normalizedImage
-        }
+
+            let parsedReference = try Reference.parse(image)
+            let updatedReference: Reference
+            if tag.starts(with: "sha256:") {
+                updatedReference = try parsedReference.withDigest(tag)
+            } else {
+                updatedReference = try parsedReference.withTag(tag)
+            }
+            return try ClientImage.normalizeReference(updatedReference.description)
+        }()
 
         logger.info("Pulling image reference: \(reference)")
-
-        // Create authentication from X-Registry-Auth header if provided
-        let authentication: Authentication? = {
-            guard let auth = registryAuth else {
-                logger.debug("No registry authentication provided")
-                return nil
-            }
-
-            guard let username = auth.username, let password = auth.password else {
-                logger.debug("Registry auth missing username or password")
-                return nil
-            }
-
-            logger.debug("Creating BasicAuthentication for user: \(username)")
-            return BasicAuthentication(username: username, password: password)
-        }()
 
         return AsyncThrowingStream { continuation in
             logger.info("Starting to pull image \(reference) for platform \(platform.description)")
             continuation.yield("Trying to pull \(reference)")
             Task {
                 do {
-                    let imageStore = try ImageStore(path: appleContainerAppSupportUrl)
-
-                    let image = try await imageStore.pull(
+                    let image = try await ClientImage.pull(
                         reference: reference,
                         platform: platform,
-                        insecure: false,  //Should be revisited later
-                        auth: authentication,
-                        progress: { progressEvents in
+                        progressUpdate: { progressEvents in
                             for event in progressEvents {
-                                switch event.event {
-                                case "add-total-size":
-                                    if let size = event.value as? UInt64 {
-                                        let humanReadableSize = ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
-                                        let message = "Downloaded \(humanReadableSize)"
-                                        continuation.yield(message)
-                                    } else if let size = event.value as? Int64 {
-                                        let humanReadableSize = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
-                                        let message = "Downloaded \(humanReadableSize)"
-                                        continuation.yield(message)
-                                    }
-                                case "add-total-items":
-                                    if let items = event.value as? Int {
-                                        let message = "Processing \(items) layer\(items == 1 ? "" : "s")"
-                                        continuation.yield(message)
-                                    }
+                                switch event {
+                                case .setDescription(let description),
+                                    .setSubDescription(let description),
+                                    .setItemsName(let description),
+                                    .custom(let description):
+                                    continuation.yield(description)
+                                case .addTotalSize(let size),
+                                    .setTotalSize(let size),
+                                    .addSize(let size),
+                                    .setSize(let size):
+                                    let humanReadableSize = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+                                    continuation.yield("Downloaded \(humanReadableSize)")
+                                case .addTotalItems(let items),
+                                    .setTotalItems(let items),
+                                    .addItems(let items),
+                                    .setItems(let items):
+                                    continuation.yield("Processing \(items) layer\(items == 1 ? "" : "s")")
                                 default:
-                                    logger.debug("Progress event: \(event.event) = \(event.value)")
+                                    break
                                 }
                             }
                         }
                     )
+                    continuation.yield("Unpacking image")
+                    try await image.unpack(platform: platform, progressUpdate: nil)
                     logger.info("Successfully pulled image \(reference) for platform \(platform.description)")
                     continuation.yield("Image digest: \(image.digest)")
                     continuation.finish()
@@ -129,10 +150,10 @@ struct ClientImageService: ClientImageProtocol {
         }
     }
 
-    func push(reference: String, platform: Platform?, registryAuth: AuthConfig?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> AsyncThrowingStream<
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let normalizedReference = ContainerImageUtility.normalizeImageReference(reference)
+        let normalizedReference = try ClientImage.normalizeReference(reference)
 
         logger.info("Pushing image reference: \(normalizedReference)")
 
@@ -146,58 +167,39 @@ struct ClientImageService: ClientImageProtocol {
 
         logger.debug("Image reference from ClientImage: \(image.reference)")
 
-        // WARN: Tagged images may fail to push if layers are not properly linked
-        //       in Apple's ImageStore. This is a limitation of the Containerization framework.
-
-        let authentication: Authentication? = {
-            guard let auth = registryAuth else {
-                logger.debug("No registry authentication provided")
-                return nil
-            }
-
-            guard let username = auth.username, let password = auth.password else {
-                logger.debug("Registry auth missing username or password")
-                return nil
-            }
-
-            logger.debug("Creating BasicAuthentication for user: \(username)")
-            return BasicAuthentication(username: username, password: password)
-        }()
+        let effectivePlatform = try await resolvedPushPlatform(for: image, requestedPlatform: platform, logger: logger)
 
         return AsyncThrowingStream { continuation in
-            let platformDesc = platform?.description ?? "default"
+            let platformDesc = effectivePlatform?.description ?? "default"
             logger.info("Starting to push image \(normalizedReference) for platform \(platformDesc)")
             logger.info("Retrieved image object with reference: \(image.reference)")
             continuation.yield("Trying to push \(normalizedReference)")
             Task {
                 do {
-                    let imageStore = try ImageStore(path: appleContainerAppSupportUrl)
-
-                    try await imageStore.push(
-                        reference: normalizedReference,
-                        platform: platform,
-                        insecure: false,  //Should be revisited later
-                        auth: authentication,
-                        progress: { progressEvents in
+                    try await image.push(
+                        platform: effectivePlatform,
+                        scheme: .auto,
+                        progressUpdate: { progressEvents in
                             for event in progressEvents {
-                                switch event.event {
-                                case "add-total-size":
-                                    if let size = event.value as? UInt64 {
-                                        let humanReadableSize = ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
-                                        let message = "Uploaded \(humanReadableSize)"
-                                        continuation.yield(message)
-                                    } else if let size = event.value as? Int64 {
-                                        let humanReadableSize = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
-                                        let message = "Uploaded \(humanReadableSize)"
-                                        continuation.yield(message)
-                                    }
-                                case "add-total-items":
-                                    if let items = event.value as? Int {
-                                        let message = "Pushing \(items) layer\(items == 1 ? "" : "s")"
-                                        continuation.yield(message)
-                                    }
+                                switch event {
+                                case .setDescription(let description),
+                                    .setSubDescription(let description),
+                                    .setItemsName(let description),
+                                    .custom(let description):
+                                    continuation.yield(description)
+                                case .addTotalSize(let size),
+                                    .setTotalSize(let size),
+                                    .addSize(let size),
+                                    .setSize(let size):
+                                    let humanReadableSize = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+                                    continuation.yield("Uploaded \(humanReadableSize)")
+                                case .addTotalItems(let items),
+                                    .setTotalItems(let items),
+                                    .addItems(let items),
+                                    .setItems(let items):
+                                    continuation.yield("Pushing \(items) layer\(items == 1 ? "" : "s")")
                                 default:
-                                    logger.debug("Progress event: \(event.event) = \(event.value)")
+                                    break
                                 }
                             }
                         }
@@ -446,40 +448,11 @@ struct ClientImageService: ClientImageProtocol {
         var resolvedRefs: [String] = []
 
         for reference in references {
-            let candidatesToTry: [String] = {
-                var candidates: [String] = []
-
-                candidates.append(reference)
-
-                if !reference.contains(":") && !reference.contains("@sha256:") {
-                    candidates.append("\(reference):latest")
-                }
-
-                let normalized = ContainerImageUtility.normalizeImageReference(reference)
-                if normalized != reference {
-                    candidates.append(normalized)
-                    if !normalized.contains(":") && !normalized.contains("@sha256:") {
-                        candidates.append("\(normalized):latest")
-                    }
-                }
-
-                return candidates
-            }()
-
-            var resolved = false
-            for candidate in candidatesToTry {
-                do {
-                    _ = try await ClientImage.get(reference: candidate)
-                    logger.debug("Image exists: \(candidate)")
-                    resolvedRefs.append(candidate)
-                    resolved = true
-                    break
-                } catch {
-                    continue
-                }
-            }
-
-            if !resolved {
+            do {
+                let image = try await ClientImage.get(reference: reference)
+                logger.debug("Image exists: \(image.reference)")
+                resolvedRefs.append(image.reference)
+            } catch {
                 logger.error("Image not found: \(reference)")
                 throw ClientImageError.notFound(id: reference)
             }

--- a/Sources/socktainer/Models/RESTImageHistory.swift
+++ b/Sources/socktainer/Models/RESTImageHistory.swift
@@ -1,0 +1,10 @@
+import Vapor
+
+struct RESTImageHistoryResponseItem: Content {
+    let Id: String
+    let Created: Int64
+    let CreatedBy: String
+    let Tags: [String]
+    let Size: Int64
+    let Comment: String
+}

--- a/Sources/socktainer/Models/RESTImageInspect.swift
+++ b/Sources/socktainer/Models/RESTImageInspect.swift
@@ -1,12 +1,24 @@
 import Vapor
 
+extension KeyedEncodingContainer {
+    fileprivate mutating func encodeNullable<T: Encodable>(_ value: T?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}
+
 struct OCIDescriptor: Content {
     let mediaType: String?
     let digest: String?
     let size: Int64?
     let urls: [String]?
     let annotations: [String: String]?
+    let data: String?
     let platform: OCIPlatform?
+    let artifactType: String?
 
     struct OCIPlatform: Content {
         let architecture: String?
@@ -14,18 +26,129 @@ struct OCIDescriptor: Content {
         let osVersion: String?
         let osFeatures: [String]?
         let variant: String?
+
+        enum CodingKeys: String, CodingKey {
+            case architecture
+            case os
+            case osVersion
+            case osFeatures
+            case variant
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeNullable(architecture, forKey: .architecture)
+            try container.encodeNullable(os, forKey: .os)
+            try container.encodeNullable(osVersion, forKey: .osVersion)
+            try container.encodeNullable(osFeatures, forKey: .osFeatures)
+            try container.encodeNullable(variant, forKey: .variant)
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mediaType
+        case digest
+        case size
+        case urls
+        case annotations
+        case data
+        case platform
+        case artifactType
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeNullable(mediaType, forKey: .mediaType)
+        try container.encodeNullable(digest, forKey: .digest)
+        try container.encodeNullable(size, forKey: .size)
+        try container.encodeNullable(urls, forKey: .urls)
+        try container.encodeNullable(annotations, forKey: .annotations)
+        try container.encodeNullable(data, forKey: .data)
+        try container.encodeNullable(platform, forKey: .platform)
+        try container.encodeNullable(artifactType, forKey: .artifactType)
     }
 }
 
 struct ImageManifestSummary: Content {
+    let ID: String?
     let Descriptor: OCIDescriptor?
     let Available: Bool?
     let Kind: String?
     let Size: ImageManifestSize?
+    let ImageData: ImageManifestData?
+    let AttestationData: AttestationManifestData?
 
     struct ImageManifestSize: Content {
         let Total: Int64?
         let Content: Int64?
+
+        enum CodingKeys: String, CodingKey {
+            case Total
+            case Content
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeNullable(Total, forKey: .Total)
+            try container.encodeNullable(Content, forKey: .Content)
+        }
+    }
+
+    struct ImageManifestData: Content {
+        let Platform: OCIDescriptor.OCIPlatform?
+        let Containers: [String]
+        let Size: ImageManifestImageSize
+
+        enum CodingKeys: String, CodingKey {
+            case Platform
+            case Containers
+            case Size
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeNullable(Platform, forKey: .Platform)
+            try container.encode(Containers, forKey: .Containers)
+            try container.encode(Size, forKey: .Size)
+        }
+
+        struct ImageManifestImageSize: Content {
+            let Unpacked: Int64?
+
+            enum CodingKeys: String, CodingKey {
+                case Unpacked
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeNullable(Unpacked, forKey: .Unpacked)
+            }
+        }
+    }
+
+    struct AttestationManifestData: Content {
+        let For: String
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ID
+        case Descriptor
+        case Available
+        case Kind
+        case Size
+        case ImageData
+        case AttestationData
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeNullable(ID, forKey: .ID)
+        try container.encodeNullable(Descriptor, forKey: .Descriptor)
+        try container.encodeNullable(Available, forKey: .Available)
+        try container.encodeNullable(Kind, forKey: .Kind)
+        try container.encodeNullable(Size, forKey: .Size)
+        try container.encodeNullable(ImageData, forKey: .ImageData)
+        try container.encodeNullable(AttestationData, forKey: .AttestationData)
     }
 }
 
@@ -43,6 +166,39 @@ struct ImageConfig: Content {
     let Labels: [String: String]?
     let StopSignal: String?
     let Shell: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case User
+        case ExposedPorts
+        case Env
+        case Cmd
+        case Healthcheck
+        case ArgsEscaped
+        case Volumes
+        case WorkingDir
+        case Entrypoint
+        case OnBuild
+        case Labels
+        case StopSignal
+        case Shell
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeNullable(User, forKey: .User)
+        try container.encodeNullable(ExposedPorts, forKey: .ExposedPorts)
+        try container.encodeNullable(Env, forKey: .Env)
+        try container.encodeNullable(Cmd, forKey: .Cmd)
+        try container.encodeNullable(Healthcheck, forKey: .Healthcheck)
+        try container.encodeNullable(ArgsEscaped, forKey: .ArgsEscaped)
+        try container.encodeNullable(Volumes, forKey: .Volumes)
+        try container.encodeNullable(WorkingDir, forKey: .WorkingDir)
+        try container.encodeNullable(Entrypoint, forKey: .Entrypoint)
+        try container.encodeNullable(OnBuild, forKey: .OnBuild)
+        try container.encodeNullable(Labels, forKey: .Labels)
+        try container.encodeNullable(StopSignal, forKey: .StopSignal)
+        try container.encodeNullable(Shell, forKey: .Shell)
+    }
 }
 
 struct HealthConfig: Content {
@@ -52,6 +208,25 @@ struct HealthConfig: Content {
     let Retries: Int?
     let StartPeriod: Int64?
     let StartInterval: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case Test
+        case Interval
+        case Timeout
+        case Retries
+        case StartPeriod
+        case StartInterval
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeNullable(Test, forKey: .Test)
+        try container.encodeNullable(Interval, forKey: .Interval)
+        try container.encodeNullable(Timeout, forKey: .Timeout)
+        try container.encodeNullable(Retries, forKey: .Retries)
+        try container.encodeNullable(StartPeriod, forKey: .StartPeriod)
+        try container.encodeNullable(StartInterval, forKey: .StartInterval)
+    }
 }
 
 struct DriverData: Content {
@@ -68,10 +243,25 @@ struct RootFS: Content {
 
     let rootfsType: String
     let Layers: [String]?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(rootfsType, forKey: .rootfsType)
+        try container.encodeNullable(Layers, forKey: .Layers)
+    }
 }
 
 struct ImageMetadata: Content {
     let LastTagTime: String?
+
+    enum CodingKeys: String, CodingKey {
+        case LastTagTime
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeNullable(LastTagTime, forKey: .LastTagTime)
+    }
 }
 
 struct RESTImageInspect: Content {
@@ -80,19 +270,63 @@ struct RESTImageInspect: Content {
     let Manifests: [ImageManifestSummary]?
     let RepoTags: [String]
     let RepoDigests: [String]
-    let Parent: String?
-    let Comment: String?
+    let Parent: String
+    let Comment: String
     let Created: String?
-    let DockerVersion: String?
-    let Author: String?
+    let DockerVersion: String
+    let Author: String
     let Config: ImageConfig?
-    let Architecture: String?
+    let Architecture: String
     let Variant: String?
-    let Os: String?
+    let Os: String
     let OsVersion: String?
     let Size: Int64
-    let VirtualSize: Int64?
     let GraphDriver: DriverData?
     let RootFS: RootFS?
     let Metadata: ImageMetadata?
+
+    enum CodingKeys: String, CodingKey {
+        case Id
+        case Descriptor
+        case Manifests
+        case RepoTags
+        case RepoDigests
+        case Parent
+        case Comment
+        case Created
+        case DockerVersion
+        case Author
+        case Config
+        case Architecture
+        case Variant
+        case Os
+        case OsVersion
+        case Size
+        case GraphDriver
+        case RootFS
+        case Metadata
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Id, forKey: .Id)
+        try container.encodeNullable(Descriptor, forKey: .Descriptor)
+        try container.encodeNullable(Manifests, forKey: .Manifests)
+        try container.encode(RepoTags, forKey: .RepoTags)
+        try container.encode(RepoDigests, forKey: .RepoDigests)
+        try container.encode(Parent, forKey: .Parent)
+        try container.encode(Comment, forKey: .Comment)
+        try container.encodeNullable(Created, forKey: .Created)
+        try container.encode(DockerVersion, forKey: .DockerVersion)
+        try container.encode(Author, forKey: .Author)
+        try container.encodeNullable(Config, forKey: .Config)
+        try container.encode(Architecture, forKey: .Architecture)
+        try container.encodeNullable(Variant, forKey: .Variant)
+        try container.encode(Os, forKey: .Os)
+        try container.encodeNullable(OsVersion, forKey: .OsVersion)
+        try container.encode(Size, forKey: .Size)
+        try container.encodeNullable(GraphDriver, forKey: .GraphDriver)
+        try container.encodeNullable(RootFS, forKey: .RootFS)
+        try container.encodeNullable(Metadata, forKey: .Metadata)
+    }
 }

--- a/Sources/socktainer/Models/RESTImageSummary.swift
+++ b/Sources/socktainer/Models/RESTImageSummary.swift
@@ -2,9 +2,51 @@ import Vapor
 
 struct RESTImageSummary: Content {
     let Id: String
+    let ParentId: String
     let RepoTags: [String]
     let RepoDigests: [String]
     let Created: Int
     let Size: Int64
+    let SharedSize: Int64
     let Labels: [String: String]
+    let Containers: Int
+    let Manifests: [ImageManifestSummary]?
+    let Descriptor: OCIDescriptor?
+
+    enum CodingKeys: String, CodingKey {
+        case Id
+        case ParentId
+        case RepoTags
+        case RepoDigests
+        case Created
+        case Size
+        case SharedSize
+        case Labels
+        case Containers
+        case Manifests
+        case Descriptor
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Id, forKey: .Id)
+        try container.encode(ParentId, forKey: .ParentId)
+        try container.encode(RepoTags, forKey: .RepoTags)
+        try container.encode(RepoDigests, forKey: .RepoDigests)
+        try container.encode(Created, forKey: .Created)
+        try container.encode(Size, forKey: .Size)
+        try container.encode(SharedSize, forKey: .SharedSize)
+        try container.encode(Labels, forKey: .Labels)
+        try container.encode(Containers, forKey: .Containers)
+        if let Manifests {
+            try container.encode(Manifests, forKey: .Manifests)
+        } else {
+            try container.encodeNil(forKey: .Manifests)
+        }
+        if let Descriptor {
+            try container.encode(Descriptor, forKey: .Descriptor)
+        } else {
+            try container.encodeNil(forKey: .Descriptor)
+        }
+    }
 }

--- a/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
@@ -25,7 +25,7 @@ extension ImageCreateRoute {
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             let query = try req.query.decode(RESTImageCreateQuery.self)
-            let image = ContainerImageUtility.normalizeImageReference(query.fromImage ?? "")
+            let image = query.fromImage ?? ""
             let tag = query.tag ?? ""
             let decodedTag = tag.removingPercentEncoding ?? tag
             let platformString = query.platform
@@ -43,24 +43,10 @@ extension ImageCreateRoute {
                 platform = currentPlatform()
             }
 
-            // Extract and decode X-Registry-Auth header
-            var registryAuth: AuthConfig?
-            if let xAuthConfigHeader = req.headers.first(name: "X-Registry-Auth") {
-                if let decodedData = Data(base64Encoded: xAuthConfigHeader),
-                    let auth = try? JSONDecoder().decode(AuthConfig.self, from: decodedData)
-                {
-                    registryAuth = auth
-                }
-            }
-
-            guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
-                throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
-            }
-
             let response = Response()
             response.headers.add(name: .contentType, value: "application/json")
             let progressStream = try await client.pull(
-                image: image, tag: decodedTag, platform: platform, registryAuth: registryAuth, appleContainerAppSupportUrl: appleContainerAppSupportUrl, logger: req.logger)
+                image: image, tag: decodedTag, platform: platform, logger: req.logger)
 
             response.body = .init(stream: { writer in
                 Task {

--- a/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
@@ -1,14 +1,154 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
 import Vapor
 
-struct ImageHistoryRoute: RouteCollection {
-    func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/history", use: ImageHistoryRoute.handler)
-    }
+struct RESTImageHistoryQuery: Vapor.Content {
+    let platform: String?
+}
 
+struct ImageHistoryRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/history", use: ImageHistoryRoute.handler(client: client))
+    }
 }
 
 extension ImageHistoryRoute {
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/images/{name}/history", req.method.rawValue)
+    private static func prioritizedManifests(_ manifests: [Descriptor], preferredPlatform: Platform?) -> [Descriptor] {
+        let primaryPlatform = requestedOrDefaultPlatform(preferredPlatform)
+
+        return manifests.enumerated().sorted { leftManifest, rightManifest in
+            let leftPlatform = leftManifest.element.platform
+            let rightPlatform = rightManifest.element.platform
+
+            if preferredPlatformMatches(
+                leftPlatform,
+                over: rightPlatform,
+                preferredPlatform: primaryPlatform
+            ) {
+                return true
+            }
+
+            return leftManifest.offset < rightManifest.offset
+        }.map(\.element)
+    }
+
+    private static func historyResponseItems(
+        for image: ClientImage,
+        requestedName: String,
+        details: ImageDetail,
+        preferredPlatform: Platform?
+    ) async throws -> [RESTImageHistoryResponseItem] {
+        let imageIndex = try await image.index()
+        let manifests = prioritizedManifests(imageIndex.manifests, preferredPlatform: preferredPlatform)
+
+        for descriptor in manifests {
+            if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
+                referenceType == "attestation-manifest"
+            {
+                continue
+            }
+
+            guard let platform = descriptor.platform else {
+                continue
+            }
+
+            let config: ContainerizationOCI.Image
+            let manifest: ContainerizationOCI.Manifest
+            do {
+                config = try await image.config(for: platform)
+                manifest = try await image.manifest(for: platform)
+            } catch {
+                continue
+            }
+
+            let history = config.history ?? []
+            var layerIndex = 0
+            var items: [RESTImageHistoryResponseItem] = []
+
+            for (index, entry) in history.enumerated() {
+                let isEmptyLayer = entry.emptyLayer ?? false
+                let itemId: String
+                let itemSize: Int64
+
+                if isEmptyLayer {
+                    itemId = "<missing>"
+                    itemSize = 0
+                } else if layerIndex < manifest.layers.count {
+                    let layer = manifest.layers[layerIndex]
+                    itemId = layer.digest
+                    itemSize = layer.size
+                    layerIndex += 1
+                } else {
+                    itemId = "<missing>"
+                    itemSize = 0
+                }
+
+                let tags = index == history.index(before: history.endIndex) ? [details.name] : []
+
+                items.append(
+                    RESTImageHistoryResponseItem(
+                        Id: itemId,
+                        Created: AppleContainerTimestampResolver.unixTimestampSeconds(entry.created ?? config.created),
+                        CreatedBy: entry.createdBy ?? "",
+                        Tags: tags,
+                        Size: itemSize,
+                        Comment: entry.comment ?? ""
+                    )
+                )
+            }
+
+            if !items.isEmpty {
+                return items.reversed()
+            }
+
+            return [
+                RESTImageHistoryResponseItem(
+                    Id: image.digest,
+                    Created: AppleContainerTimestampResolver.unixTimestampSeconds(config.created),
+                    CreatedBy: "",
+                    Tags: [details.name],
+                    Size: manifest.layers.reduce(0) { $0 + $1.size },
+                    Comment: ""
+                )
+            ]
+        }
+
+        throw Abort(.notFound, reason: "Image '\(requestedName)' not found")
+    }
+
+    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> [RESTImageHistoryResponseItem] {
+        { req in
+            guard let refOrId = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing image name parameter")
+            }
+
+            let query = try req.query.decode(RESTImageHistoryQuery.self)
+            let preferredPlatform: Platform?
+            if let platformString = query.platform, !platformString.isEmpty {
+                preferredPlatform = try platformOrThrow(platformString)
+            } else {
+                preferredPlatform = nil
+            }
+
+            _ = client
+
+            let image: ClientImage
+            do {
+                image = try await ClientImage.get(reference: refOrId)
+            } catch {
+                throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
+            }
+
+            let details = try await image.details()
+            return try await historyResponseItems(
+                for: image,
+                requestedName: refOrId,
+                details: details,
+                preferredPlatform: preferredPlatform
+            )
+        }
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
@@ -3,6 +3,11 @@ import ContainerResource
 import ContainerizationOCI
 import Vapor
 
+struct RESTImageInspectQuery: Vapor.Content {
+    let manifests: Bool?
+    let platform: String?
+}
+
 struct ImageInspectRoute: RouteCollection {
     let client: ClientImageProtocol
 
@@ -12,43 +17,104 @@ struct ImageInspectRoute: RouteCollection {
 }
 
 extension ImageInspectRoute {
-    /// Checks if an image name matches the requested name, considering Docker Hub prefixes and digest hashes
-    private static func imageMatches(imageName: String, imageDigest: String, refOrId: String) -> Bool {
-        // Check if refOrId is a digest hash (sha256:, sha512:, etc.)
-        if refOrId.contains(":") && refOrId.split(separator: ":").count == 2 {
-            let parts = refOrId.split(separator: ":")
-            let algorithm = String(parts[0])
-            let hash = String(parts[1])
+    private static func makeOCIDescriptor(
+        from descriptor: Descriptor,
+        appSupportURL: URL? = nil,
+        parentDigest: String? = nil
+    ) -> OCIDescriptor {
+        let platform = descriptor.platform.map {
+            OCIDescriptor.OCIPlatform(
+                architecture: $0.architecture,
+                os: $0.os,
+                osVersion: $0.osVersion,
+                osFeatures: $0.osFeatures,
+                variant: $0.variant
+            )
+        }
 
-            // Check if it looks like a hash algorithm (common ones: sha256, sha512, sha1, md5, etc.)
-            if algorithm.lowercased().matches(of: /^(sha|md)\d*$/).count > 0 && hash.allSatisfy({ $0.isHexDigit }) {
-                return imageDigest == refOrId
+        let extras: AppleContainerImageStoreResolver.DescriptorExtras? =
+            if let appSupportURL, let parentDigest {
+                AppleContainerImageStoreResolver.descriptorExtras(
+                    appSupportURL: appSupportURL,
+                    parentDigest: parentDigest,
+                    childDigest: descriptor.digest
+                )
+            } else {
+                nil
             }
-        }
 
-        // Exact match
-        if imageName == refOrId {
-            return true
-        }
+        return OCIDescriptor(
+            mediaType: descriptor.mediaType,
+            digest: descriptor.digest,
+            size: descriptor.size,
+            urls: descriptor.urls,
+            annotations: descriptor.annotations,
+            data: extras?.data,
+            platform: platform,
+            artifactType: extras?.artifactType
+        )
+    }
 
-        // Extract the base name without tag from both names
-        let imageBaseName = imageName.components(separatedBy: ":").first ?? imageName
-        let requestedBaseName = refOrId.components(separatedBy: ":").first ?? refOrId
+    private static func prioritizedManifests(_ manifests: [Descriptor]) -> [Descriptor] {
+        let primaryPlatform = requestedOrDefaultPlatform(nil)
 
-        // If requested name contains no registry/namespace, check if image has docker.io/library prefix
-        if !requestedBaseName.contains("/") {
-            // Check if image has docker.io/library/ prefix
-            if imageBaseName == "docker.io/library/\(requestedBaseName)" || imageBaseName == "docker.io/\(requestedBaseName)" {
+        return manifests.enumerated().sorted { leftManifest, rightManifest in
+            let leftPlatform = leftManifest.element.platform
+            let rightPlatform = rightManifest.element.platform
+
+            if preferredPlatformMatches(
+                leftPlatform,
+                over: rightPlatform,
+                preferredPlatform: primaryPlatform
+            ) {
                 return true
             }
+
+            return leftManifest.offset < rightManifest.offset
+        }.map(\.element)
+    }
+
+    private static func repoDigestReference(name: String, digest: String?) -> String? {
+        guard let digest, !digest.isEmpty, !name.isEmpty else {
+            return nil
         }
 
-        // Check if image base name ends with the requested name (for partial matches)
-        if imageBaseName.hasSuffix("/\(requestedBaseName)") {
-            return true
+        if let reference = try? Reference.parse(name) {
+            return "\(reference.name)@\(digest)"
         }
 
-        return false
+        if let atIndex = name.firstIndex(of: "@") {
+            return "\(name[..<atIndex])@\(digest)"
+        }
+
+        return "\(name)@\(digest)"
+    }
+
+    private static func prioritizeVariants(_ variants: [ImageDetail.Variants]) -> [ImageDetail.Variants] {
+        let hostPlatform = requestedOrDefaultPlatform(nil)
+
+        return variants.enumerated().sorted { leftVariant, rightVariant in
+            let leftPlatform = leftVariant.element.platform
+            let rightPlatform = rightVariant.element.platform
+
+            if preferredPlatformMatches(
+                leftPlatform,
+                over: rightPlatform,
+                preferredPlatform: hostPlatform
+            ) {
+                return true
+            }
+
+            return leftVariant.offset < rightVariant.offset
+        }.map(\.element)
+    }
+
+    private static func inspectPlatformOrThrow(_ platformString: String?) throws -> Platform? {
+        guard let platformString, !platformString.isEmpty else {
+            return nil
+        }
+
+        return try platformOrThrow(platformString)
     }
 
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> RESTImageInspect {
@@ -56,114 +122,184 @@ extension ImageInspectRoute {
             guard let refOrId = req.parameters.get("name") else {
                 throw Abort(.badRequest, reason: "Missing image name parameter")
             }
+            let query = try req.query.decode(RESTImageInspectQuery.self)
+            let requestedPlatform = try inspectPlatformOrThrow(query.platform)
+            let includeManifests = (query.manifests ?? false) && requestedPlatform == nil
+            guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
+                throw Abort(.internalServerError, reason: "Apple Container application support URL is not configured")
+            }
 
-            let images = try await client.list()
+            _ = client
 
-            // Find the specific image by name
-            for image in images {
-                let details: ImageDetail = try await image.details()
+            let image: ClientImage
+            do {
+                image = try await ClientImage.get(reference: refOrId)
+            } catch {
+                throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
+            }
 
-                // Check if this is the image we're looking for using improved matching
-                if imageMatches(imageName: details.name, imageDigest: image.digest, refOrId: refOrId) {
-                    let manifests = try await image.index().manifests
+            let containers = includeManifests ? try await ContainerClient().list() : []
+            let details: ImageDetail = try await image.details()
+            let imageIndex = try await image.index()
+            let manifests = imageIndex.manifests
+            let availablePlatforms = Set(details.variants.map(\.platform))
+            var manifestSummaries: [ImageManifestSummary] = []
+            let containerIDs =
+                containers
+                .filter { $0.configuration.image.reference == image.reference || $0.configuration.image.reference == details.name }
+                .map(\.id)
 
-                    for descriptor in manifests {
-                        // skip these manifests
-                        if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
-                            referenceType == "attestation-manifest"
-                        {
-                            continue
-                        }
+            for descriptor in manifests {
+                let kind: String
+                if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
+                    referenceType == "attestation-manifest"
+                {
+                    kind = "attestation"
+                } else {
+                    kind = "image"
+                }
 
-                        guard let platform = descriptor.platform else {
-                            continue
-                        }
+                let platform = descriptor.platform
+                let manifest: ContainerizationOCI.Manifest?
+                let available: Bool
 
-                        var config: ContainerizationOCI.Image
-                        var manifest: ContainerizationOCI.Manifest
-
-                        // try to get the config and manifest for the platform
-                        do {
-                            config = try await image.config(for: platform)
-                            manifest = try await image.manifest(for: platform)
-                        } catch {
-                            // ignore failure
-                            continue
-                        }
-
-                        // created is a String value like Optional("2025-05-14T11:03:12.497281595Z"
-                        // need to convert it to a Unix timestamp (number of seconds since EPOCH).
-                        let createdIso8601 = config.created ?? "1970-01-01T00:00:00Z"  // Default to epoch if not available
-
-                        let iso8601Formatter = ISO8601DateFormatter()
-                        iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                        var formattedDate = iso8601Formatter.date(from: createdIso8601)
-
-                        if formattedDate == nil {
-                            // Try without fractional seconds
-                            iso8601Formatter.formatOptions = [.withInternetDateTime]
-                            formattedDate = iso8601Formatter.date(from: createdIso8601)
-                        }
-
-                        // Use guard to ensure we now have a valid date
-                        guard formattedDate != nil else {
-                            continue  // or return, depending on context
-                        }
-                        let size = descriptor.size + manifest.config.size + manifest.layers.reduce(0, { (l, r) in l + r.size })
-
-                        let imageConfig: ImageConfig? = config.config.map { ociConfig in
-                            ImageConfig(
-                                User: ociConfig.user,
-                                ExposedPorts: nil,  // Not available in OCI config
-                                Env: ociConfig.env,
-                                Cmd: ociConfig.cmd,
-                                Healthcheck: nil,  // Not available in OCI config
-                                ArgsEscaped: nil,
-                                Volumes: nil,  // Not available in OCI config
-                                WorkingDir: ociConfig.workingDir,
-                                Entrypoint: ociConfig.entrypoint,
-                                OnBuild: nil,  // Not available in OCI config
-                                Labels: ociConfig.labels,
-                                StopSignal: ociConfig.stopSignal,
-                                Shell: nil  // Not available in OCI config
-                            )
-                        }
-
-                        // Build RootFS from manifest layers
-                        let rootFS = RootFS(
-                            rootfsType: config.rootfs.type,
-                            Layers: config.rootfs.diffIDs
-                        )
-
-                        let summary = RESTImageInspect(
-                            Id: image.digest,
-                            Descriptor: nil,  // Not readily available
-                            Manifests: nil,  // Not readily available
-                            RepoTags: [details.name],
-                            RepoDigests: [],  // Would need registry information
-                            Parent: nil,  // Not available from OCI format
-                            Comment: nil,  // Not available from OCI format
-                            Created: config.created,
-                            DockerVersion: nil,  // Not available from OCI format
-                            Author: config.author,
-                            Config: imageConfig,
-                            Architecture: config.architecture,
-                            Variant: config.variant,
-                            Os: config.os,
-                            OsVersion: config.osVersion,
-                            Size: size,
-                            VirtualSize: size,  // Same as Size for compatibility
-                            GraphDriver: nil,  // Storage driver info not available
-                            RootFS: rootFS,
-                            Metadata: nil  // Local metadata not available
-                        )
-
-                        return summary
+                if let platform {
+                    do {
+                        manifest = try await image.manifest(for: platform)
+                        available = availablePlatforms.contains(platform)
+                    } catch {
+                        manifest = nil
+                        available = false
                     }
+                } else {
+                    manifest = nil
+                    available = false
+                }
+
+                let contentSize = (manifest?.config.size ?? 0) + (manifest?.layers.reduce(0) { $0 + $1.size } ?? 0)
+                let totalSize = descriptor.size + contentSize
+
+                if includeManifests {
+                    let unpackedSize =
+                        kind == "image"
+                        ? AppleContainerSnapshotResolver.unpackedSize(
+                            appSupportURL: appleContainerAppSupportUrl,
+                            descriptor: descriptor
+                        ) : 0
+                    let platformSummary = platform.map {
+                        OCIDescriptor.OCIPlatform(
+                            architecture: $0.architecture,
+                            os: $0.os,
+                            osVersion: $0.osVersion,
+                            osFeatures: $0.osFeatures,
+                            variant: $0.variant
+                        )
+                    }
+
+                    manifestSummaries.append(
+                        ImageManifestSummary(
+                            ID: descriptor.digest,
+                            Descriptor: makeOCIDescriptor(
+                                from: descriptor,
+                                appSupportURL: appleContainerAppSupportUrl,
+                                parentDigest: details.index.digest
+                            ),
+                            Available: available,
+                            Kind: kind,
+                            Size: .init(Total: totalSize + unpackedSize, Content: contentSize),
+                            ImageData: kind == "image"
+                                ? .init(
+                                    Platform: platformSummary,
+                                    Containers: containerIDs,
+                                    Size: .init(Unpacked: unpackedSize)
+                                ) : nil,
+                            AttestationData: kind == "attestation"
+                                ? .init(
+                                    For: descriptor.annotations?["vnd.docker.reference.digest"] ?? ""
+                                ) : nil
+                        )
+                    )
                 }
             }
 
-            // If we get here, the image was not found
+            let selectedVariant =
+                if let requestedPlatform {
+                    details.variants.first(where: { $0.platform == requestedPlatform })
+                } else {
+                    prioritizeVariants(details.variants).first
+                }
+
+            if let selectedVariant {
+                let selectedManifest = try? await image.manifest(for: selectedVariant.platform)
+                let imageConfig: ImageConfig? = selectedVariant.config.config.map { ociConfig in
+                    ImageConfig(
+                        User: ociConfig.user,
+                        ExposedPorts: nil,
+                        Env: ociConfig.env,
+                        Cmd: ociConfig.cmd,
+                        Healthcheck: nil,
+                        ArgsEscaped: nil,
+                        Volumes: nil,
+                        WorkingDir: ociConfig.workingDir,
+                        Entrypoint: ociConfig.entrypoint,
+                        OnBuild: nil,
+                        Labels: ociConfig.labels,
+                        StopSignal: ociConfig.stopSignal,
+                        Shell: nil
+                    )
+                }
+
+                let selectedDescriptor = manifests.first { descriptor in
+                    descriptor.platform == selectedVariant.platform
+                        && descriptor.annotations?["vnd.docker.reference.type"] != "attestation-manifest"
+                }
+
+                let rootFS = RootFS(
+                    rootfsType: selectedVariant.config.rootfs.type,
+                    Layers: selectedVariant.config.rootfs.diffIDs
+                )
+
+                let summary = RESTImageInspect(
+                    Id: selectedManifest?.config.digest ?? image.digest,
+                    Descriptor: makeOCIDescriptor(
+                        from: details.index,
+                        appSupportURL: appleContainerAppSupportUrl
+                    ),
+                    Manifests: includeManifests ? manifestSummaries : nil,
+                    RepoTags: [details.name],
+                    RepoDigests: repoDigestReference(name: details.name, digest: selectedDescriptor?.digest).map { [$0] } ?? [],
+                    Parent: "",
+                    Comment: selectedVariant.config.history?.last?.comment ?? "",
+                    Created: selectedVariant.config.created,
+                    DockerVersion: "",
+                    Author: selectedVariant.config.author ?? "",
+                    Config: imageConfig,
+                    Architecture: selectedVariant.config.architecture,
+                    Variant: selectedVariant.config.variant,
+                    Os: selectedVariant.config.os,
+                    OsVersion: selectedVariant.config.osVersion,
+                    Size: selectedVariant.size,
+                    GraphDriver: selectedDescriptor.map {
+                        AppleContainerImageStoreResolver.graphDriver(
+                            appSupportURL: appleContainerAppSupportUrl,
+                            descriptor: $0
+                        )
+                    } ?? nil,
+                    RootFS: rootFS,
+                    // Docker's schema allows Metadata.LastTagTime, but Apple's image
+                    // reference store only persists `reference -> descriptor` in state.json.
+                    // There is no authoritative per-tag timestamp to surface here, so
+                    // we emit `Metadata.LastTagTime` as null instead of inventing a value.
+                    Metadata: .init(LastTagTime: nil)
+                )
+
+                return summary
+            }
+
+            if let requestedPlatform {
+                throw Abort(.notFound, reason: "Image '\(refOrId)' does not provide platform '\(requestedPlatform.description)'")
+            }
+
             throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
         }
     }

--- a/Sources/socktainer/Routes/Images/ImageListRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageListRoute.swift
@@ -3,6 +3,11 @@ import ContainerResource
 import ContainerizationOCI
 import Vapor
 
+struct RESTImageListQuery: Vapor.Content {
+    let manifests: Bool?
+    let digests: Bool?
+}
+
 struct ImageListRoute: RouteCollection {
     let client: ClientImageProtocol
 
@@ -16,23 +21,67 @@ struct CustomImageDetail: Decodable {
 }
 
 extension ImageListRoute {
+    private static func makeOCIDescriptor(
+        from descriptor: Descriptor,
+        appSupportURL: URL? = nil,
+        parentDigest: String? = nil
+    ) -> OCIDescriptor {
+        let platform = descriptor.platform.map {
+            OCIDescriptor.OCIPlatform(
+                architecture: $0.architecture,
+                os: $0.os,
+                osVersion: $0.osVersion,
+                osFeatures: $0.osFeatures,
+                variant: $0.variant
+            )
+        }
+
+        let extras: AppleContainerImageStoreResolver.DescriptorExtras? =
+            if let appSupportURL, let parentDigest {
+                AppleContainerImageStoreResolver.descriptorExtras(
+                    appSupportURL: appSupportURL,
+                    parentDigest: parentDigest,
+                    childDigest: descriptor.digest
+                )
+            } else {
+                nil
+            }
+
+        return OCIDescriptor(
+            mediaType: descriptor.mediaType,
+            digest: descriptor.digest,
+            size: descriptor.size,
+            urls: descriptor.urls,
+            annotations: descriptor.annotations,
+            data: extras?.data,
+            platform: platform,
+            artifactType: extras?.artifactType
+        )
+    }
+
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> [RESTImageSummary] {
         { req in
-
+            let query = try req.query.decode(RESTImageListQuery.self)
+            guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
+                throw Abort(.internalServerError, reason: "Apple Container application support URL is not configured")
+            }
             let images = try await client.list()
-
+            let containers = try await ContainerClient().list()
+            let includeManifests = query.manifests ?? false
+            let includeDigests = query.digests ?? false
             var imagesSummaries: [RESTImageSummary] = []
 
-            // for each images, grab the details and print
             for image in images {
                 let details: ImageDetail = try await image.details()
-
-                //
-                let manifests = try await image.index().manifests
+                let imageIndex = try await image.index()
+                let manifests = imageIndex.manifests
+                var manifestSummaries: [ImageManifestSummary] = []
+                var created = 0
+                var size: Int64 = 0
+                var labels: [String: String] = [:]
+                var foundUsableManifest = false
 
                 for descriptor in manifests {
-
-                    // skip these manifests
                     if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
                         referenceType == "attestation-manifest"
                     {
@@ -43,59 +92,89 @@ extension ImageListRoute {
                         continue
                     }
 
-                    var config: ContainerizationOCI.Image
-                    var manifest: ContainerizationOCI.Manifest
-
-                    // try to get the config and manifest for the platform
+                    let available: Bool
+                    let manifest: ContainerizationOCI.Manifest?
+                    let config: ContainerizationOCI.Image?
                     do {
-
-                        config = try await image.config(for: platform)
-                        manifest = try await image.manifest(for: platform)
-
+                        let resolvedConfig = try await image.config(for: platform)
+                        let resolvedManifest = try await image.manifest(for: platform)
+                        config = resolvedConfig
+                        manifest = resolvedManifest
+                        available = true
                     } catch {
-                        // ignore failure
-                        continue
+                        config = nil
+                        manifest = nil
+                        available = false
                     }
 
-                    // created is a String value like Optional("2025-05-14T11:03:12.497281595Z"
-                    // need to convert it to a Unix timestamp (number of seconds since EPOCH).
-                    let createdIso8601 = config.created ?? "1970-01-01T00:00:00Z"  // Default to epoch if not available
+                    let contentSize = (manifest?.config.size ?? 0) + (manifest?.layers.reduce(0) { $0 + $1.size } ?? 0)
+                    let totalSize = descriptor.size + contentSize
 
-                    let iso8601Formatter = ISO8601DateFormatter()
-                    iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                    var formattedDate = iso8601Formatter.date(from: createdIso8601)
+                    if includeManifests {
+                        let unpackedSize = AppleContainerSnapshotResolver.unpackedSize(
+                            appSupportURL: appleContainerAppSupportUrl,
+                            descriptor: descriptor
+                        )
+                        let platformSummary = descriptor.platform.map {
+                            OCIDescriptor.OCIPlatform(
+                                architecture: $0.architecture,
+                                os: $0.os,
+                                osVersion: $0.osVersion,
+                                osFeatures: $0.osFeatures,
+                                variant: $0.variant
+                            )
+                        }
 
-                    if formattedDate == nil {
-                        // Try without fractional seconds
-                        iso8601Formatter.formatOptions = [.withInternetDateTime]
-                        formattedDate = iso8601Formatter.date(from: createdIso8601)
+                        manifestSummaries.append(
+                            ImageManifestSummary(
+                                ID: descriptor.digest,
+                                Descriptor: makeOCIDescriptor(
+                                    from: descriptor,
+                                    appSupportURL: appleContainerAppSupportUrl,
+                                    parentDigest: details.index.digest
+                                ),
+                                Available: available,
+                                Kind: "image",
+                                Size: .init(Total: totalSize + unpackedSize, Content: contentSize),
+                                ImageData: .init(
+                                    Platform: platformSummary,
+                                    Containers: [],
+                                    Size: .init(Unpacked: unpackedSize)
+                                ),
+                                AttestationData: nil
+                            )
+                        )
                     }
 
-                    // Use guard to ensure we now have a valid date
-                    guard let date = formattedDate else {
-                        continue  // or return, depending on context
+                    if !foundUsableManifest, let config, available {
+                        created = Int(AppleContainerTimestampResolver.unixTimestampSeconds(config.created))
+                        size = totalSize
+                        labels = config.config?.labels ?? [:]
+                        foundUsableManifest = true
                     }
-                    let unixTimestamp = date.timeIntervalSince1970
-                    let created = Int(unixTimestamp)
-                    let size = descriptor.size + manifest.config.size + manifest.layers.reduce(0, { (l, r) in l + r.size })
-
-                    let name = details.name
-
-                    let repoTags = name.isEmpty ? [] : [name]
-                    let repoDigests = image.reference.contains("@sha256:") ? [image.reference] : []
-                    let summary = RESTImageSummary(
-                        Id: image.digest,
-                        RepoTags: repoTags,
-                        RepoDigests: repoDigests,
-                        Created: created,
-                        Size: size,
-                        Labels: [:],
-                    )
-
-                    imagesSummaries.append(summary)
-
                 }
 
+                let repoTags = details.name.isEmpty ? [] : [details.name]
+                let repoDigests = includeDigests && image.reference.contains("@sha256:") ? [image.reference] : []
+                let containersUsingImage = containers.filter { $0.configuration.image.reference == image.reference || $0.configuration.image.reference == details.name }
+                let summary = RESTImageSummary(
+                    Id: image.digest,
+                    ParentId: "",
+                    RepoTags: repoTags,
+                    RepoDigests: repoDigests,
+                    Created: created,
+                    Size: size,
+                    SharedSize: -1,
+                    Labels: labels,
+                    Containers: containersUsingImage.count,
+                    Manifests: includeManifests ? manifestSummaries : nil,
+                    Descriptor: makeOCIDescriptor(
+                        from: details.index,
+                        appSupportURL: appleContainerAppSupportUrl
+                    )
+                )
+
+                imagesSummaries.append(summary)
             }
 
             return imagesSummaries

--- a/Sources/socktainer/Routes/Images/ImagePushRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagePushRoute.swift
@@ -18,6 +18,18 @@ struct RESTImagePushQuery: Vapor.Content {
 }
 
 extension ImagePushRoute {
+    private static func resolvedReference(imageName: String, tag: String?) throws -> String {
+        guard let tag, !tag.isEmpty else {
+            return imageName
+        }
+
+        let parsedReference = try Reference.parse(imageName)
+        if tag.starts(with: "sha256:") {
+            return try parsedReference.withDigest(tag).description
+        }
+        return try parsedReference.withTag(tag).description
+    }
+
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             guard let imageName = req.parameters.get("name") else {
@@ -26,24 +38,7 @@ extension ImagePushRoute {
 
             let query = try req.query.decode(RESTImagePushQuery.self)
 
-            // Extract and decode X-Registry-Auth header
-            var registryAuth: AuthConfig?
-            if let xAuthConfigHeader = req.headers.first(name: "X-Registry-Auth") {
-                if let decodedData = Data(base64Encoded: xAuthConfigHeader),
-                    let auth = try? JSONDecoder().decode(AuthConfig.self, from: decodedData)
-                {
-                    registryAuth = auth
-                }
-            }
-
-            // Build the full reference (name:tag)
-            let reference: String
-            if let tag = query.tag, !tag.isEmpty {
-                reference = "\(imageName):\(tag)"
-            } else {
-                // If no tag is provided, push all tags (use the name as-is)
-                reference = imageName
-            }
+            let reference = try resolvedReference(imageName: imageName, tag: query.tag)
 
             // Parse platform if provided
             let platform: Platform?
@@ -60,18 +55,12 @@ extension ImagePushRoute {
                 platform = nil
             }
 
-            guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
-                throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
-            }
-
             let response = Response()
             response.headers.add(name: .contentType, value: "application/json")
 
             let progressStream = try await client.push(
                 reference: reference,
                 platform: platform,
-                registryAuth: registryAuth,
-                appleContainerAppSupportUrl: appleContainerAppSupportUrl,
                 logger: req.logger
             )
 

--- a/Sources/socktainer/Routes/Images/ImageTagRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageTagRoute.swift
@@ -24,12 +24,12 @@ extension ImageTagRoute {
             throw Abort(.badRequest, reason: "repo parameter is required")
         }
 
-        let targetReference: String
-        if let tag = query.tag, !tag.isEmpty {
-            targetReference = "\(repo):\(tag)"
-        } else {
-            targetReference = "\(repo):latest"
-        }
+        let targetReference = try {
+            if let tag = query.tag, !tag.isEmpty {
+                return try ClientImage.normalizeReference("\(repo):\(tag)")
+            }
+            return try ClientImage.normalizeReference(repo)
+        }()
 
         let sourceImage: ClientImage
         do {

--- a/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
@@ -37,20 +37,7 @@ struct ImagesGetRoute: RouteCollection {
 
     private static func saveImages(references: [String], req: Request, client: ClientImageProtocol) async throws -> Response {
         let platformString = try? req.query.get(String.self, at: "platform")
-        let platform: Platform? = {
-            guard let platformString = platformString else {
-                return nil
-            }
-
-            do {
-                let data = platformString.data(using: .utf8) ?? Data()
-                let decoder = JSONDecoder()
-                return try decoder.decode(Platform.self, from: data)
-            } catch {
-                req.logger.warning("Failed to decode platform JSON: \(platformString)")
-                return nil
-            }
-        }()
+        let platform = try platformString.map(platformOrThrow)
 
         guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
             throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")

--- a/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
@@ -19,9 +19,7 @@ struct ImagesGetRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "Image name is required")
             }
 
-            let normalizedName = ContainerImageUtility.normalizeImageReference(name)
-
-            return try await saveImages(references: [normalizedName], req: req, client: client)
+            return try await saveImages(references: [name], req: req, client: client)
         }
     }
 
@@ -33,9 +31,7 @@ struct ImagesGetRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "At least one image name is required in 'names' query parameter")
             }
 
-            let normalizedNames = names.map { ContainerImageUtility.normalizeImageReference($0) }
-
-            return try await saveImages(references: normalizedNames, req: req, client: client)
+            return try await saveImages(references: names, req: req, client: client)
         }
     }
 

--- a/Sources/socktainer/Utilities/AppleContainerImageStoreResolver.swift
+++ b/Sources/socktainer/Utilities/AppleContainerImageStoreResolver.swift
@@ -1,0 +1,124 @@
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+
+struct AppleContainerImageStoreResolver {
+    struct DescriptorExtras {
+        let data: String?
+        let artifactType: String?
+    }
+
+    static func descriptorExtras(
+        appSupportURL: URL,
+        parentDigest: String,
+        childDigest: String
+    ) -> DescriptorExtras? {
+        // Docker's descriptor schema allows `data` and `artifactType`, but Apple's typed
+        // Descriptor model does not expose either field. Recover them from the raw OCI blob
+        // only when the underlying content actually contains them.
+        guard
+            let document = jsonObject(
+                at: blobURL(appSupportURL: appSupportURL, digest: parentDigest)
+            ),
+            let descriptor = findDescriptor(in: document, childDigest: childDigest)
+        else {
+            return nil
+        }
+
+        return DescriptorExtras(
+            data: descriptor["data"] as? String,
+            artifactType: descriptor["artifactType"] as? String
+        )
+    }
+
+    static func graphDriver(
+        appSupportURL: URL,
+        descriptor: Descriptor
+    ) -> DriverData? {
+        // Docker exposes GraphDriver details on inspect. Apple does not model an image graph
+        // driver directly, but unpacked snapshots persist `snapshot-info`, which is the closest
+        // host-side source we can map without inventing values.
+        let infoURL =
+            appSupportURL
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(descriptor.digest.trimmingDigestPrefix, isDirectory: true)
+            .appendingPathComponent("snapshot-info", isDirectory: false)
+
+        guard
+            let data = try? Data(contentsOf: infoURL),
+            let filesystem = try? JSONDecoder().decode(Filesystem.self, from: data)
+        else {
+            return nil
+        }
+
+        let name: String
+        var driverData: [String: String] = [
+            "Source": filesystem.source,
+            "Destination": filesystem.destination,
+        ]
+
+        if !filesystem.options.isEmpty {
+            driverData["Options"] = filesystem.options.joined(separator: ",")
+        }
+
+        switch filesystem.type {
+        case .block(let format, let cache, let sync):
+            name = format
+            driverData["Cache"] = String(describing: cache)
+            driverData["Sync"] = String(describing: sync)
+        case .volume(let volumeName, let format, let cache, let sync):
+            name = format
+            driverData["Volume"] = volumeName
+            driverData["Cache"] = String(describing: cache)
+            driverData["Sync"] = String(describing: sync)
+        case .virtiofs:
+            name = "virtiofs"
+        case .tmpfs:
+            name = "tmpfs"
+        }
+
+        return DriverData(Name: name, Data: driverData)
+    }
+
+    private static func blobURL(appSupportURL: URL, digest: String) -> URL {
+        appSupportURL
+            .appendingPathComponent("content", isDirectory: true)
+            .appendingPathComponent("blobs", isDirectory: true)
+            .appendingPathComponent("sha256", isDirectory: true)
+            .appendingPathComponent(digest.trimmingDigestPrefix, isDirectory: false)
+    }
+
+    private static func jsonObject(at url: URL) -> Any? {
+        guard
+            let data = try? Data(contentsOf: url),
+            let object = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return nil
+        }
+        return object
+    }
+
+    private static func findDescriptor(in object: Any, childDigest: String) -> [String: Any]? {
+        if let dictionary = object as? [String: Any] {
+            if dictionary["digest"] as? String == childDigest {
+                return dictionary
+            }
+
+            for value in dictionary.values {
+                if let match = findDescriptor(in: value, childDigest: childDigest) {
+                    return match
+                }
+            }
+        }
+
+        if let array = object as? [Any] {
+            for value in array {
+                if let match = findDescriptor(in: value, childDigest: childDigest) {
+                    return match
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/socktainer/Utilities/AppleContainerSnapshotResolver.swift
+++ b/Sources/socktainer/Utilities/AppleContainerSnapshotResolver.swift
@@ -1,0 +1,44 @@
+import ContainerizationOCI
+import Foundation
+
+enum AppleContainerSnapshotResolver {
+    static func unpackedSize(appSupportURL: URL, descriptor: Descriptor) -> Int64 {
+        let snapshotDirectory =
+            appSupportURL
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(descriptor.digest.trimmingDigestPrefix, isDirectory: true)
+
+        guard FileManager.default.fileExists(atPath: snapshotDirectory.path) else {
+            return 0
+        }
+
+        return Int64((try? FileManager.default.directorySize(dir: snapshotDirectory)) ?? 0)
+    }
+}
+
+extension FileManager {
+    fileprivate func directorySize(dir: URL) throws -> UInt64 {
+        var size: UInt64 = 0
+        let resourceKeys: [URLResourceKey] = [.totalFileAllocatedSizeKey]
+
+        guard
+            let enumerator = self.enumerator(
+                at: dir,
+                includingPropertiesForKeys: resourceKeys,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return 0
+        }
+
+        for case let fileURL as URL in enumerator {
+            if let resourceValues = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
+                let fileSize = resourceValues.totalFileAllocatedSize
+            {
+                size += UInt64(fileSize)
+            }
+        }
+
+        return size
+    }
+}

--- a/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
+++ b/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
@@ -54,6 +54,27 @@ enum AppleContainerTimestampResolver {
         return Int64(date.timeIntervalSince1970)
     }
 
+    static func iso8601Date(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        if let date = formatter.date(from: value) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+
+    static func unixTimestampSeconds(_ value: String?) -> Int64 {
+        unixTimestampSeconds(iso8601Date(value))
+    }
+
     static func iso8601Timestamp(_ date: Date?) -> String {
         guard let date else {
             return "1970-01-01T00:00:00Z"

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -1,4 +1,3 @@
-import ContainerPersistence
 import CryptoKit
 import Foundation
 import Logging
@@ -7,27 +6,6 @@ enum ContainerImageUtility {
 
     enum Error: Swift.Error {
         case invalidTarball(reason: String)
-    }
-
-    static func normalizeImageReference(_ reference: String) -> String {
-        guard !reference.isEmpty else { return reference }
-
-        let components = reference.split(separator: "/", maxSplits: 1)
-        if components.count > 1 {
-            let firstComponent = String(components[0])
-            if firstComponent.contains(".") || firstComponent.contains(":") || firstComponent == "localhost" {
-                return reference
-            }
-        }
-
-        let defaultRegistry = DefaultsStore.get(key: .defaultRegistryDomain)
-        let defaultRepo = "library"
-
-        if components.count == 1 {
-            return "\(defaultRegistry)/\(defaultRepo)/\(reference)"
-        }
-
-        return "\(defaultRegistry)/\(reference)"
     }
 
     static func convertDockerTarToOCI(

--- a/Sources/socktainer/Utilities/PlatformUtility.swift
+++ b/Sources/socktainer/Utilities/PlatformUtility.swift
@@ -2,6 +2,7 @@ import ContainerAPIClient
 import Containerization
 import ContainerizationOCI
 import Foundation
+import Vapor
 
 public typealias Platform = ContainerizationOCI.Platform
 
@@ -10,5 +11,49 @@ public func currentPlatform() -> Platform {
 }
 
 public func platformOrThrow(_ platformString: String) throws -> Platform {
-    try Platform(from: platformString)
+    let trimmed = platformString.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if trimmed.first == "{" {
+        guard let data = trimmed.data(using: .utf8) else {
+            throw Abort(.badRequest, reason: "invalid JSON-encoded OCI platform object")
+        }
+
+        do {
+            return try JSONDecoder().decode(Platform.self, from: data)
+        } catch {
+            throw Abort(.badRequest, reason: "invalid JSON-encoded OCI platform object")
+        }
+    }
+
+    return try Platform(from: trimmed)
+}
+
+public func requestedOrDefaultPlatform(_ requestedPlatform: Platform?) -> Platform {
+    requestedPlatform ?? Platform.current
+}
+
+public func preferredPlatformMatches(
+    _ leftPlatform: Platform?,
+    over rightPlatform: Platform?,
+    preferredPlatform: Platform
+) -> Bool {
+    let leftExactMatch = leftPlatform == preferredPlatform
+    let rightExactMatch = rightPlatform == preferredPlatform
+    if leftExactMatch != rightExactMatch {
+        return leftExactMatch
+    }
+
+    let leftArchitectureMatch = leftPlatform?.architecture == preferredPlatform.architecture
+    let rightArchitectureMatch = rightPlatform?.architecture == preferredPlatform.architecture
+    if leftArchitectureMatch != rightArchitectureMatch {
+        return leftArchitectureMatch
+    }
+
+    let leftOSMatch = leftPlatform?.os == preferredPlatform.os
+    let rightOSMatch = rightPlatform?.os == preferredPlatform.os
+    if leftOSMatch != rightOSMatch {
+        return leftOSMatch
+    }
+
+    return false
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -63,7 +63,7 @@ func configure(_ app: Application) async throws {
 
     // /images
     try app.register(collection: ImageDeleteRoute(client: imageClient))
-    try app.register(collection: ImageHistoryRoute())
+    try app.register(collection: ImageHistoryRoute(client: imageClient))
     try app.register(collection: ImageListRoute(client: imageClient))
     try app.register(collection: ImagePruneRoute(client: imageClient))
     try app.register(collection: ImageCreateRoute(client: imageClient))


### PR DESCRIPTION
Updating current routes to adhere to v1.51 spec:
  - Align `/images/{name}/json` and `/images/json` with Descriptor/Manifests.
  - Populate manifest size and unpacked snapshot.
  - Include OCI descriptors from raw blob metadata.
  - Emit nullable schema fields explicitly in image responses

Add `/images/{name}/history` route.

Unify platform and timestamp handling for image routes using a shared utility.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
