### PR TITLE
feat(routes): Add `/system/df` Route

### DIFF
--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -24,10 +24,24 @@ struct BuilderPruneResult: Sendable {
     let spaceReclaimed: Int64
 }
 
+struct BuilderCacheRecord: Sendable {
+    let id: String
+    let parents: [String]
+    let kind: String
+    let description: String
+    let inUse: Bool
+    let shared: Bool
+    let size: Int64
+    let createdAt: String
+    let lastUsedAt: String?
+    let usageCount: Int
+}
+
 protocol ClientBuilderProtocol: Sendable {
     func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws
     func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult
+    func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord]
 }
 
 struct ClientBuilderService: ClientBuilderProtocol {
@@ -56,46 +70,37 @@ struct ClientBuilderService: ClientBuilderProtocol {
         let container = try await runningBuilderContainer(logger: logger)
 
         let command = try BuildctlUtility.pruneCommand(from: request)
-
-        var processConfig = container.configuration.initProcess
-        processConfig.executable = command.executable
-        processConfig.arguments = command.arguments
-        processConfig.terminal = false
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        let process = try await containerClient.createProcess(
-            containerId: container.id,
-            processId: UUID().uuidString.lowercased(),
-            configuration: processConfig,
-            stdio: [nil, stdoutPipe.fileHandleForWriting, stderrPipe.fileHandleForWriting]
-        )
-
-        try await process.start()
-        let exitCode = try await process.wait()
-
-        try? stdoutPipe.fileHandleForWriting.close()
-        try? stderrPipe.fileHandleForWriting.close()
-
-        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
-        let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
-
-        if !stderrText.isEmpty {
-            logger.error("buildctl prune stderr:\n\(stderrText)")
-        }
-
-        guard exitCode == 0 else {
-            let details = stderrText.isEmpty ? stdoutText : stderrText
-            throw ContainerizationError(.unknown, message: "buildctl prune failed with exit code \(exitCode): \(details)")
-        }
+        let stdoutText = try await execute(command: command, in: container, actionName: "buildctl prune", logger: logger)
 
         let entries = BuildctlUtility.parsePruneOutput(stdoutText, logger: logger)
         let deletedIds = entries.compactMap(\.id)
         let reclaimed = entries.reduce(Int64(0)) { $0 + ($1.size ?? 0) }
 
         return BuilderPruneResult(deletedCaches: deletedIds, spaceReclaimed: reclaimed)
+    }
+
+    func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord] {
+        let container = try await runningBuilderContainer(logger: logger)
+        let command = BuildctlUtility.duCommand()
+        let stdoutText = try await execute(command: command, in: container, actionName: "buildctl du", logger: logger)
+
+        return BuildctlUtility.parseDuOutput(stdoutText, logger: logger).compactMap { record in
+            guard let id = record.id else {
+                return nil
+            }
+            return BuilderCacheRecord(
+                id: id,
+                parents: record.parents ?? [],
+                kind: record.recordType ?? "regular",
+                description: record.recordDescription ?? "",
+                inUse: record.inUse ?? false,
+                shared: record.shared ?? false,
+                size: record.size ?? 0,
+                createdAt: record.createdAt ?? "",
+                lastUsedAt: record.lastUsedAt,
+                usageCount: record.usageCount ?? 0
+            )
+        }
     }
 
     func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {
@@ -261,6 +266,44 @@ struct ClientBuilderService: ClientBuilderProtocol {
             }
             throw ContainerizationError(.internalError, message: "failed to start BuildKit: \(error)")
         }
+    }
+
+    private func execute(command: BuildctlUtility.Command, in container: ContainerSnapshot, actionName: String, logger: Logger) async throws -> String {
+        var processConfig = container.configuration.initProcess
+        processConfig.executable = command.executable
+        processConfig.arguments = command.arguments
+        processConfig.terminal = false
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let process = try await containerClient.createProcess(
+            containerId: container.id,
+            processId: UUID().uuidString.lowercased(),
+            configuration: processConfig,
+            stdio: [nil, stdoutPipe.fileHandleForWriting, stderrPipe.fileHandleForWriting]
+        )
+
+        try await process.start()
+        let exitCode = try await process.wait()
+
+        try? stdoutPipe.fileHandleForWriting.close()
+        try? stderrPipe.fileHandleForWriting.close()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
+
+        if !stderrText.isEmpty {
+            logger.error("\(actionName) stderr:\n\(stderrText)")
+        }
+
+        guard exitCode == 0 else {
+            let details = stderrText.isEmpty ? stdoutText : stderrText
+            throw ContainerizationError(.unknown, message: "\(actionName) failed with exit code \(exitCode): \(details)")
+        }
+
+        return stdoutText
     }
 
 }

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -6,7 +6,7 @@ import Logging
 import TerminalProgress
 
 protocol ClientImageProtocol: Sendable {
-    func list() async throws -> [ClientImage]
+    func list(includeSystemImages: Bool) async throws -> [ClientImage]
     func delete(id: String) async throws
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
@@ -17,6 +17,12 @@ protocol ClientImageProtocol: Sendable {
     func prune(filters: [String: [String]], logger: Logger) async throws -> (deletedImages: [String], spaceReclaimed: Int64)
     func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String]
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL
+}
+
+extension ClientImageProtocol {
+    func list() async throws -> [ClientImage] {
+        try await list(includeSystemImages: false)
+    }
 }
 
 enum ClientImageError: Error {
@@ -60,8 +66,11 @@ struct ClientImageService: ClientImageProtocol {
         return nil
     }
 
-    func list() async throws -> [ClientImage] {
+    func list(includeSystemImages: Bool = false) async throws -> [ClientImage] {
         let allImages = try await ClientImage.list()
+        guard !includeSystemImages else {
+            return allImages
+        }
         // filter out infra images
         // also filter images based on digests
         let filteredImages = allImages.filter { img in

--- a/Sources/socktainer/Models/RESTBuildCache.swift
+++ b/Sources/socktainer/Models/RESTBuildCache.swift
@@ -1,0 +1,27 @@
+import Vapor
+
+struct RESTBuildCache: Content {
+    let ID: String
+    let Parents: [String]?
+    let kind: String
+    let Description: String
+    let InUse: Bool
+    let Shared: Bool
+    let Size: Int64
+    let CreatedAt: String
+    let LastUsedAt: String?
+    let UsageCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ID
+        case Parents
+        case kind = "Type"
+        case Description
+        case InUse
+        case Shared
+        case Size
+        case CreatedAt
+        case LastUsedAt
+        case UsageCount
+    }
+}

--- a/Sources/socktainer/Models/RESTConfig.swift
+++ b/Sources/socktainer/Models/RESTConfig.swift
@@ -352,6 +352,10 @@ struct VolumeRequest: Content {
 struct VolumeUsageData: Content {
     let Size: Int64
     let RefCount: Int64
+    init(Size: Int64, RefCount: Int64) {
+        self.Size = Size
+        self.RefCount = RefCount
+    }
     init() {
         self.Size = -1  // will return -1, we have no option to calculate the actual usage of volume
         self.RefCount = -1  // will return -1, we don't map attached containers to volumes

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -1,11 +1,329 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
 import Vapor
 
+struct SystemDFResponse: Vapor.Content {
+    let LayersSize: Int64?
+    let Images: [RESTImageSummary]?
+    let Containers: [RESTContainerSummary]?
+    let Volumes: [Volume]?
+    let BuildCache: [RESTBuildCache]?
+}
+
+struct SystemDFQuery: Vapor.Content {
+    let type: [String]?
+}
+
 struct SystemDFRoute: RouteCollection {
+    let imageClient: ClientImageProtocol
+    let containerClient: ClientContainerProtocol
+    let volumeClient: ClientVolumeProtocol
+    let builderClient: ClientBuilderProtocol
+
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/system/df", use: SystemDFRoute.handler)
+        try routes.registerVersionedRoute(.GET, pattern: "/system/df", use: handler)
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/system/df", req.method.rawValue)
+    func handler(_ req: Request) async throws -> Response {
+        let query = try req.query.decode(SystemDFQuery.self)
+        let requestedTypes = Set(query.type ?? [])
+        let includeAll = requestedTypes.isEmpty
+
+        async let images = imageClient.list(includeSystemImages: true)
+        async let containers = containerClient.list(showAll: true, filters: [:])
+        async let volumes = volumeClient.list(filters: nil, logger: req.logger)
+
+        let (allImages, allContainers, allVolumes) = try await (images, containers, volumes)
+        let usageByImageReference = Dictionary(grouping: allContainers, by: \.configuration.image.reference).mapValues(\.count)
+
+        let imageSummaries: [RESTImageSummary]?
+        if includeAll || requestedTypes.contains("image") {
+            imageSummaries = try await Self.buildImageSummaries(images: allImages, usageByImageReference: usageByImageReference)
+        } else {
+            imageSummaries = nil
+        }
+
+        let containerSummaries: [RESTContainerSummary]?
+        if includeAll || requestedTypes.contains("container") {
+            containerSummaries = try await Self.buildContainerSummaries(containers: allContainers)
+        } else {
+            containerSummaries = nil
+        }
+
+        let volumeSummaries: [Volume]?
+        if includeAll || requestedTypes.contains("volume") {
+            volumeSummaries = try await Self.buildVolumeSummaries(volumes: allVolumes, containers: allContainers)
+        } else {
+            volumeSummaries = nil
+        }
+
+        let layersSize: Int64?
+        if includeAll || requestedTypes.contains("image") {
+            let activeReferences = Set(allContainers.map(\.configuration.image.reference))
+            let usage = try await ClientImage.calculateDiskUsage(activeReferences: activeReferences)
+            layersSize = Int64(clamping: usage.totalSize)
+        } else {
+            layersSize = nil
+        }
+
+        // NOTE: This type is optional at the moment
+        let buildCache: [RESTBuildCache]?
+        if includeAll {
+            buildCache = []
+        } else if requestedTypes.contains("build-cache") {
+            buildCache = try await builderClient.diskUsage(logger: req.logger).map {
+                RESTBuildCache(
+                    ID: $0.id,
+                    Parents: $0.parents,
+                    kind: $0.kind,
+                    Description: $0.description,
+                    InUse: $0.inUse,
+                    Shared: $0.shared,
+                    Size: $0.size,
+                    CreatedAt: $0.createdAt,
+                    LastUsedAt: $0.lastUsedAt,
+                    UsageCount: $0.usageCount
+                )
+            }
+        } else {
+            buildCache = nil
+        }
+
+        let response = SystemDFResponse(
+            LayersSize: layersSize,
+            Images: imageSummaries,
+            Containers: containerSummaries,
+            Volumes: volumeSummaries,
+            BuildCache: buildCache
+        )
+
+        return try await response.encodeResponse(status: .ok, for: req)
+    }
+}
+
+extension SystemDFRoute {
+    fileprivate static func buildImageSummaries(
+        images: [ClientImage],
+        usageByImageReference: [String: Int]
+    ) async throws -> [RESTImageSummary] {
+        try await withThrowingTaskGroup(of: RESTImageSummary.self) { group in
+            for image in images {
+                group.addTask {
+                    let details: ImageDetail = try await image.details()
+                    let manifests = try await image.index().manifests
+                    var created = 0
+                    var totalSize: Int64 = 0
+                    var labels: [String: String] = [:]
+                    var foundUsableManifest = false
+
+                    for descriptor in manifests {
+                        if descriptor.annotations?["vnd.docker.reference.type"] == "attestation-manifest" {
+                            continue
+                        }
+
+                        let manifestSize: Int64
+                        if let platform = descriptor.platform {
+                            do {
+                                let config = try await image.config(for: platform)
+                                let manifest = try await image.manifest(for: platform)
+                                manifestSize = descriptor.size + manifest.config.size + manifest.layers.reduce(0) { $0 + $1.size }
+                                totalSize += manifestSize
+                                if !foundUsableManifest {
+                                    created = Int(AppleContainerTimestampResolver.unixTimestampSeconds(config.created))
+                                    labels = config.config?.labels ?? [:]
+                                    foundUsableManifest = true
+                                }
+                                continue
+                            } catch {
+                            }
+                        }
+
+                        totalSize += descriptor.size
+                    }
+
+                    let repoTags = details.name.isEmpty ? [] : [details.name]
+                    let repoDigests = image.reference.contains("@sha256:") ? [image.reference] : []
+                    let containerCount = usageByImageReference[image.reference] ?? 0
+
+                    return RESTImageSummary(
+                        Id: image.digest,
+                        ParentId: "",
+                        RepoTags: repoTags,
+                        RepoDigests: repoDigests,
+                        Created: created,
+                        Size: totalSize,
+                        SharedSize: 0,
+                        Labels: labels,
+                        Containers: containerCount,
+                        Manifests: nil,
+                        Descriptor: nil
+                    )
+                }
+            }
+
+            var summaries: [RESTImageSummary] = []
+            for try await summary in group {
+                summaries.append(summary)
+            }
+            return summaries
+        }
+    }
+
+    fileprivate static func buildContainerSummaries(containers: [ContainerSnapshot]) async throws -> [RESTContainerSummary] {
+        let containerClient = ContainerClient()
+        return try await withThrowingTaskGroup(of: RESTContainerSummary.self) { group in
+            for container in containers {
+                group.addTask {
+                    let size = try await containerClient.diskUsage(id: container.id)
+                    return containerSummary(from: container, size: Int64(clamping: size))
+                }
+            }
+
+            var summaries: [RESTContainerSummary] = []
+            for try await summary in group {
+                summaries.append(summary)
+            }
+            return summaries.sorted { $0.Created > $1.Created }
+        }
+    }
+
+    fileprivate static func buildVolumeSummaries(
+        volumes: [Volume],
+        containers: [ContainerSnapshot]
+    ) async throws -> [Volume] {
+        var refCounts: [String: Int64] = [:]
+        for container in containers {
+            for mount in container.configuration.mounts {
+                if mount.isVolume, let name = mount.volumeName {
+                    refCounts[name, default: 0] += 1
+                }
+            }
+        }
+        let normalizedRefCounts = refCounts
+
+        return try await withThrowingTaskGroup(of: Volume.self) { group in
+            for volume in volumes {
+                group.addTask {
+                    let size = try await ClientVolume.volumeDiskUsage(name: volume.Name)
+                    return Volume(
+                        Name: volume.Name,
+                        Driver: volume.Driver,
+                        Mountpoint: volume.Mountpoint,
+                        CreatedAt: volume.CreatedAt,
+                        Status: volume.Status,
+                        Labels: volume.Labels,
+                        Scope: volume.Scope,
+                        ClusterVolume: volume.ClusterVolume,
+                        Options: volume.Options,
+                        UsageData: VolumeUsageData(
+                            Size: Int64(clamping: size),
+                            RefCount: normalizedRefCounts[volume.Name] ?? 0
+                        )
+                    )
+                }
+            }
+
+            var enrichedVolumes: [Volume] = []
+            for try await volume in group {
+                enrichedVolumes.append(volume)
+            }
+            return enrichedVolumes.sorted { $0.Name < $1.Name }
+        }
+    }
+
+    fileprivate static func containerSummary(from container: ContainerSnapshot, size: Int64) -> RESTContainerSummary {
+        let ports = container.configuration.publishedPorts.map { port in
+            ContainerPort(
+                IP: port.hostAddress.description,
+                PrivatePort: Int(port.containerPort),
+                PublicPort: Int(port.hostPort),
+                type: port.proto.rawValue
+            )
+        }
+
+        let networkMode = container.networks.first?.network ?? "default"
+        let networkSettings = Dictionary(
+            uniqueKeysWithValues: container.networks.map { attachment in
+                let endpoint = ContainerEndpointSettings(
+                    IPAMConfig: nil,
+                    Links: nil,
+                    Aliases: nil,
+                    NetworkID: attachment.network,
+                    EndpointID: nil,
+                    Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
+                    IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
+                    IPPrefixLen: nil,
+                    IPv6Gateway: nil,
+                    GlobalIPv6Address: nil,
+                    GlobalIPv6PrefixLen: nil,
+                    MacAddress: nil,
+                    DriverOpts: nil
+                )
+                return (attachment.network, endpoint)
+            }
+        )
+
+        let mounts = container.configuration.mounts.map { mount in
+            let mountType: String
+            let mountName: String?
+            let driver: String?
+
+            switch mount.type {
+            case .block:
+                mountType = "bind"
+                mountName = nil
+                driver = nil
+            case .volume(let name, _, _, _):
+                mountType = "volume"
+                mountName = name
+                driver = "local"
+            case .virtiofs:
+                mountType = "bind"
+                mountName = nil
+                driver = nil
+            case .tmpfs:
+                mountType = "tmpfs"
+                mountName = nil
+                driver = nil
+            }
+
+            let isReadOnly = mount.options.readonly
+            return ContainerMountPoint(
+                type: mountType,
+                name: mountName,
+                source: mount.source,
+                destination: mount.destination,
+                driver: driver,
+                mode: isReadOnly ? "ro" : "rw",
+                rw: !isReadOnly,
+                propagation: ""
+            )
+        }
+
+        let createdTimestamp = AppleContainerTimestampResolver.unixTimestampSeconds(
+            AppleContainerTimestampResolver.containerCreationDate(container)
+        )
+
+        return RESTContainerSummary(
+            Id: container.id,
+            Names: ["/" + container.id],
+            Image: container.configuration.image.reference,
+            ImageID: container.configuration.image.digest,
+            ImageManifestDescriptor: nil,
+            Command: ([container.configuration.initProcess.executable] + container.configuration.initProcess.arguments).joined(separator: " "),
+            Created: createdTimestamp,
+            Ports: ports,
+            SizeRw: size,
+            SizeRootFs: size,
+            Labels: container.configuration.labels,
+            State: container.status.mobyState,
+            Status: container.status.mobyState,
+            HostConfig: ContainerHostConfig(NetworkMode: networkMode, Annotations: nil),
+            NetworkSettings: ContainerNetworkSummary(Networks: networkSettings.isEmpty ? nil : networkSettings),
+            Mounts: mounts,
+            Platform: "linux"
+        )
     }
 }

--- a/Sources/socktainer/Utilities/BuildctlUtility.swift
+++ b/Sources/socktainer/Utilities/BuildctlUtility.swift
@@ -5,7 +5,7 @@ import Logging
 enum BuildctlUtility {
     static let executable = "/usr/bin/buildctl"
 
-    struct PruneCommand {
+    struct Command {
         let executable: String
         let arguments: [String]
 
@@ -36,7 +36,102 @@ enum BuildctlUtility {
         }
     }
 
-    static func pruneCommand(from request: BuilderPruneRequest) throws -> PruneCommand {
+    struct DuRecord: Decodable {
+        let id: String?
+        let parents: [String]?
+        let recordType: String?
+        let recordDescription: String?
+        let inUse: Bool?
+        let shared: Bool?
+        let size: Int64?
+        let createdAt: String?
+        let lastUsedAt: String?
+        let usageCount: Int?
+
+        init(
+            id: String?,
+            parents: [String]?,
+            recordType: String?,
+            recordDescription: String?,
+            inUse: Bool?,
+            shared: Bool?,
+            size: Int64?,
+            createdAt: String?,
+            lastUsedAt: String?,
+            usageCount: Int?
+        ) {
+            self.id = id
+            self.parents = parents
+            self.recordType = recordType
+            self.recordDescription = recordDescription
+            self.inUse = inUse
+            self.shared = shared
+            self.size = size
+            self.createdAt = createdAt
+            self.lastUsedAt = lastUsedAt
+            self.usageCount = usageCount
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case parents
+            case recordType = "type"
+            case recordDescription = "description"
+            case inUse
+            case shared
+            case size
+            case createdAt
+            case lastUsedAt
+            case usageCount
+
+            case idLegacy = "ID"
+            case parentsLegacy = "Parents"
+            case typeLegacy = "Type"
+            case descriptionLegacy = "Description"
+            case inUseLegacy = "InUse"
+            case sharedLegacy = "Shared"
+            case sizeLegacy = "Size"
+            case createdAtLegacy = "CreatedAt"
+            case lastUsedAtLegacy = "LastUsedAt"
+            case usageCountLegacy = "UsageCount"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id =
+                try container.decodeIfPresent(String.self, forKey: .id)
+                ?? container.decodeIfPresent(String.self, forKey: .idLegacy)
+            parents =
+                try container.decodeIfPresent([String].self, forKey: .parents)
+                ?? container.decodeIfPresent([String].self, forKey: .parentsLegacy)
+            recordType =
+                try container.decodeIfPresent(String.self, forKey: .recordType)
+                ?? container.decodeIfPresent(String.self, forKey: .typeLegacy)
+            recordDescription =
+                try container.decodeIfPresent(String.self, forKey: .recordDescription)
+                ?? container.decodeIfPresent(String.self, forKey: .descriptionLegacy)
+            inUse =
+                try container.decodeIfPresent(Bool.self, forKey: .inUse)
+                ?? container.decodeIfPresent(Bool.self, forKey: .inUseLegacy)
+            shared =
+                try container.decodeIfPresent(Bool.self, forKey: .shared)
+                ?? container.decodeIfPresent(Bool.self, forKey: .sharedLegacy)
+            size =
+                try container.decodeIfPresent(Int64.self, forKey: .size)
+                ?? container.decodeIfPresent(Int64.self, forKey: .sizeLegacy)
+            createdAt =
+                try container.decodeIfPresent(String.self, forKey: .createdAt)
+                ?? container.decodeIfPresent(String.self, forKey: .createdAtLegacy)
+            lastUsedAt =
+                try container.decodeIfPresent(String.self, forKey: .lastUsedAt)
+                ?? container.decodeIfPresent(String.self, forKey: .lastUsedAtLegacy)
+            usageCount =
+                try container.decodeIfPresent(Int.self, forKey: .usageCount)
+                ?? container.decodeIfPresent(Int.self, forKey: .usageCountLegacy)
+        }
+    }
+
+    static func pruneCommand(from request: BuilderPruneRequest) throws -> Command {
         var arguments = [
             "--addr", "unix:///run/buildkit/buildkitd.sock",
             "prune",
@@ -71,7 +166,16 @@ enum BuildctlUtility {
             arguments.append(contentsOf: ["--filter", filter])
         }
 
-        return PruneCommand(executable: executable, arguments: arguments)
+        return Command(executable: executable, arguments: arguments)
+    }
+
+    static func duCommand() -> Command {
+        var arguments = [
+            "--addr", "unix:///run/buildkit/buildkitd.sock",
+            "du",
+            "--format=json",
+        ]
+        return Command(executable: executable, arguments: arguments)
     }
 
     static func parsePruneOutput(_ output: String, logger: Logger) -> [PruneRecord] {
@@ -94,6 +198,18 @@ enum BuildctlUtility {
         }
 
         return results
+    }
+
+    static func parseDuOutput(_ output: String, logger: Logger) -> [DuRecord] {
+        guard let data = output.data(using: .utf8) else {
+            return []
+        }
+        do {
+            return try JSONDecoder().decode([DuRecord].self, from: data)
+        } catch {
+            logger.debug("Failed to decode buildctl du JSON output: \(error)")
+            return []
+        }
     }
 
     private static func toBuildkitFilters(_ filters: [String: [String]]) -> [String] {

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -152,7 +152,7 @@ func configure(_ app: Application) async throws {
     // --- miscellaneous ---
     try app.register(collection: AuthRoute(client: registryClient))
     try app.register(collection: CommitRoute())
-    try app.register(collection: SystemDFRoute())
+    try app.register(collection: SystemDFRoute(imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClinet, builderClient: builderClient))
     try app.register(collection: VersionRoute())
 
     // Initialize broadcaster


### PR DESCRIPTION
Adding support for reporting Apple container's disk usage using the
`/system/df` route.
There will be a parity in results compared to Apple container due to
each backend calculating "reclaimable" storage differently.

Extending ClientBuilderService.swift to allow running various commands
in the builder container managed by Apple container.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>
