### PR TITLE
feat(routes): Add HEAD method support to /_ping health check route

### DIFF
--- a/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
+++ b/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
@@ -4,6 +4,7 @@ struct HealthCheckPingRoute: RouteCollection {
     let client: ClientHealthCheckProtocol
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.GET, pattern: "/_ping", use: HealthCheckPingRoute.handler(client: client))
+        try routes.registerVersionedRoute(.HEAD, pattern: "/_ping", use: HealthCheckPingRoute.handler(client: client))
     }
 }
 

--- a/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
+++ b/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
@@ -4,32 +4,35 @@ struct HealthCheckPingRoute: RouteCollection {
     let client: ClientHealthCheckProtocol
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.GET, pattern: "/_ping", use: HealthCheckPingRoute.handler(client: client))
-        try routes.registerVersionedRoute(.HEAD, pattern: "/_ping", use: HealthCheckPingRoute.handler(client: client))
+        try routes.registerVersionedRoute(.HEAD, pattern: "/_ping", use: HealthCheckPingRoute.headHandler(client: client))
     }
 }
 
 extension HealthCheckPingRoute {
+    private static func buildResponse(includeBody: Bool) -> Response {
+        let response = Response(status: .ok)
+        if includeBody {
+            response.body = .init(string: "OK")
+        }
+        response.headers.add(name: "Api-Version", value: "1.51")
+        response.headers.add(name: "Builder-Version", value: "")
+        response.headers.add(name: "Docker-Experimental", value: "false")
+        response.headers.add(name: "Cache-Control", value: "no-cache, no-store, must-revalidate")
+        response.headers.add(name: "Pragma", value: "no-cache")
+        return response
+    }
+
     static func handler(client: ClientHealthCheckProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
-
             try await client.ping()
+            return buildResponse(includeBody: true)
+        }
+    }
 
-            let response = Response(status: .ok)
-            response.body = .init(string: "OK")
-
-            // add headers
-            response.headers.add(name: "Api-Version", value: "1.51")
-            // not supported
-            response.headers.add(name: "Builder-Version", value: "")
-            response.headers.add(name: "Docker-Experimental", value: "false")
-
-            // Cache control
-            response.headers.add(name: "Cache-Control", value: "no-cache, no-store, must-revalidate")
-            // Pragma: no-cache
-            response.headers.add(name: "Pragma", value: "no-cache")
-
-            return response
-
+    static func headHandler(client: ClientHealthCheckProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            try await client.ping()
+            return buildResponse(includeBody: false)
         }
     }
 }

--- a/Tests/socktainerTests/Routes/Server/HealthCheckPingRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/HealthCheckPingRouteTests.swift
@@ -43,10 +43,11 @@ private struct MockHealthCheckClient: ClientHealthCheckProtocol {
     }
 
     @Test
-    func headPingReturnsOK() async throws {
+    func headPingReturnsOKWithNoBody() async throws {
         try await withRoute { app in
             try await app.testing().test(.HEAD, "/_ping") { res async in
                 #expect(res.status == .ok)
+                #expect(res.body.readableBytes == 0)
             }
         }
     }

--- a/Tests/socktainerTests/Routes/Server/HealthCheckPingRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/HealthCheckPingRouteTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct MockHealthCheckClient: ClientHealthCheckProtocol {
+    func ping() async throws {}
+}
+
+@Suite class HealthCheckPingRouteTests {
+
+    private func withRoute(_ test: @escaping (Application) async throws -> Void) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: HealthCheckPingRoute(client: MockHealthCheckClient()))
+            try await test(app)
+        }
+    }
+
+    @Test
+    func getPingReturnsOK() async throws {
+        try await withRoute { app in
+            try await app.testing().test(.GET, "/_ping") { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "OK")
+            }
+        }
+    }
+
+    @Test
+    func getPingReturnsExpectedHeaders() async throws {
+        try await withRoute { app in
+            try await app.testing().test(.GET, "/_ping") { res async in
+                #expect(res.headers.first(name: "Api-Version") == "1.51")
+                #expect(res.headers.first(name: "Docker-Experimental") == "false")
+                #expect(res.headers.first(name: "Cache-Control") == "no-cache, no-store, must-revalidate")
+                #expect(res.headers.first(name: "Pragma") == "no-cache")
+            }
+        }
+    }
+
+    @Test
+    func headPingReturnsOK() async throws {
+        try await withRoute { app in
+            try await app.testing().test(.HEAD, "/_ping") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test
+    func headPingReturnsExpectedHeaders() async throws {
+        try await withRoute { app in
+            try await app.testing().test(.HEAD, "/_ping") { res async in
+                #expect(res.headers.first(name: "Api-Version") == "1.51")
+                #expect(res.headers.first(name: "Cache-Control") == "no-cache, no-store, must-revalidate")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Registers a `HEAD` handler for the `/_ping` health check route alongside the existing `GET` handler, matching Docker Engine API behaviour
- Adds `HealthCheckPingRouteTests` covering `GET` and `HEAD` responses (status, body, headers)

## Test plan
- [x] Tests added in `Tests/socktainerTests/Routes/Server/HealthCheckPingRouteTests.swift`
- [x] `HEAD /_ping` returns 200 with no body
- [x] `GET /_ping` continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)