### PR TITLE
fix(archive): follow symlinks and release EXT4Reader scope to prevent archive write failures

### DIFF
--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -176,98 +176,77 @@ struct ClientArchiveService: ClientArchiveProtocol {
             throw ClientArchiveError.rootfsNotFound(id: containerId)
         }
 
-        // Normalize the destination path
         let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
 
-        // Scope the reader to this block so it is released before putArchiveFallback
-        // opens its own EXT4.EXT4Reader on the same rootfs file. Two concurrent readers
-        // on the same block device can deadlock if the EXT4 library uses exclusive locking.
-        do {
-            let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
-            try validateArchiveEntries(
-                reader: reader,
-                tarPath: tarPath,
-                destinationPath: normalizedPath,
-                noOverwriteDirNonDir: noOverwriteDirNonDir
-            )
+        // Pre-scan for dir/non-dir conflicts. Reader is scoped here and released
+        // before EXT4Editor opens the same file, avoiding any exclusive-lock conflict.
+        if noOverwriteDirNonDir {
+            do {
+                let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
+                try validateArchiveEntries(reader: reader, tarPath: tarPath, destinationPath: normalizedPath)
+            }
         }
 
-        try await putArchiveFallback(
-            rootfsPath: rootfsPath,
-            destinationPath: normalizedPath,
-            inputTarPath: tarPath
-        )
+        let editor = try EXT4Editor(devicePath: FilePath(rootfsPath.path))
+        let archiveReader = try ArchiveReader(file: tarPath)
+
+        for (entry, streamReader) in archiveReader.makeStreamingIterator() {
+            guard let fullPath = ArchiveUtility.destinationPath(for: entry.path, under: normalizedPath) else {
+                continue
+            }
+
+            switch entry.fileType {
+            case .directory:
+                if !editor.exists(path: fullPath) {
+                    try ensureParentDirectories(of: fullPath, editor: editor)
+                    try editor.createDirectory(
+                        path: fullPath,
+                        mode: UInt16(entry.permissions),
+                        uid: entry.owner ?? 0,
+                        gid: entry.group ?? 0
+                    )
+                }
+            case .symbolicLink:
+                try ensureParentDirectories(of: fullPath, editor: editor)
+                try editor.addSymlink(
+                    path: fullPath,
+                    target: entry.symlinkTarget ?? "",
+                    uid: entry.owner ?? 0,
+                    gid: entry.group ?? 0
+                )
+            case .regular:
+                try ensureParentDirectories(of: fullPath, editor: editor)
+                var data = Data()
+                var buf = Data(count: 65536)
+                while true {
+                    let n = buf.withUnsafeMutableBytes { raw -> Int in
+                        guard let ptr = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+                        return streamReader.read(ptr, maxLength: raw.count)
+                    }
+                    if n <= 0 { break }
+                    data.append(buf.prefix(n))
+                }
+                try editor.addFile(
+                    path: fullPath,
+                    data: data,
+                    mode: UInt16(entry.permissions),
+                    uid: entry.owner ?? 0,
+                    gid: entry.group ?? 0
+                )
+            default:
+                continue
+            }
+        }
+
+        try editor.sync()
     }
 
-    /// Fallback PUT using full read-modify-write approach
-    private func putArchiveFallback(
-        rootfsPath: URL,
-        destinationPath: String,
-        inputTarPath: URL
-    ) async throws {
-        // Create temporary files for the operation
-        let tempDir = FileManager.default.temporaryDirectory
-        let sessionId = UUID().uuidString
-        let exportedTarPath = tempDir.appendingPathComponent("\(sessionId)-export.tar")
-        let newRootfsPath = tempDir.appendingPathComponent("\(sessionId)-rootfs.ext4")
-
-        defer {
-            try? FileManager.default.removeItem(at: exportedTarPath)
-            try? FileManager.default.removeItem(at: newRootfsPath)
-        }
-
-        // Step 1: Export existing filesystem to tar
-        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
-        try reader.export(archive: FilePath(exportedTarPath.path))
-
-        // Step 2: Get the size of the existing rootfs to create a new one of similar size
-        let rootfsAttributes = try FileManager.default.attributesOfItem(atPath: rootfsPath.path)
-        let rootfsSize = (rootfsAttributes[.size] as? UInt64) ?? (2 * 1024 * 1024 * 1024)  // Default 2GB
-
-        // Step 3: Create a new ext4 formatter
-        // Use a minimum size that can accommodate the filesystem
-        let minSize = max(rootfsSize, 256 * 1024)  // At least 256KB
-        let formatter = try EXT4.Formatter(
-            FilePath(newRootfsPath.path),
-            blockSize: 4096,
-            minDiskSize: minSize
-        )
-
-        // Step 4: Unpack the existing filesystem
-        let existingReader = try ArchiveReader(
-            format: .paxRestricted,
-            filter: .none,
-            file: exportedTarPath
-        )
-        try formatter.unpack(reader: existingReader)
-
-        // Step 5: Unpack the new tar at the specified destination path
-        try ArchiveUtility.unpack(
-            tarPath: inputTarPath,
-            to: formatter,
-            destinationPath: destinationPath
-        )
-
-        // Step 6: Finalize the new filesystem
-        try formatter.close()
-
-        // Step 7: Atomically replace the old rootfs with the new one
-        let backupPath = rootfsPath.appendingPathExtension("backup")
-        try? FileManager.default.removeItem(at: backupPath)
-
-        // Move old rootfs to backup
-        try FileManager.default.moveItem(at: rootfsPath, to: backupPath)
-
-        do {
-            // Move new rootfs into place
-            try FileManager.default.moveItem(at: newRootfsPath, to: rootfsPath)
-            // Remove backup on success
-            try? FileManager.default.removeItem(at: backupPath)
-        } catch {
-            // Restore backup on failure
-            try? FileManager.default.moveItem(at: backupPath, to: rootfsPath)
-            throw ClientArchiveError.operationFailed(message: "Failed to replace rootfs: \(error.localizedDescription)")
-        }
+    private func ensureParentDirectories(of path: String, editor: EXT4Editor) throws {
+        let parent = (path as NSString).deletingLastPathComponent
+        guard parent != "/" else { return }
+        if editor.exists(path: parent) { return }
+        try ensureParentDirectories(of: parent, editor: editor)
+        try editor.createDirectory(path: parent)
     }
 
     /// Read symlink target using the reader's public API
@@ -281,21 +260,16 @@ struct ClientArchiveService: ClientArchiveProtocol {
     private func validateArchiveEntries(
         reader: EXT4.EXT4Reader,
         tarPath: URL,
-        destinationPath: String,
-        noOverwriteDirNonDir: Bool
+        destinationPath: String
     ) throws {
-        let archiveReader = try ArchiveReader(
-            format: .paxRestricted,
-            filter: .none,
-            file: tarPath
-        )
+        let archiveReader = try ArchiveReader(file: tarPath)
 
         for (entry, _) in archiveReader.makeStreamingIterator() {
             guard let fullPath = ArchiveUtility.destinationPath(for: entry.path, under: destinationPath) else {
                 continue
             }
 
-            guard noOverwriteDirNonDir, reader.exists(FilePath(fullPath)) else {
+            guard reader.exists(FilePath(fullPath)) else {
                 continue
             }
 

--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -179,13 +179,18 @@ struct ClientArchiveService: ClientArchiveProtocol {
         // Normalize the destination path
         let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
 
-        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
-        try validateArchiveEntries(
-            reader: reader,
-            tarPath: tarPath,
-            destinationPath: normalizedPath,
-            noOverwriteDirNonDir: noOverwriteDirNonDir
-        )
+        // Scope the reader to this block so it is released before putArchiveFallback
+        // opens its own EXT4.EXT4Reader on the same rootfs file. Two concurrent readers
+        // on the same block device can deadlock if the EXT4 library uses exclusive locking.
+        do {
+            let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
+            try validateArchiveEntries(
+                reader: reader,
+                tarPath: tarPath,
+                destinationPath: normalizedPath,
+                noOverwriteDirNonDir: noOverwriteDirNonDir
+            )
+        }
 
         try await putArchiveFallback(
             rootfsPath: rootfsPath,

--- a/Sources/socktainer/Utilities/ArchiveUtility.swift
+++ b/Sources/socktainer/Utilities/ArchiveUtility.swift
@@ -88,7 +88,8 @@ struct ArchiveUtility {
             return entryPath
         }
 
-        return destinationPath + entryPath
+        let base = destinationPath.hasSuffix("/") ? String(destinationPath.dropLast()) : destinationPath
+        return base + entryPath
     }
 
     static func unpack(
@@ -96,11 +97,7 @@ struct ArchiveUtility {
         to formatter: EXT4.Formatter,
         destinationPath targetPath: String
     ) throws {
-        let archiveReader = try ArchiveReader(
-            format: .paxRestricted,
-            filter: .none,
-            file: tarPath
-        )
+        let archiveReader = try ArchiveReader(file: tarPath)
 
         let bufferSize = 128 * 1024
         let reusableBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: bufferSize)

--- a/Sources/socktainer/Utilities/EXT4Editor.swift
+++ b/Sources/socktainer/Utilities/EXT4Editor.swift
@@ -175,6 +175,14 @@ struct EXT4ExtentLeaf {
     var startLow: UInt32 = 0
 }
 
+/// Extent index node structure (used in depth > 0 extent trees)
+struct EXT4ExtentIndex {
+    var block: UInt32 = 0     // first logical block covered by this index
+    var leafLow: UInt32 = 0   // physical block number (low 32 bits)
+    var leafHigh: UInt16 = 0  // physical block number (high 16 bits)
+    var unused: UInt16 = 0
+}
+
 private enum EXT4FileType: UInt8 {
     case unknown = 0
     case regular = 1
@@ -669,19 +677,39 @@ public final class EXT4Editor {
         let headerSize = MemoryLayout<EXT4ExtentHeader>.size
         let leafSize = MemoryLayout<EXT4ExtentLeaf>.size
 
+        let indexSize = MemoryLayout<EXT4ExtentIndex>.size
+
         if header.depth == 0 {
-            // Direct extents
             for i in 0..<Int(header.entries) {
                 let leafOffset = headerSize + i * leafSize
                 guard leafOffset + leafSize <= blockData.count else { break }
-
-                let leaf = blockData.subdata(in: leafOffset..<leafOffset + leafSize).withUnsafeBytes { ptr in
-                    ptr.load(as: EXT4ExtentLeaf.self)
+                let leaf = blockData.subdata(in: leafOffset..<leafOffset + leafSize).withUnsafeBytes {
+                    $0.load(as: EXT4ExtentLeaf.self)
                 }
                 extents.append((start: leaf.startLow, end: leaf.startLow + UInt32(leaf.length)))
             }
+        } else if header.depth == 1 {
+            for i in 0..<Int(header.entries) {
+                let indexOffset = headerSize + i * indexSize
+                guard indexOffset + indexSize <= blockData.count else { break }
+                let index = blockData.subdata(in: indexOffset..<indexOffset + indexSize).withUnsafeBytes {
+                    $0.load(as: EXT4ExtentIndex.self)
+                }
+                let leafBlockOffset = UInt64(index.leafLow) * UInt64(blockSize)
+                try handle.seek(toOffset: leafBlockOffset)
+                guard let lpData = try handle.read(upToCount: Int(blockSize)) else { continue }
+                let lpHeader = lpData.withUnsafeBytes { $0.load(as: EXT4ExtentHeader.self) }
+                guard lpHeader.magic == EXT4Constants.extentHeaderMagic, lpHeader.depth == 0 else { continue }
+                for j in 0..<Int(lpHeader.entries) {
+                    let leafOffset = headerSize + j * leafSize
+                    guard leafOffset + leafSize <= lpData.count else { break }
+                    let leaf = lpData.subdata(in: leafOffset..<leafOffset + leafSize).withUnsafeBytes {
+                        $0.load(as: EXT4ExtentLeaf.self)
+                    }
+                    extents.append((start: leaf.startLow, end: leaf.startLow + UInt32(leaf.length)))
+                }
+            }
         }
-        // For depth > 0, we'd need to follow extent index nodes (not implemented for MVP)
 
         return extents
     }
@@ -981,54 +1009,211 @@ public final class EXT4Editor {
         return tupleFromArray(blockData)
     }
 
-    /// Append a new allocated block to a directory inode's inline extent tree.
+    /// Append a new allocated block to a directory inode's extent tree.
+    /// Promotes from depth=0 to depth=1 when the inline leaf slots are exhausted.
     private func appendBlockToDirectoryInode(_ inode: inout EXT4Inode, newBlock: UInt32) throws {
         var bd = withUnsafeBytes(of: inode.block) { Data($0) }
         let headerSize = MemoryLayout<EXT4ExtentHeader>.size
         let leafSize = MemoryLayout<EXT4ExtentLeaf>.size
+        let indexSize = MemoryLayout<EXT4ExtentIndex>.size
 
         var header = bd.withUnsafeBytes { $0.load(as: EXT4ExtentHeader.self) }
-        guard header.magic == EXT4Constants.extentHeaderMagic, header.depth == 0 else {
-            throw EXT4EditorError.notImplemented("Cannot grow directory with non-inline extent tree")
+        guard header.magic == EXT4Constants.extentHeaderMagic else {
+            throw EXT4EditorError.notImplemented("Cannot grow directory with non-extent inode")
         }
 
-        let lastLeafOffset = headerSize + Int(header.entries - 1) * leafSize
-        var lastLeaf = bd.subdata(in: lastLeafOffset..<lastLeafOffset + leafSize).withUnsafeBytes {
-            $0.load(as: EXT4ExtentLeaf.self)
-        }
-
-        if lastLeaf.startLow + UInt32(lastLeaf.length) == newBlock {
-            // Contiguous — just extend the last extent
-            lastLeaf.length += 1
-            withUnsafeBytes(of: lastLeaf) { ptr in
-                for (i, byte) in ptr.enumerated() { bd[lastLeafOffset + i] = byte }
+        if header.depth == 0 {
+            let lastLeafOffset = headerSize + Int(header.entries - 1) * leafSize
+            var lastLeaf = bd.subdata(in: lastLeafOffset..<lastLeafOffset + leafSize).withUnsafeBytes {
+                $0.load(as: EXT4ExtentLeaf.self)
             }
+
+            if lastLeaf.startLow + UInt32(lastLeaf.length) == newBlock {
+                // Contiguous — extend last extent
+                lastLeaf.length += 1
+                withUnsafeBytes(of: lastLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { bd[lastLeafOffset + i] = byte }
+                }
+                inode.block = bd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
+            } else if header.entries < header.max {
+                // Non-contiguous, space available — add new inline leaf
+                var logicalBlock: UInt32 = 0
+                for i in 0..<Int(header.entries) {
+                    let off = headerSize + i * leafSize
+                    let leaf = bd.subdata(in: off..<off + leafSize).withUnsafeBytes { $0.load(as: EXT4ExtentLeaf.self) }
+                    logicalBlock = leaf.block + UInt32(leaf.length)
+                }
+                var newLeaf = EXT4ExtentLeaf()
+                newLeaf.block = logicalBlock
+                newLeaf.length = 1
+                newLeaf.startLow = newBlock
+                let off = headerSize + Int(header.entries) * leafSize
+                withUnsafeBytes(of: newLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { bd[off + i] = byte }
+                }
+                header.entries += 1
+                withUnsafeBytes(of: header) { ptr in
+                    for (i, byte) in ptr.enumerated() { bd[i] = byte }
+                }
+                inode.block = bd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
+            } else {
+                // Inline leaf slots exhausted — promote to depth=1.
+                // Allocate one block to hold all existing leaves plus the new leaf.
+                let lpBlocks = try allocateBlocks(count: 1)
+                let lpBlock = lpBlocks[0]
+
+                let leavesPerBlock = (Int(blockSize) - headerSize) / leafSize
+                var lpData = Data(repeating: 0, count: Int(blockSize))
+
+                // Compute logical block offset for the new leaf
+                var logicalBlock: UInt32 = 0
+                for i in 0..<Int(header.entries) {
+                    let off = headerSize + i * leafSize
+                    let leaf = bd.subdata(in: off..<off + leafSize).withUnsafeBytes { $0.load(as: EXT4ExtentLeaf.self) }
+                    logicalBlock = leaf.block + UInt32(leaf.length)
+                }
+
+                // Write leaf page header
+                var lpHeader = EXT4ExtentHeader()
+                lpHeader.magic = EXT4Constants.extentHeaderMagic
+                lpHeader.entries = header.entries + 1
+                lpHeader.max = UInt16(leavesPerBlock)
+                lpHeader.depth = 0
+                withUnsafeBytes(of: lpHeader) { ptr in
+                    for (i, byte) in ptr.enumerated() { lpData[i] = byte }
+                }
+                // Copy existing inline leaves
+                for i in 0..<Int(header.entries) {
+                    let off = headerSize + i * leafSize
+                    for j in 0..<leafSize { lpData[off + j] = bd[off + j] }
+                }
+                // Append the new leaf
+                var newLeaf = EXT4ExtentLeaf()
+                newLeaf.block = logicalBlock
+                newLeaf.length = 1
+                newLeaf.startLow = newBlock
+                let newLeafOff = headerSize + Int(header.entries) * leafSize
+                withUnsafeBytes(of: newLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { lpData[newLeafOff + i] = byte }
+                }
+
+                try handle.seek(toOffset: UInt64(lpBlock) * UInt64(blockSize))
+                try handle.write(contentsOf: lpData)
+
+                // Rewrite inode block field as depth=1 with one index entry
+                var newBd = Data(repeating: 0, count: 60)
+                var newHeader = EXT4ExtentHeader()
+                newHeader.magic = EXT4Constants.extentHeaderMagic
+                newHeader.entries = 1
+                newHeader.max = UInt16((60 - headerSize) / indexSize)
+                newHeader.depth = 1
+                withUnsafeBytes(of: newHeader) { ptr in
+                    for (i, byte) in ptr.enumerated() { newBd[i] = byte }
+                }
+                var idx = EXT4ExtentIndex()
+                idx.block = 0
+                idx.leafLow = lpBlock
+                withUnsafeBytes(of: idx) { ptr in
+                    for (i, byte) in ptr.enumerated() { newBd[headerSize + i] = byte }
+                }
+                inode.block = newBd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
+                // Extra block used for the leaf page
+                inode.blocksLow += blockSize / 512
+                try updateSuperBlockAfterAllocation(blocksUsed: 1, inodesUsed: 0)
+            }
+        } else if header.depth == 1 {
+            // Find the last index entry and its leaf block
+            let lastIdxOff = headerSize + Int(header.entries - 1) * indexSize
+            let lastIdx = bd.subdata(in: lastIdxOff..<lastIdxOff + indexSize).withUnsafeBytes {
+                $0.load(as: EXT4ExtentIndex.self)
+            }
+            let lpBlockNum = lastIdx.leafLow
+            let lpOffset = UInt64(lpBlockNum) * UInt64(blockSize)
+            try handle.seek(toOffset: lpOffset)
+            guard var lpData = try handle.read(upToCount: Int(blockSize)) else {
+                throw EXT4EditorError.readError("Failed to read extent leaf block")
+            }
+            var lpHeader = lpData.withUnsafeBytes { $0.load(as: EXT4ExtentHeader.self) }
+            guard lpHeader.magic == EXT4Constants.extentHeaderMagic, lpHeader.depth == 0 else {
+                throw EXT4EditorError.readError("Invalid extent leaf block header")
+            }
+
+            let lastLeafOff = headerSize + Int(lpHeader.entries - 1) * leafSize
+            var lastLeaf = lpData.subdata(in: lastLeafOff..<lastLeafOff + leafSize).withUnsafeBytes {
+                $0.load(as: EXT4ExtentLeaf.self)
+            }
+
+            if lastLeaf.startLow + UInt32(lastLeaf.length) == newBlock {
+                // Contiguous — extend last leaf in this leaf block
+                lastLeaf.length += 1
+                withUnsafeBytes(of: lastLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { lpData[lastLeafOff + i] = byte }
+                }
+            } else if lpHeader.entries < lpHeader.max {
+                // Space in existing leaf block — add a new leaf
+                let logicalBlock = lastLeaf.block + UInt32(lastLeaf.length)
+                var newLeaf = EXT4ExtentLeaf()
+                newLeaf.block = logicalBlock
+                newLeaf.length = 1
+                newLeaf.startLow = newBlock
+                let newLeafOff = headerSize + Int(lpHeader.entries) * leafSize
+                withUnsafeBytes(of: newLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { lpData[newLeafOff + i] = byte }
+                }
+                lpHeader.entries += 1
+                withUnsafeBytes(of: lpHeader) { ptr in
+                    for (i, byte) in ptr.enumerated() { lpData[i] = byte }
+                }
+            } else if header.entries < header.max {
+                // Leaf block full — add a new index entry pointing to a fresh leaf block
+                let newLpBlocks = try allocateBlocks(count: 1)
+                let newLpBlock = newLpBlocks[0]
+                let leavesPerBlock = (Int(blockSize) - headerSize) / leafSize
+
+                let logicalBlock = lastLeaf.block + UInt32(lastLeaf.length)
+                var newLpData = Data(repeating: 0, count: Int(blockSize))
+                var newLpHeader = EXT4ExtentHeader()
+                newLpHeader.magic = EXT4Constants.extentHeaderMagic
+                newLpHeader.entries = 1
+                newLpHeader.max = UInt16(leavesPerBlock)
+                newLpHeader.depth = 0
+                withUnsafeBytes(of: newLpHeader) { ptr in
+                    for (i, byte) in ptr.enumerated() { newLpData[i] = byte }
+                }
+                var newLeaf = EXT4ExtentLeaf()
+                newLeaf.block = logicalBlock
+                newLeaf.length = 1
+                newLeaf.startLow = newBlock
+                withUnsafeBytes(of: newLeaf) { ptr in
+                    for (i, byte) in ptr.enumerated() { newLpData[headerSize + i] = byte }
+                }
+                try handle.seek(toOffset: UInt64(newLpBlock) * UInt64(blockSize))
+                try handle.write(contentsOf: newLpData)
+
+                var newIdx = EXT4ExtentIndex()
+                newIdx.block = logicalBlock
+                newIdx.leafLow = newLpBlock
+                let newIdxOff = headerSize + Int(header.entries) * indexSize
+                withUnsafeBytes(of: newIdx) { ptr in
+                    for (i, byte) in ptr.enumerated() { bd[newIdxOff + i] = byte }
+                }
+                header.entries += 1
+                withUnsafeBytes(of: header) { ptr in
+                    for (i, byte) in ptr.enumerated() { bd[i] = byte }
+                }
+                inode.block = bd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
+                inode.blocksLow += blockSize / 512
+                try updateSuperBlockAfterAllocation(blocksUsed: 1, inodesUsed: 0)
+            } else {
+                throw EXT4EditorError.notImplemented("Directory too large: extent index tree full")
+            }
+
+            try handle.seek(toOffset: lpOffset)
+            try handle.write(contentsOf: lpData)
         } else {
-            // Non-contiguous — add a new extent leaf
-            guard header.entries < header.max else {
-                throw EXT4EditorError.directoryFull("Directory inline extent tree is full")
-            }
-            var logicalBlock: UInt32 = 0
-            for i in 0..<Int(header.entries) {
-                let off = headerSize + i * leafSize
-                let leaf = bd.subdata(in: off..<off + leafSize).withUnsafeBytes { $0.load(as: EXT4ExtentLeaf.self) }
-                logicalBlock = leaf.block + UInt32(leaf.length)
-            }
-            var newLeaf = EXT4ExtentLeaf()
-            newLeaf.block = logicalBlock
-            newLeaf.length = 1
-            newLeaf.startLow = newBlock
-            let newLeafOffset = headerSize + Int(header.entries) * leafSize
-            withUnsafeBytes(of: newLeaf) { ptr in
-                for (i, byte) in ptr.enumerated() { bd[newLeafOffset + i] = byte }
-            }
-            header.entries += 1
-            withUnsafeBytes(of: header) { ptr in
-                for (i, byte) in ptr.enumerated() { bd[i] = byte }
-            }
+            throw EXT4EditorError.notImplemented("Cannot grow directory with extent tree depth > 1")
         }
 
-        inode.block = bd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
         inode.blocksLow += blockSize / 512
     }
 

--- a/Sources/socktainer/Utilities/EXT4Editor.swift
+++ b/Sources/socktainer/Utilities/EXT4Editor.swift
@@ -981,129 +981,181 @@ public final class EXT4Editor {
         return tupleFromArray(blockData)
     }
 
+    /// Append a new allocated block to a directory inode's inline extent tree.
+    private func appendBlockToDirectoryInode(_ inode: inout EXT4Inode, newBlock: UInt32) throws {
+        var bd = withUnsafeBytes(of: inode.block) { Data($0) }
+        let headerSize = MemoryLayout<EXT4ExtentHeader>.size
+        let leafSize = MemoryLayout<EXT4ExtentLeaf>.size
+
+        var header = bd.withUnsafeBytes { $0.load(as: EXT4ExtentHeader.self) }
+        guard header.magic == EXT4Constants.extentHeaderMagic, header.depth == 0 else {
+            throw EXT4EditorError.notImplemented("Cannot grow directory with non-inline extent tree")
+        }
+
+        let lastLeafOffset = headerSize + Int(header.entries - 1) * leafSize
+        var lastLeaf = bd.subdata(in: lastLeafOffset..<lastLeafOffset + leafSize).withUnsafeBytes {
+            $0.load(as: EXT4ExtentLeaf.self)
+        }
+
+        if lastLeaf.startLow + UInt32(lastLeaf.length) == newBlock {
+            // Contiguous — just extend the last extent
+            lastLeaf.length += 1
+            withUnsafeBytes(of: lastLeaf) { ptr in
+                for (i, byte) in ptr.enumerated() { bd[lastLeafOffset + i] = byte }
+            }
+        } else {
+            // Non-contiguous — add a new extent leaf
+            guard header.entries < header.max else {
+                throw EXT4EditorError.directoryFull("Directory inline extent tree is full")
+            }
+            var logicalBlock: UInt32 = 0
+            for i in 0..<Int(header.entries) {
+                let off = headerSize + i * leafSize
+                let leaf = bd.subdata(in: off..<off + leafSize).withUnsafeBytes { $0.load(as: EXT4ExtentLeaf.self) }
+                logicalBlock = leaf.block + UInt32(leaf.length)
+            }
+            var newLeaf = EXT4ExtentLeaf()
+            newLeaf.block = logicalBlock
+            newLeaf.length = 1
+            newLeaf.startLow = newBlock
+            let newLeafOffset = headerSize + Int(header.entries) * leafSize
+            withUnsafeBytes(of: newLeaf) { ptr in
+                for (i, byte) in ptr.enumerated() { bd[newLeafOffset + i] = byte }
+            }
+            header.entries += 1
+            withUnsafeBytes(of: header) { ptr in
+                for (i, byte) in ptr.enumerated() { bd[i] = byte }
+            }
+        }
+
+        inode.block = bd.withUnsafeBytes { tupleFromArray(Array($0.prefix(60))) }
+        inode.blocksLow += blockSize / 512
+    }
+
+    private func writeDirectoryEntry(
+        into blockData: inout Data,
+        atOffset newEntryOffset: Int,
+        recordLen: UInt16,
+        childInodeNum: UInt32,
+        nameBytes: [UInt8],
+        fileType: EXT4FileType
+    ) {
+        let newEntryAlignedSize = (MemoryLayout<EXT4DirectoryEntry>.size + nameBytes.count + 3) & ~3
+        var newEntry = EXT4DirectoryEntry()
+        newEntry.inode = childInodeNum
+        newEntry.recordLength = recordLen
+        newEntry.nameLength = UInt8(nameBytes.count)
+        newEntry.fileType = fileType.rawValue
+
+        withUnsafeBytes(of: newEntry) { ptr in
+            for (i, byte) in ptr.enumerated() { blockData[newEntryOffset + i] = byte }
+        }
+        for (i, byte) in nameBytes.enumerated() {
+            blockData[newEntryOffset + MemoryLayout<EXT4DirectoryEntry>.size + i] = byte
+        }
+        let entryEnd = newEntryOffset + newEntryAlignedSize
+        for i in (newEntryOffset + MemoryLayout<EXT4DirectoryEntry>.size + nameBytes.count)..<entryEnd {
+            if i < blockData.count { blockData[i] = 0 }
+        }
+    }
+
     private func addDirectoryEntry(
         parentInodeNum: UInt32,
         childInodeNum: UInt32,
         childName: String,
         fileType: EXT4FileType
     ) throws {
-        let parentInode = try readInode(number: parentInodeNum)
+        var parentInode = try readInode(number: parentInodeNum)
         let extents = try getExtents(from: parentInode)
 
-        guard let lastExtent = extents.last, lastExtent.end > lastExtent.start else {
-            throw EXT4EditorError.directoryFull("Parent directory has no blocks")
-        }
-
-        // Read the last block of the directory
-        let lastBlock = lastExtent.end - 1
-        let blockOffset = UInt64(lastBlock) * UInt64(blockSize)
-        try handle.seek(toOffset: blockOffset)
-        guard var blockData = try handle.read(upToCount: Int(blockSize)) else {
-            throw EXT4EditorError.readError("Failed to read directory block")
-        }
-
-        // Parse all directory entries to find the last REAL entry (with inode != 0)
-        // and any sentinel entry (inode == 0) or free space at the end
-        var offset = 0
-        var lastRealEntryOffset = -1
-        var lastRealEntryRecordLen: UInt16 = 0
-        var lastRealEntryNameLen: UInt8 = 0
-        var sentinelOffset = -1
-        var sentinelRecordLen: UInt16 = 0
-
-        while offset < Int(blockSize) {
-            guard offset + MemoryLayout<EXT4DirectoryEntry>.size <= blockData.count else { break }
-
-            let entryData = blockData.subdata(in: offset..<offset + MemoryLayout<EXT4DirectoryEntry>.size)
-            let entry = entryData.withUnsafeBytes { ptr in
-                ptr.load(as: EXT4DirectoryEntry.self)
-            }
-
-            if entry.recordLength == 0 {
-                // No more entries
-                break
-            }
-
-            if entry.inode == 0 {
-                // This is a sentinel/free entry - we can use this space
-                sentinelOffset = offset
-                sentinelRecordLen = entry.recordLength
-                break
-            }
-
-            // This is a real entry
-            lastRealEntryOffset = offset
-            lastRealEntryRecordLen = entry.recordLength
-            lastRealEntryNameLen = entry.nameLength
-            offset += Int(entry.recordLength)
-        }
-
-        // Calculate space needed for new entry
         let nameBytes = Array(childName.utf8)
         let newEntryMinSize = MemoryLayout<EXT4DirectoryEntry>.size + nameBytes.count
         let newEntryAlignedSize = (newEntryMinSize + 3) & ~3
 
-        var newEntryOffset: Int
-        var newRecordLen: UInt16
-
-        if sentinelOffset >= 0 {
-            // There's a sentinel entry - check if we can fit in its space
-            guard Int(sentinelRecordLen) >= newEntryAlignedSize else {
-                throw EXT4EditorError.directoryFull("No space in directory block for new entry")
+        // Try to fit the new entry in the existing last block
+        if let lastExtent = extents.last, lastExtent.end > lastExtent.start {
+            let lastBlock = lastExtent.end - 1
+            let blockOffset = UInt64(lastBlock) * UInt64(blockSize)
+            try handle.seek(toOffset: blockOffset)
+            guard var blockData = try handle.read(upToCount: Int(blockSize)) else {
+                throw EXT4EditorError.readError("Failed to read directory block")
             }
-            newEntryOffset = sentinelOffset
-            newRecordLen = sentinelRecordLen
-        } else if lastRealEntryOffset >= 0 {
-            // No sentinel - check if we can split the last real entry's record
-            let lastEntryActualSize = (MemoryLayout<EXT4DirectoryEntry>.size + Int(lastRealEntryNameLen) + 3) & ~3
-            let availableSpace = Int(lastRealEntryRecordLen) - lastEntryActualSize
 
-            guard availableSpace >= newEntryAlignedSize else {
-                throw EXT4EditorError.directoryFull("No space in directory block for new entry")
+            // Scan for free space in the last block
+            var offset = 0
+            var lastRealEntryOffset = -1
+            var lastRealEntryRecordLen: UInt16 = 0
+            var lastRealEntryNameLen: UInt8 = 0
+            var sentinelOffset = -1
+            var sentinelRecordLen: UInt16 = 0
+
+            while offset < Int(blockSize) {
+                guard offset + MemoryLayout<EXT4DirectoryEntry>.size <= blockData.count else { break }
+                let entry = blockData.subdata(in: offset..<offset + MemoryLayout<EXT4DirectoryEntry>.size)
+                    .withUnsafeBytes { $0.load(as: EXT4DirectoryEntry.self) }
+
+                if entry.recordLength == 0 { break }
+
+                if entry.inode == 0 {
+                    sentinelOffset = offset
+                    sentinelRecordLen = entry.recordLength
+                    break
+                }
+
+                lastRealEntryOffset = offset
+                lastRealEntryRecordLen = entry.recordLength
+                lastRealEntryNameLen = entry.nameLength
+                offset += Int(entry.recordLength)
             }
-            // Shrink last entry's record length to its actual size
-            let updatedRecordLen = UInt16(lastEntryActualSize)
-            blockData[lastRealEntryOffset + 4] = UInt8(updatedRecordLen & 0xFF)
-            blockData[lastRealEntryOffset + 5] = UInt8((updatedRecordLen >> 8) & 0xFF)
 
-            newEntryOffset = lastRealEntryOffset + lastEntryActualSize
-            newRecordLen = UInt16(Int(blockSize) - newEntryOffset)
-        } else {
-            // Empty directory block (shouldn't happen for valid directories)
-            newEntryOffset = 0
-            newRecordLen = UInt16(blockSize)
+            var newEntryOffset: Int? = nil
+            var newRecordLen: UInt16 = 0
+
+            if sentinelOffset >= 0, Int(sentinelRecordLen) >= newEntryAlignedSize {
+                newEntryOffset = sentinelOffset
+                newRecordLen = sentinelRecordLen
+            } else if lastRealEntryOffset >= 0 {
+                let lastEntryActualSize = (MemoryLayout<EXT4DirectoryEntry>.size + Int(lastRealEntryNameLen) + 3) & ~3
+                let available = Int(lastRealEntryRecordLen) - lastEntryActualSize
+                if available >= newEntryAlignedSize {
+                    let updatedRecordLen = UInt16(lastEntryActualSize)
+                    blockData[lastRealEntryOffset + 4] = UInt8(updatedRecordLen & 0xFF)
+                    blockData[lastRealEntryOffset + 5] = UInt8((updatedRecordLen >> 8) & 0xFF)
+                    newEntryOffset = lastRealEntryOffset + lastEntryActualSize
+                    newRecordLen = UInt16(Int(blockSize) - newEntryOffset!)
+                }
+            } else {
+                // Empty block
+                newEntryOffset = 0
+                newRecordLen = UInt16(blockSize)
+            }
+
+            if let entryOffset = newEntryOffset {
+                writeDirectoryEntry(
+                    into: &blockData, atOffset: entryOffset, recordLen: newRecordLen,
+                    childInodeNum: childInodeNum, nameBytes: nameBytes, fileType: fileType)
+                try handle.seek(toOffset: blockOffset)
+                try handle.write(contentsOf: blockData)
+                return
+            }
         }
 
-        // Create new directory entry
-        var newEntry = EXT4DirectoryEntry()
-        newEntry.inode = childInodeNum
-        newEntry.recordLength = newRecordLen
-        newEntry.nameLength = UInt8(nameBytes.count)
-        newEntry.fileType = fileType.rawValue
+        // No space in any existing block — allocate a new directory block
+        let newBlocks = try allocateBlocks(count: 1)
+        let newBlock = newBlocks[0]
 
-        // Write new entry header
-        withUnsafeBytes(of: newEntry) { ptr in
-            for (i, byte) in ptr.enumerated() {
-                blockData[newEntryOffset + i] = byte
-            }
-        }
+        var newBlockData = Data(repeating: 0, count: Int(blockSize))
+        writeDirectoryEntry(
+            into: &newBlockData, atOffset: 0, recordLen: UInt16(blockSize),
+            childInodeNum: childInodeNum, nameBytes: nameBytes, fileType: fileType)
 
-        // Write name
-        for (i, byte) in nameBytes.enumerated() {
-            blockData[newEntryOffset + MemoryLayout<EXT4DirectoryEntry>.size + i] = byte
-        }
+        let newBlockOffset = UInt64(newBlock) * UInt64(blockSize)
+        try handle.seek(toOffset: newBlockOffset)
+        try handle.write(contentsOf: newBlockData)
 
-        // Zero out remaining bytes of the entry (padding)
-        let entryEnd = newEntryOffset + newEntryAlignedSize
-        for i in (newEntryOffset + MemoryLayout<EXT4DirectoryEntry>.size + nameBytes.count)..<entryEnd {
-            if i < blockData.count {
-                blockData[i] = 0
-            }
-        }
-
-        // Write updated block
-        try handle.seek(toOffset: blockOffset)
-        try handle.write(contentsOf: blockData)
+        try appendBlockToDirectoryInode(&parentInode, newBlock: newBlock)
+        try writeInode(number: parentInodeNum, inode: &parentInode)
+        try updateSuperBlockAfterAllocation(blocksUsed: 1, inodesUsed: 0)
     }
 
     private func writeInitialDirectoryEntries(

--- a/Sources/socktainer/Utilities/EXT4Editor.swift
+++ b/Sources/socktainer/Utilities/EXT4Editor.swift
@@ -528,15 +528,51 @@ public final class EXT4Editor {
         try handle.write(contentsOf: padding)
     }
 
-    private func resolvePathToInode(_ path: String) throws -> UInt32 {
+    private func readSymlinkTarget(inode: EXT4Inode) throws -> String {
+        let size = Int(inode.sizeLow)
+        // Short symlink: target stored directly in block field (no allocated blocks)
+        if inode.blocksLow == 0 {
+            let bytes = withUnsafeBytes(of: inode.block) { ptr -> [UInt8] in
+                Array(ptr.prefix(size))
+            }
+            guard let target = String(bytes: bytes, encoding: .utf8) else {
+                throw EXT4EditorError.readError("Invalid symlink target encoding")
+            }
+            return target
+        }
+        // Long symlink: target stored in data blocks
+        let extents = try getExtents(from: inode)
+        var data = Data()
+        for (startBlock, endBlock) in extents {
+            for blockNum in startBlock..<endBlock {
+                let blockOffset = UInt64(blockNum) * UInt64(blockSize)
+                try handle.seek(toOffset: blockOffset)
+                guard let blockData = try handle.read(upToCount: Int(blockSize)) else {
+                    throw EXT4EditorError.readError("Failed to read symlink block")
+                }
+                data.append(blockData)
+            }
+        }
+        guard let target = String(data: data.prefix(size), encoding: .utf8) else {
+            throw EXT4EditorError.readError("Invalid symlink target encoding")
+        }
+        return target
+    }
+
+    private func resolvePathToInode(_ path: String, depth: Int = 0) throws -> UInt32 {
+        guard depth < 40 else {
+            throw EXT4EditorError.invalidPath("Symlink loop detected resolving: \(path)")
+        }
+
         if path == "/" || path.isEmpty {
             return EXT4Constants.rootInode
         }
 
         var currentInode = EXT4Constants.rootInode
+        var currentPath = "/"
         let components = path.split(separator: "/").map(String.init)
 
-        for component in components {
+        for (index, component) in components.enumerated() {
             if component.isEmpty || component == "." {
                 continue
             }
@@ -550,7 +586,23 @@ public final class EXT4Editor {
             guard let entry = entries.first(where: { $0.name == component }) else {
                 throw EXT4EditorError.parentNotFound(path)
             }
+
+            let inode = try readInode(number: entry.inode)
+            if (inode.mode & 0xF000) == EXT4ModeFlag.S_IFLNK.rawValue {
+                let target = try readSymlinkTarget(inode: inode)
+                let remaining = components[(index + 1)...].joined(separator: "/")
+                let resolvedTarget: String
+                if target.hasPrefix("/") {
+                    resolvedTarget = remaining.isEmpty ? target : "\(target)/\(remaining)"
+                } else {
+                    let base = currentPath == "/" ? "" : currentPath
+                    resolvedTarget = remaining.isEmpty ? "\(base)/\(target)" : "\(base)/\(target)/\(remaining)"
+                }
+                return try resolvePathToInode(resolvedTarget, depth: depth + 1)
+            }
+
             currentInode = entry.inode
+            currentPath = currentPath == "/" ? "/\(component)" : "\(currentPath)/\(component)"
         }
 
         return currentInode

--- a/Tests/socktainerTests/Utilitites/ArchiveUtilityTests.swift
+++ b/Tests/socktainerTests/Utilitites/ArchiveUtilityTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+struct ArchiveUtilityTests {
+
+    // MARK: - destinationPath
+
+    @Test("nil entry returns nil")
+    func nilEntryReturnsNil() {
+        #expect(ArchiveUtility.destinationPath(for: nil, under: "/target") == nil)
+    }
+
+    @Test("'.' entry maps to destination itself")
+    func dotEntryMapsToDestination() {
+        #expect(ArchiveUtility.destinationPath(for: ".", under: "/var/run/act") == "/var/run/act")
+    }
+
+    @Test("'/' entry maps to destination itself")
+    func slashEntryMapsToDestination() {
+        #expect(ArchiveUtility.destinationPath(for: "/", under: "/var/run/act") == "/var/run/act")
+    }
+
+    @Test("'./file.txt' is placed directly under destination")
+    func dotSlashFileUnderDestination() {
+        #expect(
+            ArchiveUtility.destinationPath(for: "./file.txt", under: "/var/run/act")
+                == "/var/run/act/file.txt"
+        )
+    }
+
+    @Test("bare 'file.txt' is placed directly under destination")
+    func bareFileUnderDestination() {
+        #expect(
+            ArchiveUtility.destinationPath(for: "file.txt", under: "/var/run/act")
+                == "/var/run/act/file.txt"
+        )
+    }
+
+    @Test("nested './sub/dir/file.txt' preserves hierarchy under destination")
+    func nestedEntryPreservesHierarchy() {
+        #expect(
+            ArchiveUtility.destinationPath(for: "./sub/dir/file.txt", under: "/target")
+                == "/target/sub/dir/file.txt"
+        )
+    }
+
+    @Test("destination '/' returns entry path directly")
+    func rootDestinationReturnsEntryPath() {
+        #expect(ArchiveUtility.destinationPath(for: "./file.txt", under: "/") == "/file.txt")
+    }
+
+    @Test("absolute entry path is placed under destination")
+    func absoluteEntryUnderDestination() {
+        #expect(
+            ArchiveUtility.destinationPath(for: "/file.txt", under: "/target")
+                == "/target/file.txt"
+        )
+    }
+}

--- a/Tests/socktainerTests/Utilitites/ClientArchiveServiceTests.swift
+++ b/Tests/socktainerTests/Utilitites/ClientArchiveServiceTests.swift
@@ -1,0 +1,213 @@
+import ContainerizationEXT4
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+struct ClientArchiveServiceTests {
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("archive-service-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Builds a minimal ext4 rootfs at `appSupportPath/containers/{id}/rootfs.ext4`
+    /// with `/var/run` pre-created so tests can extract into paths beneath it.
+    private func createRootfs(containerId: String, appSupportPath: URL) throws -> URL {
+        let containerDir = appSupportPath
+            .appendingPathComponent("containers")
+            .appendingPathComponent(containerId)
+        try FileManager.default.createDirectory(at: containerDir, withIntermediateDirectories: true)
+
+        let rootfsPath = containerDir.appendingPathComponent("rootfs.ext4")
+        let formatter = try EXT4.Formatter(
+            FilePath(rootfsPath.path),
+            blockSize: 4096,
+            minDiskSize: 10 * 1024 * 1024
+        )
+        try formatter.create(path: FilePath("/var"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+        try formatter.create(path: FilePath("/var/run"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+        try formatter.close()
+
+        return rootfsPath
+    }
+
+    /// Creates a tar archive containing a single file `hello.txt` with the given content.
+    private func createSingleFileTar(content: String, in tempDir: URL) throws -> URL {
+        let stagingDir = tempDir.appendingPathComponent("staging-\(UUID().uuidString)")
+        let tarPath = tempDir.appendingPathComponent("input-\(UUID().uuidString).tar")
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        try content.write(
+            to: stagingDir.appendingPathComponent("hello.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try ArchiveUtility.create(tarPath: tarPath, from: stagingDir)
+        try? FileManager.default.removeItem(at: stagingDir)
+        return tarPath
+    }
+
+    private func fileExists(rootfsPath: URL, path: String) throws -> Bool {
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
+        return reader.exists(FilePath(path))
+    }
+
+    private func readFile(rootfsPath: URL, path: String) throws -> String {
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
+        let data = try reader.readFile(at: FilePath(path))
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - putArchive
+
+    @Test("putArchive creates destination directory and places files when path has no trailing slash")
+    func putArchiveNoTrailingSlash() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let containerId = "c-\(UUID().uuidString)"
+        let service = ClientArchiveService(appSupportPath: tempDir)
+        let rootfsPath = try createRootfs(containerId: containerId, appSupportPath: tempDir)
+        let tarPath = try createSingleFileTar(content: "hello\n", in: tempDir)
+
+        try await service.putArchive(
+            containerId: containerId,
+            path: "/var/run/act",
+            tarPath: tarPath,
+            noOverwriteDirNonDir: false
+        )
+
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/run/act"))
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/run/act/hello.txt"))
+        #expect(try readFile(rootfsPath: rootfsPath, path: "/var/run/act/hello.txt") == "hello\n")
+    }
+
+    @Test("putArchive creates destination directory and places files when path has trailing slash")
+    func putArchiveTrailingSlash() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let containerId = "c-\(UUID().uuidString)"
+        let service = ClientArchiveService(appSupportPath: tempDir)
+        let rootfsPath = try createRootfs(containerId: containerId, appSupportPath: tempDir)
+        let tarPath = try createSingleFileTar(content: "hello\n", in: tempDir)
+
+        try await service.putArchive(
+            containerId: containerId,
+            path: "/var/run/act/",
+            tarPath: tarPath,
+            noOverwriteDirNonDir: false
+        )
+
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/run/act/hello.txt"))
+        #expect(try readFile(rootfsPath: rootfsPath, path: "/var/run/act/hello.txt") == "hello\n")
+    }
+
+    @Test("putArchive preserves pre-existing files in the container")
+    func putArchivePreservesExistingFiles() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let containerId = "c-\(UUID().uuidString)"
+        let service = ClientArchiveService(appSupportPath: tempDir)
+        let rootfsPath = try createRootfs(containerId: containerId, appSupportPath: tempDir)
+
+        // Add a pre-existing file to the container's /var directory
+        let preExistingContent = "pre-existing\n"
+        let containerDir = tempDir.appendingPathComponent("containers").appendingPathComponent(containerId)
+        let existingFormatter = try EXT4.Formatter(
+            FilePath(rootfsPath.path),
+            blockSize: 4096,
+            minDiskSize: 10 * 1024 * 1024
+        )
+        let preExistingData = Data(preExistingContent.utf8)
+        let stream = InputStream(data: preExistingData)
+        stream.open()
+        try existingFormatter.create(
+            path: FilePath("/var/existing.txt"),
+            mode: EXT4.Inode.Mode(.S_IFREG, 0o644),
+            buf: stream
+        )
+        stream.close()
+        try existingFormatter.close()
+        _ = containerDir  // silence unused warning
+
+        let tarPath = try createSingleFileTar(content: "new\n", in: tempDir)
+
+        try await service.putArchive(
+            containerId: containerId,
+            path: "/var/run/newdir",
+            tarPath: tarPath,
+            noOverwriteDirNonDir: false
+        )
+
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/existing.txt"))
+        #expect(try readFile(rootfsPath: rootfsPath, path: "/var/existing.txt") == preExistingContent)
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/run/newdir/hello.txt"))
+    }
+
+    @Test("putArchive throws rootfsNotFound when container has no rootfs")
+    func putArchiveRootfsNotFound() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let service = ClientArchiveService(appSupportPath: tempDir)
+        let tarPath = try createSingleFileTar(content: "x", in: tempDir)
+
+        await #expect(throws: ClientArchiveError.self) {
+            try await service.putArchive(
+                containerId: "nonexistent-container",
+                path: "/some/path",
+                tarPath: tarPath,
+                noOverwriteDirNonDir: false
+            )
+        }
+    }
+
+    @Test("putArchive with noOverwriteDirNonDir rejects overwriting a directory with a file")
+    func putArchiveNoOverwriteDirNonDir() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let containerId = "c-\(UUID().uuidString)"
+        let service = ClientArchiveService(appSupportPath: tempDir)
+        let rootfsPath = try createRootfs(containerId: containerId, appSupportPath: tempDir)
+
+        // First PUT: create /var/run/target as a directory
+        let firstTar = try createSingleFileTar(content: "first\n", in: tempDir)
+        try await service.putArchive(
+            containerId: containerId,
+            path: "/var/run/target",
+            tarPath: firstTar,
+            noOverwriteDirNonDir: false
+        )
+        #expect(try fileExists(rootfsPath: rootfsPath, path: "/var/run/target"))
+
+        // Build a tar containing a plain file named "target" (not a directory)
+        let stagingDir = tempDir.appendingPathComponent("staging-conflict-\(UUID().uuidString)")
+        let conflictTar = tempDir.appendingPathComponent("conflict-\(UUID().uuidString).tar")
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        try "conflict".write(
+            to: stagingDir.appendingPathComponent("target"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try ArchiveUtility.create(tarPath: conflictTar, from: stagingDir)
+        try? FileManager.default.removeItem(at: stagingDir)
+
+        // Second PUT into /var/run with noOverwriteDirNonDir=true should fail
+        await #expect(throws: Error.self) {
+            try await service.putArchive(
+                containerId: containerId,
+                path: "/var/run",
+                tarPath: conflictTar,
+                noOverwriteDirNonDir: true
+            )
+        }
+    }
+}

--- a/Tests/socktainerTests/Utilitites/ClientArchiveServiceTests.swift
+++ b/Tests/socktainerTests/Utilitites/ClientArchiveServiceTests.swift
@@ -19,7 +19,8 @@ struct ClientArchiveServiceTests {
     /// Builds a minimal ext4 rootfs at `appSupportPath/containers/{id}/rootfs.ext4`
     /// with `/var/run` pre-created so tests can extract into paths beneath it.
     private func createRootfs(containerId: String, appSupportPath: URL) throws -> URL {
-        let containerDir = appSupportPath
+        let containerDir =
+            appSupportPath
             .appendingPathComponent("containers")
             .appendingPathComponent(containerId)
         try FileManager.default.createDirectory(at: containerDir, withIntermediateDirectories: true)

--- a/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
+++ b/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
@@ -257,6 +257,26 @@ struct EXT4EditorTests {
         }
     }
 
+    @Test("Directory extent tree promotion to depth-1")
+    func testDirectoryExtentTreePromotion() throws {
+        // Use a larger filesystem to accommodate many directory blocks
+        let fsPath = try createTestFilesystem(name: "large.ext4")
+        defer { cleanup(fsPath: fsPath) }
+
+        let editor = try EXT4Editor(devicePath: FilePath(fsPath.path))
+
+        // 600 files × ~24 bytes/entry ≈ 14400 bytes > 3 blocks (12288 bytes), forcing the
+        // inline extent tree (max 4 leaves) to exhaust and promote to depth=1.
+        for i in 0..<600 {
+            try editor.addFile(path: "/file_\(i).txt", data: Data("x".utf8))
+        }
+        try editor.sync()
+
+        for i in 0..<600 {
+            #expect(try verifyFileExists(fsPath: fsPath, path: "/file_\(i).txt"))
+        }
+    }
+
     @Test("Create directory")
     func testCreateDirectory() throws {
         let fsPath = try createTestFilesystem()

--- a/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
+++ b/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
@@ -237,6 +237,26 @@ struct EXT4EditorTests {
         #expect(try verifyFileExists(fsPath: fsPath, path: "/run/act"))
     }
 
+    @Test("Directory block overflow allocates new block")
+    func testDirectoryBlockOverflow() throws {
+        let fsPath = try createTestFilesystem()
+        defer { cleanup(fsPath: fsPath) }
+
+        let editor = try EXT4Editor(devicePath: FilePath(fsPath.path))
+
+        // Fill root directory with enough entries to overflow one 4096-byte block.
+        // Each entry needs at least 8 bytes header + aligned name. 80+ short-named files
+        // comfortably exceeds a single 4096-byte directory block.
+        for i in 0..<100 {
+            try editor.addFile(path: "/overflow_\(i).txt", data: Data("x".utf8))
+        }
+        try editor.sync()
+
+        for i in 0..<100 {
+            #expect(try verifyFileExists(fsPath: fsPath, path: "/overflow_\(i).txt"))
+        }
+    }
+
     @Test("Create directory")
     func testCreateDirectory() throws {
         let fsPath = try createTestFilesystem()

--- a/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
+++ b/Tests/socktainerTests/Utilitites/EXT4EditorTests.swift
@@ -217,6 +217,26 @@ struct EXT4EditorTests {
         #expect(try verifyFileExists(fsPath: fsPath, path: "/link"))
     }
 
+    @Test("Create directory through symlink")
+    func testCreateDirectoryThroughSymlink() throws {
+        let fsPath = try createTestFilesystem()
+        defer { cleanup(fsPath: fsPath) }
+
+        let editor = try EXT4Editor(devicePath: FilePath(fsPath.path))
+
+        // Create a real directory and a symlink pointing to it (mimics /var/run -> /run)
+        try editor.createDirectory(path: "/run")
+        try editor.addSymlink(path: "/varrun", target: "/run")
+        try editor.sync()
+
+        // Creating a directory through the symlink must succeed
+        let editor2 = try EXT4Editor(devicePath: FilePath(fsPath.path))
+        try editor2.createDirectory(path: "/varrun/act")
+        try editor2.sync()
+
+        #expect(try verifyFileExists(fsPath: fsPath, path: "/run/act"))
+    }
+
     @Test("Create directory")
     func testCreateDirectory() throws {
         let fsPath = try createTestFilesystem()


### PR DESCRIPTION
## Summary

- **Root cause (original)**: `putArchive` held an open `EXT4.EXT4Reader` while a fallback path tried to open a second reader on the same `rootfs.ext4`. Replaced the fallback with `EXT4Editor` in-place writes.
- **Root cause (follow-up 1)**: `resolvePathToInode` did not follow symlinks. `/var/run → /run` in most container images caused `parentNotDirectory`. Fixed with symlink traversal and a depth-40 loop guard.
- **Root cause (follow-up 2)**: `addDirectoryEntry` threw `directoryFull` once the single directory block was exhausted. Fixed by allocating a new block and extending the inode's extent tree.
- **Root cause (follow-up 3)**: The inline extent tree holds only 4 leaf entries. A dense root directory (many files extracted by `act`) exhausted all 4 slots. Fixed by promoting to a depth=1 extent tree: existing leaves are moved into an allocated leaf-page block, and the inode's inline area becomes a depth=1 header + `EXT4ExtentIndex`. Subsequent appends extend the leaf page or add new index entries as needed. `getExtents` updated to traverse depth=1 trees.

## Test plan

- [ ] CI passes all 17 `EXT4EditorTests`
- [ ] `PUT /containers/{id}/archive?path=/var/run/act` — no `parentNotDirectory`
- [ ] `PUT /containers/{id}/archive?path=/` with many files — no `directoryFull`
- [ ] `EXT4EditorTests/testCreateDirectoryThroughSymlink` passes
- [ ] `EXT4EditorTests/testDirectoryBlockOverflow` passes
- [ ] `EXT4EditorTests/testDirectoryExtentTreePromotion` passes (600 files → depth-1 promotion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)