### PR TITLE
fix(containers): shorten container names exceeding Apple VZ 64-char limit

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -134,6 +134,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func getContainer(id: String) async throws -> ContainerSnapshot? {
+        let id = ContainerNameUtility.sanitize(id)
         do {
             return try await containerClient.get(id: id)
         } catch let error as ContainerizationError where error.code == .notFound {
@@ -179,6 +180,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func stop(id: String, signal: String?, timeout: Int?) async throws {
+        let id = ContainerNameUtility.sanitize(id)
         let container = try await containerClient.list().filter { $0.id == id }.first
         guard let container else {
             throw ClientContainerError.notFound(id: id)
@@ -191,6 +193,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func kill(id: String, signal: String?) async throws {
+        let id = ContainerNameUtility.sanitize(id)
         let container = try await containerClient.list().filter { $0.id == id }.first
         guard let container else {
             throw ClientContainerError.notFound(id: id)
@@ -206,6 +209,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func restart(id: String, signal: String?, timeout: Int?) async throws {
+        let id = ContainerNameUtility.sanitize(id)
         let container = try await containerClient.list().filter { $0.id == id }.first
         guard let container else {
             throw ClientContainerError.notFound(id: id)
@@ -219,6 +223,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func delete(id: String) async throws {
+        let id = ContainerNameUtility.sanitize(id)
         let container = try await containerClient.list().filter { $0.id == id }.first
         guard let container else {
             throw ClientContainerError.notFound(id: id)
@@ -229,6 +234,7 @@ struct ClientContainerService: ClientContainerProtocol {
     // NOTE: For Apple Container, we'll implement a simple polling mechanism
     //       since there's no direct wait API
     func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        let id = ContainerNameUtility.sanitize(id)
         var container = try await containerClient.list().filter { $0.id == id }.first
         guard let initialContainer = container else {
             throw ClientContainerError.notFound(id: id)

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -65,7 +65,8 @@ extension ContainerCreateRoute {
 
             req.logger.info("Creating container for image: \(body.Image)")
 
-            let id = Utility.createContainerID(name: containerName)
+            let rawId = Utility.createContainerID(name: containerName)
+            let id = ContainerNameUtility.sanitize(rawId)
             try Utility.validEntityName(id)
 
             // Validate the requested platform only if provided

--- a/Sources/socktainer/Utilities/ContainerNameUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerNameUtility.swift
@@ -1,0 +1,15 @@
+import CryptoKit
+import Foundation
+
+enum ContainerNameUtility {
+    static let maxLength = 64
+
+    static func sanitize(_ name: String) -> String {
+        guard name.count > maxLength else { return name }
+        let digest = SHA256.hash(data: Data(name.utf8))
+        let hashHex = digest.compactMap { String(format: "%02x", $0) }.joined()
+        let suffix = "-" + hashHex.prefix(12)
+        let prefix = String(name.prefix(maxLength - suffix.count))
+        return prefix + suffix
+    }
+}

--- a/Tests/socktainerTests/Utilitites/ContainerNameShorteningTests.swift
+++ b/Tests/socktainerTests/Utilitites/ContainerNameShorteningTests.swift
@@ -1,0 +1,68 @@
+import ContainerAPIClient
+import Testing
+
+@testable import socktainer
+
+@Suite("Container name shortening")
+struct ContainerNameShorteningTests {
+
+    @Test("Short name is returned unchanged")
+    func shortNamePassthrough() {
+        let name = "my-container"
+        #expect(ContainerNameUtility.sanitize(name) == name)
+    }
+
+    @Test("64-character name is returned unchanged")
+    func exactly64CharPassthrough() {
+        let name = "a" + String(repeating: "b", count: 63)
+        #expect(name.count == 64)
+        #expect(ContainerNameUtility.sanitize(name) == name)
+    }
+
+    @Test("65-character name is shortened to exactly 64 characters")
+    func shortens65CharName() {
+        let name = "a" + String(repeating: "b", count: 64)
+        #expect(name.count == 65)
+        let result = ContainerNameUtility.sanitize(name)
+        #expect(result.count == 64)
+    }
+
+    @Test("Name longer than 100 characters is shortened to exactly 64 characters")
+    func shortensVeryLongName() {
+        let name = "act-Build-and-Test-on-Multiple-Platforms-build-ubuntu-latest-some-extra-suffix-here"
+        #expect(name.count > 64)
+        let result = ContainerNameUtility.sanitize(name)
+        #expect(result.count == 64)
+    }
+
+    @Test("Shortening is deterministic")
+    func deterministic() {
+        let name = "act-" + String(repeating: "x", count: 70)
+        #expect(ContainerNameUtility.sanitize(name) == ContainerNameUtility.sanitize(name))
+    }
+
+    @Test("Two different long names produce different short names")
+    func collisionSafety() {
+        let base = "act-Build-and-Test-on-Multiple-Platforms-build-ubuntu-latest-"
+        let name1 = base + "job-alpha"
+        let name2 = base + "job-beta"
+        #expect(name1.count > 64)
+        #expect(name2.count > 64)
+        #expect(ContainerNameUtility.sanitize(name1) != ContainerNameUtility.sanitize(name2))
+    }
+
+    @Test("Shortened name passes validEntityName")
+    func shortenedNamePassesValidation() throws {
+        let name = "act-" + String(repeating: "valid-name-segment", count: 5)
+        #expect(name.count > 64)
+        let result = ContainerNameUtility.sanitize(name)
+        try Utility.validEntityName(result)
+    }
+
+    @Test("Shortened name preserves readable prefix")
+    func preservesPrefix() {
+        let name = "act-my-workflow-job-name-" + String(repeating: "x", count: 50)
+        let result = ContainerNameUtility.sanitize(name)
+        #expect(result.hasPrefix("act-my-workflow-job-name-"))
+    }
+}


### PR DESCRIPTION
## Background: Apple Virtualization Framework's 64-character name limit

Apple's Virtualization Framework (`com.apple.container.apiserver`) enforces a hard limit of **64 characters** on container names at the XPC/daemon layer. This is not a socktainer constraint — it lives inside Apple's closed-source daemon. Names longer than 64 characters are rejected by the daemon with no helpful error surfaced to the caller; the container simply fails to be created.

The limit itself is reasonable (it mirrors common Unix hostname and DNS label constraints), but it becomes a practical problem when the Docker API is used by automated tooling that generates names programmatically.

## Why `act` (and similar tools) cannot fix this themselves

[`act`](https://github.com/nektos/act) is the most common trigger of this bug. It runs GitHub Actions workflows locally by spinning up Docker containers for each job. Container names are derived from the workflow structure:

```
act-<workflow-name>-<job-name>-<run-id-or-sha>
```

Real-world names end up looking like:
```
act-shell-lint-yml-Shell-Lint-b09fb82471092a9c645ef7ef0e42670000288fdc3db409fc2219e55469fba0b7x
```
That's 95 characters — 31 over the limit.

**The name is not configurable.** `act` derives it from the workflow YAML, which users write without knowledge of the underlying container runtime. Asking users to rename their GitHub Actions workflows to stay within 64 characters is impractical: it changes CI behaviour visible in GitHub's web UI, breaks branch protection rules referencing job names by string, and affects status checks. The workflow name is semantic, not an implementation detail.

More broadly, the Docker API specification explicitly permits long container names. Any tool targeting the Docker API has a reasonable expectation that a name valid per the Docker spec will work. The Docker Engine itself imposes no practical length limit on container names (the constraint in the spec regex `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+` carries no maximum length).

## Why the fix belongs in socktainer, not in the framework or the tools

socktainer is the **compatibility shim** between the Docker API and Apple's container runtime. Its entire purpose is to bridge the gap between Docker's broader contract and Apple's more restrictive implementation. This is exactly that kind of gap:

- The Docker API does not cap container name length.
- Apple's runtime does.
- socktainer is the translation layer.

Fixing this in `act` would require every Docker-API-compatible tool to independently know about Apple's limit and work around it — a leaky abstraction that defeats the purpose of a compatibility layer. Fixing it here means every tool works transparently.

## Implementation

### Name shortening (`ContainerNameUtility.sanitize`)

When a name exceeds 64 characters, it is replaced with:

```
prefix(51 chars) + "-" + sha256(original).prefix(12 hex chars)
```
= exactly 64 characters.

Properties:
- **Deterministic**: the same long name always produces the same short name, so any component that independently derives the short name from the original gets the same result.
- **Collision-resistant**: two names that differ only past the 51-char prefix produce different 12-char hash suffixes (SHA-256 provides ~48 bits of collision resistance for the suffix alone).
- **Human-readable**: the prefix preserves the meaningful part of the name for log inspection.
- **Valid**: the result always passes `Utility.validEntityName` — the prefix inherits the first character's alphanumeric constraint, and lowercase hex is within `[a-zA-Z0-9_.-]`.
- **Idempotent**: names already ≤ 64 chars are returned unchanged, so applying the function twice is safe.

Uses `CryptoKit.SHA256`, already present in the project (`ContainerImageUtility.swift`).

### Two-level application

The sanitization is applied at **creation time** and at every **subsequent lookup**:

1. **`ContainerCreateRoute`** — the name is sanitized before being validated and sent to the daemon. The sanitized name is what gets stored and returned in `RESTContainerCreate.Id`.

2. **`ClientContainerService`** (`getContainer`, `stop`, `kill`, `restart`, `delete`, `wait`) — Docker clients (including `act`) commonly reference containers by the **original name they requested**, not the ID returned from the create response. When these routes receive a long name as the `{id}` path parameter, they now sanitize it before lookup. Because sanitize is deterministic, `sanitize(original)` always resolves to the same stored short name.

## Test plan

- [x] `ContainerNameShorteningTests` — 8 unit tests covering passthrough (≤64 chars), exact truncation (65+ chars → exactly 64), determinism, collision safety between similar long names, prefix preservation, and `validEntityName` compatibility
- [x] All existing `ContainerNameValidationTests` still pass (the validation layer is unchanged)
- [x] Full test suite: `make test` — 61 tests, 8 suites, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)