### PR TITLE
Make `volume create` idempotent

### DIFF
--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -19,7 +19,19 @@ struct VolumeCreateRoute: RouteCollection {
             Options: createRequest.DriverOpts ?? [:],
             Labels: createRequest.Labels ?? [:]
         )
-        let volume = try await client.create(request: restRequest)
-        return volume
+        do {
+            return try await client.create(request: restRequest)
+        } catch {
+            // Docker's `volume create` is idempotent: creating a volume that
+            // already exists returns the existing one rather than erroring.
+            // socktainer's create throws "already exists", which breaks tools
+            // that create-to-ensure a volume exists (e.g. `docker compose up`
+            // with external volumes). Fall back to returning the existing
+            // volume; rethrow if it's a different failure.
+            if let existing = try? await client.inspect(name: resolvedName) {
+                return existing
+            }
+            throw error
+        }
     }
 }

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -1,11 +1,15 @@
 import Vapor
 
+/// Route collection for the Docker `POST /volumes/create` endpoint.
 struct VolumeCreateRoute: RouteCollection {
     let client: ClientVolumeService
+
+    /// Creates the route, backed by the given volume client.
     init(client: ClientVolumeService) {
         self.client = client
     }
 
+    /// Registers the `POST /volumes/create` route on the given builder.
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.POST, pattern: "/volumes/create", use: self.handler)
     }

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -4,11 +4,6 @@ import Vapor
 struct VolumeCreateRoute: RouteCollection {
     let client: ClientVolumeService
 
-    /// Creates the route, backed by the given volume client.
-    init(client: ClientVolumeService) {
-        self.client = client
-    }
-
     /// Registers the `POST /volumes/create` route on the given builder.
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.POST, pattern: "/volumes/create", use: self.handler)

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -10,6 +10,8 @@ struct VolumeCreateRoute: RouteCollection {
         try routes.registerVersionedRoute(.POST, pattern: "/volumes/create", use: self.handler)
     }
 
+    /// Creates a volume, returning the existing volume when one with the same
+    /// name already exists (idempotent, matching Docker's `POST /volumes/create`).
     func handler(_ req: Request) async throws -> Volume {
         let createRequest = try req.content.decode(VolumeRequest.self)
         let resolvedName = (createRequest.Name?.isEmpty == false) ? createRequest.Name! : "volume-\(UUID().uuidString)"
@@ -26,12 +28,11 @@ struct VolumeCreateRoute: RouteCollection {
             // already exists returns the existing one rather than erroring.
             // socktainer's create throws "already exists", which breaks tools
             // that create-to-ensure a volume exists (e.g. `docker compose up`
-            // with external volumes). Fall back to returning the existing
-            // volume; rethrow if it's a different failure.
-            if let existing = try? await client.inspect(name: resolvedName) {
-                return existing
-            }
-            throw error
+            // with external volumes). Only treat that specific conflict as
+            // idempotent — return the existing volume; any other failure is a
+            // real error and must propagate.
+            guard "\(error)".lowercased().contains("already exists") else { throw error }
+            return try await client.inspect(name: resolvedName)
         }
     }
 }


### PR DESCRIPTION
## Problem

Docker's `POST /volumes/create` is idempotent — creating a volume that already exists returns the existing volume rather than erroring. socktainer instead throws `"already exists"`.

This breaks any tool that creates-to-ensure a volume exists. The most common case is `docker compose up` with **external volumes**: compose issues a create for each external volume on every `up`, so the second `up` fails:

```
Error response from daemon: {"reason":"Something went wrong.","error":true}
# socktainer log: invalidArgument: "volume 'X' already exists"
```

## Fix

In `VolumeCreateRoute`, on a create conflict, fall back to returning the existing volume via `inspect`; rethrow any other error. Matches Docker Engine semantics.

## Test

```
docker volume create v1   # ok
docker volume create v1   # before: error; after: returns existing volume
```