### PR TITLE
Fix non-interactive `docker exec`/`docker run`: hangs, missing output, exit codes

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -3,6 +3,28 @@ import ContainerResource
 import ContainerizationError
 import Foundation
 
+// Stores the exit code for each container's init process once it terminates.
+// Both ClientContainerService.start() and the stdin-attach bootstrap path
+// call process.wait() concurrently; whichever path runs will record the code
+// here so ContainerWaitRoute can return the real exit status.
+actor ContainerExitCodeStore {
+    static let shared = ContainerExitCodeStore()
+
+    private var codes: [String: Int32] = [:]
+
+    func set(id: String, code: Int32) {
+        codes[id] = code
+    }
+
+    func get(id: String) -> Int32? {
+        codes[id]
+    }
+
+    func remove(id: String) {
+        codes.removeValue(forKey: id)
+    }
+}
+
 protocol ClientContainerProtocol: Sendable {
     func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot]
     func getContainer(id: String) async throws -> ContainerSnapshot?
@@ -166,6 +188,13 @@ struct ClientContainerService: ClientContainerProtocol {
         do {
             let process = try await containerClient.bootstrap(id: container.id, stdio: stdio)
             try await process.start()
+            // Wait for the init process in the background so we can capture its
+            // real exit code without blocking the /start response.
+            let containerId = container.id
+            Task.detached {
+                let code = (try? await process.wait()) ?? 0
+                await ContainerExitCodeStore.shared.set(id: containerId, code: code)
+            }
         } catch {
             // NOTE: If bootstrap fails because container is already booted,
             //       the attach handler may have already bootstrapped it
@@ -231,53 +260,48 @@ struct ClientContainerService: ClientContainerProtocol {
         try await containerClient.delete(id: container.id)
     }
 
-    // NOTE: For Apple Container, we'll implement a simple polling mechanism
-    //       since there's no direct wait API
+    // Poll until the container is no longer running, then return the real exit
+    // code recorded by the background waiter started in start() (or by the
+    // stdin-attach bootstrap path).
     func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
         let id = ContainerNameUtility.sanitize(id)
-        var container = try await containerClient.list().filter { $0.id == id }.first
-        guard let initialContainer = container else {
+        guard (try await containerClient.list().filter { $0.id == id }.first) != nil else {
             throw ClientContainerError.notFound(id: id)
         }
 
-        // For now, default to 0
-        var exitCode: Int64 = 0
-
+        // `docker run` issues /wait BEFORE /start, so the container is still in
+        // `.created` state when we arrive here — we must NOT treat "not running"
+        // as "exited". Instead poll until the init process actually finishes and
+        // its real exit code is recorded by the background waiter in start().
+        // The container persists for the duration of /wait (docker removes it
+        // only after /wait returns), so disappearing means a race/out-of-band
+        // removal and we fall back to the recorded code (or 0).
         switch condition {
-        // TODO: This condition needs to be re-implemented to properly handle container lifecycle
-        //       Currently stubbed to support `docker attach` workflows,
-        //       immediately return to prevent blocking `docker attach`
-        case .notRunning:
-            // while container?.status == .running {
-            //     try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
-            //     container = try await containerClient.list().first(where: { $0.id == id })
-            //     guard let container = container else {
-            //         break
-            //     }
-            // }
-            break
-
-        case .nextExit:
-            // Wait for next exit (only if currently running)
-            if initialContainer.status == .running {
-                while true {
-                    try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
-                    container = try await containerClient.list().first(where: { $0.id == id })
-                    if container?.status != .running {
-                        exitCode = 0
-                        break
-                    }
+        case .notRunning, .nextExit, .removed:
+            while true {
+                if let code = await ContainerExitCodeStore.shared.get(id: id) {
+                    return RESTContainerWait(statusCode: Int64(code))
                 }
+                let current = try await containerClient.list().filter { $0.id == id }.first
+                if current == nil {
+                    // The container is gone — for `--rm` (AutoRemove) it is
+                    // deleted the instant it exits, which can race ahead of the
+                    // background waiter recording the exit code. Grace-poll the
+                    // store briefly so we still return the real code instead of 0.
+                    for _ in 0..<30 {
+                        if let code = await ContainerExitCodeStore.shared.get(id: id) {
+                            return RESTContainerWait(statusCode: Int64(code))
+                        }
+                        try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+                    }
+                    break
+                }
+                try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
             }
-
-        case .removed:
-            // TODO: This condition needs to be re-implemented to properly handle container lifecycle
-            //       Currently stubbed to support `docker run --rm` workflows,
-            //       immediately return to prevent blocking `docker run --rm`
-            break
         }
 
-        return RESTContainerWait(statusCode: exitCode)
+        let code = await ContainerExitCodeStore.shared.get(id: id) ?? 0
+        return RESTContainerWait(statusCode: Int64(code))
     }
 
     func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -187,6 +187,10 @@ struct ClientContainerService: ClientContainerProtocol {
 
         do {
             let process = try await containerClient.bootstrap(id: container.id, stdio: stdio)
+            // Clear any exit code recorded by a previous run of this container so
+            // /wait blocks for the new init process rather than immediately
+            // returning the stale code (e.g. after a restart).
+            await ContainerExitCodeStore.shared.remove(id: container.id)
             try await process.start()
             // Wait for the init process in the background so we can capture its
             // real exit code without blocking the /start response.
@@ -278,25 +282,29 @@ struct ClientContainerService: ClientContainerProtocol {
         // removal and we fall back to the recorded code (or 0).
         switch condition {
         case .notRunning, .nextExit, .removed:
-            while true {
-                if let code = await ContainerExitCodeStore.shared.get(id: id) {
-                    return RESTContainerWait(statusCode: Int64(code))
-                }
+            // Wait until the init process exits and its code is recorded. For
+            // `--rm` the container can be deleted the instant it exits (racing
+            // the recorder), so also stop once it's gone, then grace-poll the
+            // store below.
+            while await ContainerExitCodeStore.shared.get(id: id) == nil {
                 let current = try await containerClient.list().filter { $0.id == id }.first
                 if current == nil {
-                    // The container is gone — for `--rm` (AutoRemove) it is
-                    // deleted the instant it exits, which can race ahead of the
-                    // background waiter recording the exit code. Grace-poll the
-                    // store briefly so we still return the real code instead of 0.
-                    for _ in 0..<30 {
-                        if let code = await ContainerExitCodeStore.shared.get(id: id) {
-                            return RESTContainerWait(statusCode: Int64(code))
-                        }
+                    var graceTries = 0
+                    while await ContainerExitCodeStore.shared.get(id: id) == nil && graceTries < 30 {
                         try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+                        graceTries += 1
                     }
                     break
                 }
                 try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+            }
+
+            // `removed` must block until the container is actually gone, not just
+            // exited — otherwise the requested condition was never satisfied.
+            if condition == .removed {
+                while (try await containerClient.list().filter { $0.id == id }.first) != nil {
+                    try await Task.sleep(nanoseconds: 200_000_000)  // 200ms
+                }
             }
         }
 

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -148,18 +148,22 @@ extension ContainerAttachRoute {
                 guard let fileHandle = logHandle, shouldStreamOutput else { return }
                 defer { try? fileHandle.close() }
 
-                // Drain a chunk of log data, framing it as a Docker stdout stream.
+                // Drain a chunk of log data, framing it as a Docker stdout/stderr stream.
                 // Returns true if any bytes were written. Awaits each write so a
                 // client disconnect (the write future fails once the channel is
                 // closed) throws and ends the poll promptly instead of looping
                 // until the container stops.
                 @Sendable func drainAvailable() async throws -> Bool {
+                    // When the client requested stderr only, label frames as stderr so
+                    // demultiplexing clients route the bytes correctly; otherwise stdout.
+                    // Apple exposes a single primary log handle, so the source is the same.
+                    let frameStreamType: DockerStreamFrame.StreamType = (stderr && !stdout) ? .stderr : .stdout
                     var wrote = false
                     while let data = try? fileHandle.read(upToCount: 4096), !data.isEmpty {
                         wrote = true
                         let capacity = min(data.count + (isTTY ? 0 : 8), 65536)
                         var buf = sharedAllocator.buffer(capacity: capacity)
-                        buf.writeDockerFrame(streamType: .stdout, data: data, ttyMode: isTTY)
+                        buf.writeDockerFrame(streamType: frameStreamType, data: data, ttyMode: isTTY)
                         try await writer.write(.buffer(buf)).get()
                     }
                     return wrote
@@ -261,16 +265,24 @@ extension ContainerAttachRoute {
             stderrPipe?.fileHandleForWriting,
         ]
 
+        // Mirror ClientContainerService.start()'s exit-code contract: /wait returns
+        // as soon as ContainerExitCodeStore is non-nil, so clear any stale code
+        // before starting and record a synthetic one if bootstrap/start fails (so
+        // /wait can't return a stale status or poll forever).
+        await ContainerExitCodeStore.shared.remove(id: container.id)
+
         let process: ClientProcess
         do {
             process = try await ContainerClient().bootstrap(id: container.id, stdio: stdio)
         } catch {
+            await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             throw Abort(.internalServerError, reason: "Failed to bootstrap container: \(error.localizedDescription)")
         }
 
         do {
             try await process.start()
         } catch {
+            await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             throw Abort(.internalServerError, reason: "Failed to start main process: \(error.localizedDescription)")
         }
 

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -113,103 +113,94 @@ extension ContainerAttachRoute {
             headers.add(name: "Upgrade", value: "tcp")
         }
 
+        let shouldAttachStdout = stdout || (!stdout && !stderr)
+
         // Create streaming response body using container logs when not using stdin
         let body = Response.Body { writer in
             Task.detached {
-                let pollInterval: UInt64 = 200_000_000  // 200ms
-                var containerWasRunning = false
-
                 defer {
                     _ = writer.write(.end)
                 }
 
-                // Continuously poll for log handles and send data
-                while true {
-                    // Check if container still exists
-                    do {
-                        _ = try await client.getContainer(id: id)
-                    } catch {
+                // Flush the response head immediately. `docker run` opens the attach
+                // connection and waits for the attach response before sending /start;
+                // a Vapor streaming body otherwise withholds headers until the first
+                // write, deadlocking attach-before-start. An empty buffer sends the head.
+                _ = writer.write(.buffer(sharedAllocator.buffer(capacity: 0)))
+
+                // Wait until the log file is available (container must be created first).
+                var logHandle: FileHandle? = nil
+                while logHandle == nil {
+                    if let fhs = try? await ContainerClient().logs(id: container.id), !fhs.isEmpty {
+                        logHandle = fhs[0]
+                        // Close the boot-log handle we don't need.
+                        if fhs.count > 1 { try? fhs[1].close() }
                         break
                     }
+                    // Container may not be created yet; retry shortly.
+                    try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms
+                }
 
-                    var logHandles: [FileHandle] = []
-                    var hasValidHandles = false
+                guard let fileHandle = logHandle, shouldAttachStdout else { return }
+                defer { try? fileHandle.close() }
 
-                    // Try to get log handles
-                    do {
-                        logHandles = try await ContainerClient().logs(id: container.id)
-                        hasValidHandles = !logHandles.isEmpty
-                    } catch {
-                        hasValidHandles = false
+                // Drain a chunk of log data, framing it as a Docker stdout stream.
+                // Returns true if any bytes were written.
+                @Sendable func drainAvailable() -> Bool {
+                    var wrote = false
+                    while true {
+                        guard let data = try? fileHandle.read(upToCount: 4096),
+                              !data.isEmpty else { break }
+                        wrote = true
+                        let capacity = min(data.count + (isTTY ? 0 : 8), 65536)
+                        var buf = sharedAllocator.buffer(capacity: capacity)
+                        buf.writeDockerFrame(streamType: .stdout, data: data, ttyMode: isTTY)
+                        _ = writer.write(.buffer(buf))
+                    }
+                    return wrote
+                }
+
+                // Stream log output using a DispatchSource file-write notification so
+                // we catch data as soon as it lands in the log file. When the container
+                // exits we do one final drain to capture any last bytes, then close.
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    let fd = fileHandle.fileDescriptor
+                    let source = DispatchSource.makeFileSystemObjectSource(
+                        fileDescriptor: fd,
+                        eventMask: .write,
+                        queue: .global(qos: .userInitiated)
+                    )
+
+                    // Drain any data already written before the source was set up.
+                    _ = drainAvailable()
+
+                    source.setEventHandler {
+                        _ = drainAvailable()
                     }
 
-                    defer {
-                        for handle in logHandles {
-                            try? handle.close()
-                        }
-                    }
-
-                    if hasValidHandles {
-                        let shouldAttachStdout = stdout || (!stdout && !stderr)
-                        var consecutiveEmptyReads = 0
-                        let maxEmptyReads = 50  // Switch to polling after 100 empty reads
+                    // Poll for container exit in the background; when stopped, do a
+                    // final drain and cancel the source (which resumes the continuation).
+                    let containerClient = ContainerClient()
+                    Task.detached {
                         while true {
-                            // Check if container still exists before reading data
-                            do {
-                                let currentContainer = try await client.getContainer(id: id)
-                                guard let container = currentContainer else {
-                                    return
-                                }
-                                if container.status == .running {
-                                    containerWasRunning = true
-                                } else if containerWasRunning {
-                                    // Container was running but now stopped - exit
-                                    return
-                                }
-                            } catch {
-                                // Container not available, exit
-                                return
-                            }
-
-                            var hasData = false
-
-                            if shouldAttachStdout && logHandles.indices.contains(0) {
-                                let stdoutData = logHandles[0].availableData
-                                if !stdoutData.isEmpty {
-                                    hasData = true
-                                    let capacity = min(stdoutData.count + (isTTY ? 0 : 8), 65536)
-                                    var buffer = sharedAllocator.buffer(capacity: capacity)
-                                    buffer.writeDockerFrame(streamType: .stdout, data: stdoutData, ttyMode: isTTY)
-                                    _ = writer.write(.buffer(buffer))
-                                }
-                            }
-
-                            if !hasData {
-                                consecutiveEmptyReads += 1
-
-                                // After many empty reads, send keep-alive less frequently
-                                if consecutiveEmptyReads >= maxEmptyReads {
-                                    consecutiveEmptyReads = 0  // Reset counter
-                                    try await Task.sleep(nanoseconds: 500_000_000)  // 500ms
-                                } else {
-                                    try await Task.sleep(nanoseconds: 50_000_000)  // 50ms
-                                }
-                            } else {
-                                consecutiveEmptyReads = 0
-                                try await Task.sleep(nanoseconds: 5_000_000)  // 5ms when active
+                            try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms
+                            let current = try? await containerClient.get(id: container.id)
+                            // Container stopped or removed — exit monitoring.
+                            if current == nil || current?.status != .running {
+                                break
                             }
                         }
-
-                    } else {
-                        // No valid handles, just wait
-                        try await Task.sleep(nanoseconds: pollInterval)
+                        // Final drain: give the log a brief moment to flush, then read rest.
+                        try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+                        _ = drainAvailable()
+                        source.cancel()
                     }
 
-                    do {
-                        try await Task.sleep(nanoseconds: pollInterval)
-                    } catch {
-                        break
+                    source.setCancelHandler {
+                        continuation.resume()
                     }
+
+                    source.resume()
                 }
             }
         }
@@ -315,7 +306,9 @@ extension ContainerAttachRoute {
                         }
 
                         do {
-                            let _ = try await process.wait()
+                            // Record the real exit code so /containers/{id}/wait can return it.
+                            let code = try await process.wait()
+                            await ContainerExitCodeStore.shared.set(id: container.id, code: code)
                         } catch {
                         }
                     }
@@ -328,9 +321,12 @@ extension ContainerAttachRoute {
 
                             while true {
                                 do {
+                                    // A blocking pipe read returns empty Data only at EOF —
+                                    // the attached process exited and closed its stdout writer.
+                                    // Break so the stream finishes; sleeping/continuing here
+                                    // spins forever and the attached client hangs.
                                     guard let data = try stdoutHandle.read(upToCount: 8192), !data.isEmpty else {
-                                        try await Task.sleep(nanoseconds: 20_000_000)  // 20ms
-                                        continue
+                                        break
                                     }
 
                                     let capacity = min(data.count + (isTTY ? 0 : 8), 65536)  // Cap buffer size
@@ -352,9 +348,12 @@ extension ContainerAttachRoute {
 
                             while true {
                                 do {
+                                    // A blocking pipe read returns empty Data only at EOF —
+                                    // the attached process exited and closed its stderr writer.
+                                    // Break so the stream finishes; sleeping/continuing here
+                                    // spins forever and the attached client hangs.
                                     guard let data = try stderrHandle.read(upToCount: 8192), !data.isEmpty else {
-                                        try await Task.sleep(nanoseconds: 20_000_000)  // 20ms
-                                        continue
+                                        break
                                     }
 
                                     let capacity = min(data.count + 8, 65536)  // Cap buffer size
@@ -546,7 +545,9 @@ extension ContainerAttachRoute {
 
                 group.addTask {
                     do {
-                        let _ = try await process.wait()
+                        // Record the real exit code so /containers/{id}/wait can return it.
+                        let code = try await process.wait()
+                        await ContainerExitCodeStore.shared.set(id: container.id, code: code)
                     } catch {
                     }
 

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -113,7 +113,11 @@ extension ContainerAttachRoute {
             headers.add(name: "Upgrade", value: "tcp")
         }
 
-        let shouldAttachStdout = stdout || (!stdout && !stderr)
+        // A non-stdin attach streams the container's log regardless of whether
+        // stdout, stderr, or both (the default) were requested. Apple container
+        // exposes a single primary log handle, so a stderr-only attach streams
+        // that same source rather than short-circuiting to no output.
+        let shouldStreamOutput = stdout || stderr || (!stdout && !stderr)
 
         // Create streaming response body using container logs when not using stdin
         let body = Response.Body { writer in
@@ -141,7 +145,7 @@ extension ContainerAttachRoute {
                     try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms
                 }
 
-                guard let fileHandle = logHandle, shouldAttachStdout else { return }
+                guard let fileHandle = logHandle, shouldStreamOutput else { return }
                 defer { try? fileHandle.close() }
 
                 // Drain a chunk of log data, framing it as a Docker stdout stream.

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -176,10 +176,12 @@ extension ContainerAttachRoute {
                 // libdispatch trap (see socktainer/socktainer#205 for the same
                 // bug in the logs route). Polling is robust. Drain, then poll
                 // until the container is no longer running, then do a final drain.
+                // A snapshot attach (stream=0) drains once and ends instead of
+                // following.
                 let containerClient = ContainerClient()
                 do {
                     _ = try await drainAvailable()
-                    while true {
+                    while stream {
                         let wrote = try await drainAvailable()
                         if !wrote {
                             let current = try? await containerClient.get(id: container.id)
@@ -205,6 +207,16 @@ extension ContainerAttachRoute {
             headers: headers,
             body: body
         )
+    }
+
+    // ContainerClient surfaces a concurrent attach/start as a "booted" /
+    // "expected to be in created state" error; ClientContainerService.start
+    // treats it as a benign race (another request already started the container).
+    // Don't record a synthetic exit code for it — the container may be running
+    // fine — so /wait isn't told the container exited.
+    private static func isBenignStartRace(_ error: Error) -> Bool {
+        let message = error.localizedDescription
+        return message.contains("booted") || message.contains("expected to be in created state")
     }
 
     private static func handleAttachWithStdin(
@@ -275,6 +287,9 @@ extension ContainerAttachRoute {
         do {
             process = try await ContainerClient().bootstrap(id: container.id, stdio: stdio)
         } catch {
+            if isBenignStartRace(error) {
+                throw Abort(.conflict, reason: "Container is already starting")
+            }
             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             throw Abort(.internalServerError, reason: "Failed to bootstrap container: \(error.localizedDescription)")
         }
@@ -282,6 +297,9 @@ extension ContainerAttachRoute {
         do {
             try await process.start()
         } catch {
+            if isBenignStartRace(error) {
+                throw Abort(.conflict, reason: "Container is already starting")
+            }
             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             throw Abort(.internalServerError, reason: "Failed to start main process: \(error.localizedDescription)")
         }

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -149,17 +149,18 @@ extension ContainerAttachRoute {
                 defer { try? fileHandle.close() }
 
                 // Drain a chunk of log data, framing it as a Docker stdout stream.
-                // Returns true if any bytes were written.
-                @Sendable func drainAvailable() -> Bool {
+                // Returns true if any bytes were written. Awaits each write so a
+                // client disconnect (the write future fails once the channel is
+                // closed) throws and ends the poll promptly instead of looping
+                // until the container stops.
+                @Sendable func drainAvailable() async throws -> Bool {
                     var wrote = false
-                    while true {
-                        guard let data = try? fileHandle.read(upToCount: 4096),
-                              !data.isEmpty else { break }
+                    while let data = try? fileHandle.read(upToCount: 4096), !data.isEmpty {
                         wrote = true
                         let capacity = min(data.count + (isTTY ? 0 : 8), 65536)
                         var buf = sharedAllocator.buffer(capacity: capacity)
                         buf.writeDockerFrame(streamType: .stdout, data: data, ttyMode: isTTY)
-                        _ = writer.write(.buffer(buf))
+                        try await writer.write(.buffer(buf)).get()
                     }
                     return wrote
                 }
@@ -172,19 +173,23 @@ extension ContainerAttachRoute {
                 // bug in the logs route). Polling is robust. Drain, then poll
                 // until the container is no longer running, then do a final drain.
                 let containerClient = ContainerClient()
-                _ = drainAvailable()
-                while true {
-                    let wrote = drainAvailable()
-                    if !wrote {
-                        let current = try? await containerClient.get(id: container.id)
-                        if current == nil || current?.status != .running {
-                            // Give the log a brief moment to flush the last bytes.
-                            try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-                            _ = drainAvailable()
-                            break
+                do {
+                    _ = try await drainAvailable()
+                    while true {
+                        let wrote = try await drainAvailable()
+                        if !wrote {
+                            let current = try? await containerClient.get(id: container.id)
+                            if current == nil || current?.status != .running {
+                                // Give the log a brief moment to flush the last bytes.
+                                try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+                                _ = try await drainAvailable()
+                                break
+                            }
+                            try? await Task.sleep(nanoseconds: 150_000_000)  // 150ms
                         }
-                        try? await Task.sleep(nanoseconds: 150_000_000)  // 150ms
                     }
+                } catch {
+                    // Client disconnected (a write failed) — stop streaming.
                 }
             }
         }

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -299,6 +299,9 @@ extension ContainerAttachRoute {
                             let code = try await process.wait()
                             await ContainerExitCodeStore.shared.set(id: container.id, code: code)
                         } catch {
+                            // process.wait() failed — record a synthetic exit code so
+                            // /containers/{id}/wait can't block forever.
+                            await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                         }
                     }
 
@@ -538,6 +541,9 @@ extension ContainerAttachRoute {
                         let code = try await process.wait()
                         await ContainerExitCodeStore.shared.set(id: container.id, code: code)
                     } catch {
+                        // process.wait() failed — record a synthetic exit code so
+                        // /containers/{id}/wait can't block forever.
+                        await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                     }
 
                     // Give a small delay for any final output to be processed

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -164,47 +164,27 @@ extension ContainerAttachRoute {
                     return wrote
                 }
 
-                // Stream log output using a DispatchSource file-write notification so
-                // we catch data as soon as it lands in the log file. When the container
-                // exits we do one final drain to capture any last bytes, then close.
-                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                    let fd = fileHandle.fileDescriptor
-                    let source = DispatchSource.makeFileSystemObjectSource(
-                        fileDescriptor: fd,
-                        eventMask: .write,
-                        queue: .global(qos: .userInitiated)
-                    )
-
-                    // Drain any data already written before the source was set up.
-                    _ = drainAvailable()
-
-                    source.setEventHandler {
-                        _ = drainAvailable()
-                    }
-
-                    // Poll for container exit in the background; when stopped, do a
-                    // final drain and cancel the source (which resumes the continuation).
-                    let containerClient = ContainerClient()
-                    Task.detached {
-                        while true {
-                            try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms
-                            let current = try? await containerClient.get(id: container.id)
-                            // Container stopped or removed — exit monitoring.
-                            if current == nil || current?.status != .running {
-                                break
-                            }
+                // Stream log output by polling the log file for new writes. A
+                // DispatchSource on the log fd is fragile: it can fire on a
+                // closed/invalidated fd during teardown (container removed or
+                // client disconnect) and crash the whole process with a
+                // libdispatch trap (see socktainer/socktainer#205 for the same
+                // bug in the logs route). Polling is robust. Drain, then poll
+                // until the container is no longer running, then do a final drain.
+                let containerClient = ContainerClient()
+                _ = drainAvailable()
+                while true {
+                    let wrote = drainAvailable()
+                    if !wrote {
+                        let current = try? await containerClient.get(id: container.id)
+                        if current == nil || current?.status != .running {
+                            // Give the log a brief moment to flush the last bytes.
+                            try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
+                            _ = drainAvailable()
+                            break
                         }
-                        // Final drain: give the log a brief moment to flush, then read rest.
-                        try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-                        _ = drainAvailable()
-                        source.cancel()
+                        try? await Task.sleep(nanoseconds: 150_000_000)  // 150ms
                     }
-
-                    source.setCancelHandler {
-                        continuation.resume()
-                    }
-
-                    source.resume()
                 }
             }
         }

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -30,6 +30,13 @@ struct ContainerWaitRoute: RouteCollection {
                 condition = ContainerWaitCondition.default
             }
 
+            // Preflight before flushing headers so a missing container returns a
+            // real 404 instead of a streamed `200 {"StatusCode":0}` — the latter
+            // would make "no such container" indistinguishable from a clean exit.
+            guard try await client.getContainer(id: containerId) != nil else {
+                throw Abort(.notFound, reason: "No such container: \(containerId)")
+            }
+
             var headers = HTTPHeaders()
             headers.add(name: "Content-Type", value: "application/json")
 

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Vapor
 
 public enum ContainerWaitCondition: String, CaseIterable, Codable, Sendable {
@@ -15,7 +16,7 @@ struct ContainerWaitRoute: RouteCollection {
         try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/wait", use: ContainerWaitRoute.handler(client: client))
     }
 
-    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerWait {
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             guard let containerId = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
@@ -23,21 +24,46 @@ struct ContainerWaitRoute: RouteCollection {
 
             let conditionString = req.query["condition"] as String?
             let condition: ContainerWaitCondition
-
             if let conditionString = conditionString {
                 condition = ContainerWaitCondition(rawValue: conditionString) ?? ContainerWaitCondition.default
             } else {
                 condition = ContainerWaitCondition.default
             }
 
-            do {
-                let waitResponse = try await client.wait(id: containerId, condition: condition)
-                return waitResponse
-            } catch ClientContainerError.notFound(let id) {
-                throw Abort(.notFound, reason: "No such container: \(id)")
-            } catch {
-                throw Abort(.internalServerError, reason: "Failed to wait for container: \(error)")
+            var headers = HTTPHeaders()
+            headers.add(name: "Content-Type", value: "application/json")
+
+            // `docker run` reads the /wait response HEAD before it sends /start,
+            // then reads the body once the container exits. If we withhold the
+            // head until the body is ready (the default when returning a Content
+            // value), /start is never sent and the run deadlocks. So flush the
+            // head immediately with an empty write, then stream the exit-code
+            // JSON once client.wait() resolves (it blocks until the init process
+            // actually exits and its real code is recorded).
+            let body = Response.Body { writer in
+                Task.detached {
+                    defer { _ = writer.write(.end) }
+
+                    _ = writer.write(.buffer(sharedAllocator.buffer(capacity: 0)))
+
+                    let result: RESTContainerWait
+                    do {
+                        result = try await client.wait(id: containerId, condition: condition)
+                    } catch {
+                        // Emit a 0-status body so the client unblocks rather than
+                        // hanging on a half-open stream.
+                        result = RESTContainerWait(statusCode: 0)
+                    }
+
+                    if let data = try? JSONEncoder().encode(result) {
+                        var buf = sharedAllocator.buffer(capacity: data.count)
+                        buf.writeBytes(data)
+                        _ = writer.write(.buffer(buf))
+                    }
+                }
             }
+
+            return Response(status: .ok, headers: headers, body: body)
         }
     }
 }

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -18,6 +18,7 @@ actor ExecManager {
     }
 
     private var storage: [String: ExecConfig] = [:]
+    private var exitCodes: [String: Int32] = [:]
 
     func create(config: ExecConfig) -> String {
         let id = UUID().uuidString
@@ -31,6 +32,17 @@ actor ExecManager {
 
     func remove(id: String) {
         storage.removeValue(forKey: id)
+        exitCodes.removeValue(forKey: id)
+    }
+
+    // The Docker client calls `GET /exec/{id}/json` after the start stream
+    // closes to read the exit code, so the exec entry must outlive the stream.
+    func setExitCode(id: String, code: Int32) {
+        exitCodes[id] = code
+    }
+
+    func exitCode(id: String) -> Int32? {
+        exitCodes[id]
     }
 }
 
@@ -102,12 +114,13 @@ struct ExecRoute: RouteCollection {
                 }
             }
 
-            // For simplicity, we'll assume the exec is not running if we can inspect it
-            // In a real implementation, you'd track the actual process state
+            // The start handler records the exit code when the process finishes.
+            // If it's present the exec has completed; if not, it's still running.
+            let recordedExitCode = await ExecManager.shared.exitCode(id: execId)
             let response = ExecInspectResponse(
                 ID: execId,
-                Running: false,  // We'd need to track this properly
-                ExitCode: nil,  // We'd need to track this from the actual process
+                Running: recordedExitCode == nil,
+                ExitCode: recordedExitCode.map { Int($0) },
                 ProcessConfig: ExecInspectResponse.ProcessConfigInfo(
                     privileged: false,
                     user: "",
@@ -269,9 +282,13 @@ struct ExecRoute: RouteCollection {
 
                                 while !state.shouldStop() {
                                     do {
+                                        // A blocking pipe read returns empty Data only at EOF —
+                                        // the process exited and its stdout writer was closed.
+                                        // Break so the task group can finish and the response
+                                        // stream is closed; sleeping/continuing here spins forever
+                                        // and the Docker client hangs waiting for the stream to end.
                                         guard let data = try stdoutHandle.read(upToCount: 8192), !data.isEmpty else {
-                                            try await Task.sleep(nanoseconds: 50_000_000)  // 50ms
-                                            continue
+                                            break
                                         }
 
                                         let bufferSize = min(data.count + (tty ? 0 : 8), 65536)
@@ -296,9 +313,13 @@ struct ExecRoute: RouteCollection {
 
                                 while !state.shouldStop() {
                                     do {
+                                        // A blocking pipe read returns empty Data only at EOF —
+                                        // the process exited and its stderr writer was closed.
+                                        // Break so the task group can finish and the response
+                                        // stream is closed; sleeping/continuing here spins forever
+                                        // and the Docker client hangs waiting for the stream to end.
                                         guard let data = try stderrHandle.read(upToCount: 8192), !data.isEmpty else {
-                                            try await Task.sleep(nanoseconds: 50_000_000)  // 50ms
-                                            continue
+                                            break
                                         }
 
                                         let bufferSize = min(data.count + 8, 65536)
@@ -340,7 +361,8 @@ struct ExecRoute: RouteCollection {
                             }
 
                             do {
-                                let _ = try await process.wait()
+                                let exitCode = try await process.wait()
+                                await ExecManager.shared.setExitCode(id: execId, code: exitCode)
                             } catch {
                             }
                         }
@@ -348,7 +370,8 @@ struct ExecRoute: RouteCollection {
                         for await _ in group {}
                     }
 
-                    await ExecManager.shared.remove(id: execId)
+                    // Keep the exec entry so the client's follow-up
+                    // `GET /exec/{id}/json` can read the recorded exit code.
                     streamContinuation.finish()
                 }
             }
@@ -540,7 +563,8 @@ struct ExecRoute: RouteCollection {
                     // Process monitor with proper cleanup
                     group.addTask {
                         do {
-                            let _ = try await process.wait()
+                            let exitCode = try await process.wait()
+                            await ExecManager.shared.setExitCode(id: execId, code: exitCode)
                         } catch {
                             // Process wait error - handle gracefully
                         }
@@ -562,7 +586,8 @@ struct ExecRoute: RouteCollection {
                     for await _ in group {}
                 }
 
-                await ExecManager.shared.remove(id: execId)
+                // Keep the exec entry so the client's follow-up
+                // `GET /exec/{id}/json` can read the recorded exit code.
             }
         }
     }

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -241,13 +241,21 @@ struct ExecRoute: RouteCollection {
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
 
-                let process = try await ContainerClient().createProcess(
-                    containerId: container.id,
-                    processId: UUID().uuidString.lowercased(),
-                    configuration: processConfig,
-                    stdio: [nil, nil, nil]
-                )
-                try await process.start()
+                do {
+                    let process = try await ContainerClient().createProcess(
+                        containerId: container.id,
+                        processId: UUID().uuidString.lowercased(),
+                        configuration: processConfig,
+                        stdio: [nil, nil, nil]
+                    )
+                    try await process.start()
+                } catch {
+                    // The exec was marked started; if creating/starting the
+                    // process fails we must record an exit code, otherwise the
+                    // exec is stuck reporting Running forever.
+                    await ExecManager.shared.setExitCode(id: execId, code: -1)
+                    throw error
+                }
                 await ExecManager.shared.remove(id: execId)
                 return Response(status: .ok)
             }
@@ -289,7 +297,14 @@ struct ExecRoute: RouteCollection {
                         stdio: stdio.asArray
                     )
 
-                    try await process.start()
+                    do {
+                        try await process.start()
+                    } catch {
+                        // Record an exit code so a failed start doesn't leave
+                        // the exec stuck reporting Running forever.
+                        await ExecManager.shared.setExitCode(id: execId, code: -1)
+                        throw error
+                    }
 
                     await withTaskGroup(of: Void.self) { group in
                         // stdout handler
@@ -385,6 +400,9 @@ struct ExecRoute: RouteCollection {
                                 let exitCode = try await process.wait()
                                 await ExecManager.shared.setExitCode(id: execId, code: exitCode)
                             } catch {
+                                // process.wait() failed — record a synthetic exit
+                                // code so the exec leaves the Running state.
+                                await ExecManager.shared.setExitCode(id: execId, code: -1)
                             }
                         }
 
@@ -434,7 +452,14 @@ struct ExecRoute: RouteCollection {
                     stdio: stdio.asArray
                 )
 
-                try await process.start()
+                do {
+                    try await process.start()
+                } catch {
+                    // Record an exit code so a failed start doesn't leave the
+                    // exec stuck reporting Running forever.
+                    await ExecManager.shared.setExitCode(id: execId, code: -1)
+                    throw error
+                }
 
                 // Setup bidirectional communication for interactive sessions
                 await withTaskGroup(of: Void.self) { group in
@@ -587,7 +612,10 @@ struct ExecRoute: RouteCollection {
                             let exitCode = try await process.wait()
                             await ExecManager.shared.setExitCode(id: execId, code: exitCode)
                         } catch {
-                            // Process wait error - handle gracefully
+                            // process.wait() failed — record a synthetic exit code
+                            // so the exec leaves the Running state instead of
+                            // hanging there forever.
+                            await ExecManager.shared.setExitCode(id: execId, code: -1)
                         }
 
                         // Give a small delay for any final output to be processed

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -19,6 +19,7 @@ actor ExecManager {
 
     private var storage: [String: ExecConfig] = [:]
     private var exitCodes: [String: Int32] = [:]
+    private var startedIds: Set<String> = []
 
     func create(config: ExecConfig) -> String {
         let id = UUID().uuidString
@@ -33,6 +34,21 @@ actor ExecManager {
     func remove(id: String) {
         storage.removeValue(forKey: id)
         exitCodes.removeValue(forKey: id)
+        startedIds.remove(id)
+    }
+
+    // Marks an exec as started. Returns false if it doesn't exist or was already
+    // started — Docker rejects starting an exec instance more than once.
+    func markStarted(id: String) -> Bool {
+        guard storage[id] != nil, !startedIds.contains(id) else { return false }
+        startedIds.insert(id)
+        return true
+    }
+
+    // An exec is "running" only once it has been started and has not yet
+    // recorded an exit code — distinct from created-but-not-started.
+    func isRunning(id: String) -> Bool {
+        startedIds.contains(id) && exitCodes[id] == nil
     }
 
     // The Docker client calls `GET /exec/{id}/json` after the start stream
@@ -114,12 +130,12 @@ struct ExecRoute: RouteCollection {
                 }
             }
 
-            // The start handler records the exit code when the process finishes.
-            // If it's present the exec has completed; if not, it's still running.
+            // Running is true only once started and before an exit code is
+            // recorded — a created-but-not-yet-started exec is not running.
             let recordedExitCode = await ExecManager.shared.exitCode(id: execId)
             let response = ExecInspectResponse(
                 ID: execId,
-                Running: recordedExitCode == nil,
+                Running: await ExecManager.shared.isRunning(id: execId),
                 ExitCode: recordedExitCode.map { Int($0) },
                 ProcessConfig: ExecInspectResponse.ProcessConfigInfo(
                     privileged: false,
@@ -198,6 +214,11 @@ struct ExecRoute: RouteCollection {
             }
 
             try client.enforceContainerRunning(container: container)
+
+            // Reject starting an exec instance more than once (Docker semantics).
+            guard await ExecManager.shared.markStarted(id: execId) else {
+                throw Abort(.conflict, reason: "Exec instance \(execId) has already been started")
+            }
 
             struct StartExecRequest: Content {
                 let Detach: Bool?


### PR DESCRIPTION
Non-interactive `docker exec <c> <cmd>` and `docker run <img> <cmd>` (no `-i`) are broken in several interrelated ways. This makes them behave like Docker Engine.

### 1. `docker exec` hangs forever
In the HTTP-streaming exec path, the stdout/stderr reader loops treat an EOF read (empty `Data` after the process's pipe writer closes) as "would-block" and `sleep`/`continue` forever, so the task group never finishes and the response stream never closes — the client hangs. Fixed by breaking the reader loops on EOF. (The interactive TCP-upgrade path already handled EOF via `DispatchIO`'s `done`.)

### 2. `docker run`/attach hangs and returns no output
The non-stdin attach path had two issues:
- It only exited the poll loop if it had observed the container `.running` and *then* stopped; a fast-exiting command exits before the first poll sees `.running`, so it spun forever. Now it drains remaining output and exits once the container is gone, regardless.
- It withheld the response head until the first body write. `docker run` opens the attach connection and waits for the attach response before sending `/start`, so it deadlocked (attach-before-start). Now the head is flushed immediately.

### 3. Exit code is always 0
`ClientContainerService.wait` was stubbed to return `0`. Also, the Docker client reads the `/wait` response *before* it sends `/start`, so `/wait` must stream: flush the head immediately, then write the real exit code once the container exits. Records the init-process exit code (`process.wait()`) in a small store that `/wait` reads, with a short grace-poll for `--rm` (the container is removed the instant it exits, racing the recorder).

### Verification
```
docker run --rm alpine sh -c 'exit 7'   # exits 7 (was 0)
docker run --rm alpine echo hi          # prints "hi" (was empty)
docker exec <c> sh -c 'exit 5'          # exits 5
docker compose run --rm <svc>           # propagates exit code
```