### PR TITLE
Fix crash in docker logs --follow when the container is removed

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -64,18 +64,29 @@ extension ContainerLogsRoute {
                     // libdispatch trap. Polling is robust. Exit once the
                     // container is no longer running.
                     let logFollowClient = ContainerClient()
-                    while true {
+                    follow: while true {
                         var gotData = false
+                        var frames: [ByteBuffer] = []
                         do {
                             while let data = try fileHandle.read(upToCount: 4096), !data.isEmpty {
                                 gotData = true
                                 buffer.append(data)
                                 buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer) { outputBuffer in
-                                    _ = writer.write(.buffer(outputBuffer))
+                                    frames.append(outputBuffer)
                                 }
                             }
                         } catch {
                             break
+                        }
+                        // Await each write so a client disconnect (the write future
+                        // fails once the channel is closed) ends this task promptly
+                        // instead of polling on until the container stops.
+                        for frame in frames {
+                            do {
+                                try await writer.write(.buffer(frame)).get()
+                            } catch {
+                                break follow
+                            }
                         }
                         if !gotData {
                             let current = try? await logFollowClient.get(id: container.id)

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -91,7 +91,7 @@ extension ContainerLogsRoute {
                         if !gotData {
                             let current = try? await logFollowClient.get(id: container.id)
                             if current == nil || current?.status != .running { break }
-                            try? await Task.sleep(nanoseconds: 150_000_000)  // 150ms
+                            try? await Task.sleep(for: .milliseconds(150))
                         }
                     }
                     try? fileHandle.close()

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -29,8 +29,6 @@ extension ContainerLogsRoute {
             // `follow=1` means tail like
             let follow = (try? req.query.get(Bool.self, at: "follow")) ?? false
 
-            let fd = fileHandle.fileDescriptor
-
             let body = Response.Body { writer in
                 Task.detached {
                     var buffer = Data()
@@ -59,36 +57,34 @@ extension ContainerLogsRoute {
                         return
                     }
 
-                    // For follow mode, set up a DispatchSource to stream future writes
-                    let source = DispatchSource.makeFileSystemObjectSource(
-                        fileDescriptor: fd,
-                        eventMask: .write,
-                        queue: .global()
-                    )
-
-                    source.setEventHandler {
+                    // For follow mode, poll the log file for new writes. A
+                    // DispatchSource on the log fd is fragile: it can fire on a
+                    // closed/invalidated fd during teardown (container removed or
+                    // client disconnect) and crash the whole process with a
+                    // libdispatch trap. Polling is robust. Exit once the
+                    // container is no longer running.
+                    let logFollowClient = ContainerClient()
+                    while true {
+                        var gotData = false
                         do {
-                            while true {
-                                let data = try fileHandle.read(upToCount: 4096)
-                                guard let data, !data.isEmpty else { break }
+                            while let data = try fileHandle.read(upToCount: 4096), !data.isEmpty {
+                                gotData = true
                                 buffer.append(data)
-
-                                // Process complete frames from buffer
                                 buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer) { outputBuffer in
                                     _ = writer.write(.buffer(outputBuffer))
                                 }
                             }
                         } catch {
-                            source.cancel()
+                            break
+                        }
+                        if !gotData {
+                            let current = try? await logFollowClient.get(id: container.id)
+                            if current == nil || current?.status != .running { break }
+                            try? await Task.sleep(nanoseconds: 150_000_000)  // 150ms
                         }
                     }
-
-                    source.setCancelHandler {
-                        try? fileHandle.close()
-                        _ = writer.write(.end)
-                    }
-
-                    source.resume()
+                    try? fileHandle.close()
+                    _ = writer.write(.end)
                 }
             }
 


### PR DESCRIPTION
## Problem

`docker logs --follow` can crash the entire socktainer process. Follow mode streams new log output via a `DispatchSource.makeFileSystemObjectSource` on the log file descriptor. When the watched container is removed (or its log fd is otherwise invalidated) while the source is still active, the source fires on a dead fd and the process traps in libdispatch:

```
Thread N Crashed:
  _dispatch_source_merge_evt
  ...
EXC_BREAKPOINT (SIGTRAP)
```

Because it's the whole daemon, every other connection dies too.

### Reproduce

```sh
docker run -d --name t alpine sh -c 'while true; do date; sleep 0.05; done'
docker logs -f t >/dev/null &
docker rm -f t      # source fires on the now-invalid fd -> daemon crashes
```

## Fix

Replace the `DispatchSource` with a simple poll loop that reads newly-written log data and exits once the container is no longer running. Polling is robust to the fd being closed/invalidated and to client disconnects, and avoids the fragile requirement of tearing the dispatch source down before its fd goes away.

Verified: the repro above no longer crashes (6/6 runs).