### PR TITLE
deps: bump apple/container to 1.0.0 and containerization to 0.33.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "072feede2d671af957d2918680e34fc8282fff750f0cbc0866b53ef87e064fca",
+  "originHash" : "47de8369a8f87d87a5a96bb2d7cb3b21d73e728d2a33469fb1a379204adf1524",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "651811cc090937457956643dd2c454df77eb141b",
-        "version" : "0.12.0"
+        "revision" : "ee848e3ebfd7c73b04dd419683be54fb450b8779",
+        "version" : "1.0.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "f1ee6f8b737ab8dffbd620bfa47283f6f0bc1822",
-        "version" : "0.31.0"
+        "revision" : "a2a1add6c7e1a1665e5397edc49d925c49090b3a",
+        "version" : "0.33.3"
       }
     },
     {
@@ -161,6 +161,15 @@
       "state" : {
         "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-configuration-toml",
+      "state" : {
+        "revision" : "4ea16b4dfa4b023cecae5ae0368402c4d846d613",
+        "version" : "2.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let buildVersion = ProcessInfo.processInfo.environment["BUILD_VERSION"] ?? "unsp
 let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
 let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "unspecified"
 let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "unspecified"
-let appleContainerVersion = "0.12.0"
-let appleContainerizationVersion = "0.31.0"
+let appleContainerVersion = "1.0.0"
+let appleContainerizationVersion = "0.33.3"
 
 let package = Package(
     name: "socktainer",
@@ -28,7 +28,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ContainerBuild", package: "container"),
                 .product(name: "ContainerAPIClient", package: "container"),
-                .product(name: "ContainerNetworkService", package: "container"),
+                .product(name: "ContainerNetworkClient", package: "container"),
                 .product(name: "ContainerPersistence", package: "container"),
                 .product(name: "ContainerResource", package: "container"),
                 .product(name: "Containerization", package: "containerization"),

--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -205,11 +205,11 @@ struct ClientBuilderService: ClientBuilderProtocol {
             try FileManager.default.createDirectory(at: exportsMount, withIntermediateDirectories: true)
         }
 
-        let builderImage = DefaultsStore.get(key: .defaultBuilderImage)
+        let builderImage = BuildConfig.defaultImage
         let builderPlatform = Platform(arch: "arm64", os: "linux", variant: "v8")
-        let useRosetta = DefaultsStore.getBool(key: .buildRosetta) ?? true
+        let useRosetta = BuildConfig.defaultRosetta
 
-        let image = try await ClientImage.fetch(reference: builderImage, platform: builderPlatform)
+        let image = try await ClientImage.fetch(reference: builderImage, platform: builderPlatform, containerSystemConfig: ContainerSystemConfig())
         _ = try await image.getCreateSnapshot(platform: builderPlatform)
         let imageDesc = ImageDescription(reference: builderImage, descriptor: image.descriptor)
 
@@ -224,20 +224,18 @@ struct ClientBuilderService: ClientBuilderProtocol {
         )
 
         var config = ContainerConfiguration(id: builderContainerId, image: imageDesc, process: processConfig)
-        config.resources = try Parser.resources(cpus: builderCPUs, memory: builderMemory)
+        config.resources = try Parser.resources(cpus: builderCPUs, memory: builderMemory, defaultCPUs: BuildConfig.defaultCPUs, defaultMemory: BuildConfig.defaultMemory)
         config.labels = [ResourceLabelKeys.role: ResourceRoleValues.builder]
         config.mounts = [
-            .init(type: .tmpfs, source: "", destination: "/run", options: []),
-            .init(type: .virtiofs, source: exportsMount.path, destination: "/var/lib/container-builder-shim/exports", options: []),
+            Filesystem.tmpfs(destination: "/run", options: []),
+            Filesystem.virtiofs(source: exportsMount.path, destination: "/var/lib/container-builder-shim/exports", options: []),
         ]
         config.rosetta = useRosetta
 
         guard let defaultNetwork = try await networkClient.builtin else {
             throw ContainerizationError(.invalidState, message: "default network is not present")
         }
-        guard case .running(_, let networkStatus) = defaultNetwork else {
-            throw ContainerizationError(.invalidState, message: "default network is not running")
-        }
+        let networkStatus = defaultNetwork.status
 
         config.networks = [
             AttachmentConfiguration(network: defaultNetwork.id, options: AttachmentOptions(hostname: builderContainerId))

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -186,7 +186,7 @@ struct ClientContainerService: ClientContainerProtocol {
             throw ClientContainerError.notFound(id: id)
         }
 
-        let signal = try parseSignal(signal ?? "SIGTERM")
+        let signal = signal ?? "SIGTERM"
 
         let options = ContainerStopOptions(timeoutInSeconds: Int32(timeout ?? 5), signal: signal)
         try await containerClient.stop(id: container.id, opts: options)
@@ -203,7 +203,7 @@ struct ClientContainerService: ClientContainerProtocol {
             throw ClientContainerError.notRunning(id: id)
         }
 
-        let signal = try parseSignal(signal ?? "SIGKILL")
+        let signal = signal ?? "SIGKILL"
 
         try await containerClient.kill(id: container.id, signal: signal)
     }

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerPersistence
 import Containerization
 import ContainerizationOCI
 import Foundation
@@ -76,7 +77,7 @@ struct ClientImageService: ClientImageProtocol {
         let filteredImages = allImages.filter { img in
             let ref = img.reference.trimmingCharacters(in: .whitespacesAndNewlines)
             let isDigest = ref.contains("@sha256:")
-            let isInfra = Utility.isInfraImage(name: ref)
+            let isInfra = Utility.isInfraImage(name: ref, builderImage: BuildConfig.defaultImage, initImage: VminitConfig.defaultImage)
             return isDigest || !isInfra
         }
         return filteredImages
@@ -84,7 +85,7 @@ struct ClientImageService: ClientImageProtocol {
 
     func delete(id: String) async throws {
         do {
-            _ = try await ClientImage.get(reference: id)
+            _ = try await ClientImage.get(reference: id, containerSystemConfig: ContainerSystemConfig())
         } catch {
             // Handle specific error if needed
             throw ClientImageError.notFound(id: id)
@@ -95,9 +96,10 @@ struct ClientImageService: ClientImageProtocol {
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
+        let containerSystemConfig = ContainerSystemConfig()
         let reference = try {
             guard let tag, !tag.isEmpty else {
-                return try ClientImage.normalizeReference(image)
+                return try ClientImage.normalizeReference(image, containerSystemConfig: containerSystemConfig)
             }
 
             let parsedReference = try Reference.parse(image)
@@ -107,7 +109,7 @@ struct ClientImageService: ClientImageProtocol {
             } else {
                 updatedReference = try parsedReference.withTag(tag)
             }
-            return try ClientImage.normalizeReference(updatedReference.description)
+            return try ClientImage.normalizeReference(updatedReference.description, containerSystemConfig: containerSystemConfig)
         }()
 
         logger.info("Pulling image reference: \(reference)")
@@ -120,6 +122,7 @@ struct ClientImageService: ClientImageProtocol {
                     let image = try await ClientImage.pull(
                         reference: reference,
                         platform: platform,
+                        containerSystemConfig: ContainerSystemConfig(),
                         progressUpdate: { progressEvents in
                             for event in progressEvents {
                                 switch event {
@@ -162,13 +165,14 @@ struct ClientImageService: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let normalizedReference = try ClientImage.normalizeReference(reference)
+        let containerSystemConfig = ContainerSystemConfig()
+        let normalizedReference = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
 
         logger.info("Pushing image reference: \(normalizedReference)")
 
         let image: ClientImage
         do {
-            image = try await ClientImage.get(reference: normalizedReference)
+            image = try await ClientImage.get(reference: normalizedReference, containerSystemConfig: containerSystemConfig)
         } catch {
             logger.error("Image not found: \(normalizedReference)")
             throw ClientImageError.notFound(id: normalizedReference)
@@ -188,6 +192,7 @@ struct ClientImageService: ClientImageProtocol {
                     try await image.push(
                         platform: effectivePlatform,
                         scheme: .auto,
+                        containerSystemConfig: ContainerSystemConfig(),
                         progressUpdate: { progressEvents in
                             for event in progressEvents {
                                 switch event {
@@ -248,7 +253,7 @@ struct ClientImageService: ClientImageProtocol {
             let reference = image.reference
 
             do {
-                _ = try await image.details()
+                _ = try await image.index()
 
                 if imagesInUse.contains(reference) {
                     continue
@@ -458,7 +463,7 @@ struct ClientImageService: ClientImageProtocol {
 
         for reference in references {
             do {
-                let image = try await ClientImage.get(reference: reference)
+                let image = try await ClientImage.get(reference: reference, containerSystemConfig: ContainerSystemConfig())
                 logger.debug("Image exists: \(image.reference)")
                 resolvedRefs.append(image.reference)
             } catch {

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -31,6 +31,8 @@ enum ClientImageError: Error {
 }
 
 struct ClientImageService: ClientImageProtocol {
+    private let containerSystemConfig = ContainerSystemConfig()
+
     // Workaround for narrowing an unspecified push from all platforms to a single platform available.
     // This avoids container push failures caused by missing blobs for non local platforms.
     private func resolvedPushPlatform(for image: ClientImage, requestedPlatform: Platform?, logger: Logger) async throws -> Platform? {
@@ -85,7 +87,7 @@ struct ClientImageService: ClientImageProtocol {
 
     func delete(id: String) async throws {
         do {
-            _ = try await ClientImage.get(reference: id, containerSystemConfig: ContainerSystemConfig())
+            _ = try await ClientImage.get(reference: id, containerSystemConfig: containerSystemConfig)
         } catch {
             // Handle specific error if needed
             throw ClientImageError.notFound(id: id)
@@ -96,7 +98,6 @@ struct ClientImageService: ClientImageProtocol {
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let containerSystemConfig = ContainerSystemConfig()
         let reference = try {
             guard let tag, !tag.isEmpty else {
                 return try ClientImage.normalizeReference(image, containerSystemConfig: containerSystemConfig)
@@ -122,7 +123,7 @@ struct ClientImageService: ClientImageProtocol {
                     let image = try await ClientImage.pull(
                         reference: reference,
                         platform: platform,
-                        containerSystemConfig: ContainerSystemConfig(),
+                        containerSystemConfig: containerSystemConfig,
                         progressUpdate: { progressEvents in
                             for event in progressEvents {
                                 switch event {
@@ -165,7 +166,6 @@ struct ClientImageService: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let containerSystemConfig = ContainerSystemConfig()
         let normalizedReference = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
 
         logger.info("Pushing image reference: \(normalizedReference)")
@@ -192,7 +192,7 @@ struct ClientImageService: ClientImageProtocol {
                     try await image.push(
                         platform: effectivePlatform,
                         scheme: .auto,
-                        containerSystemConfig: ContainerSystemConfig(),
+                        containerSystemConfig: containerSystemConfig,
                         progressUpdate: { progressEvents in
                             for event in progressEvents {
                                 switch event {
@@ -463,7 +463,7 @@ struct ClientImageService: ClientImageProtocol {
 
         for reference in references {
             do {
-                let image = try await ClientImage.get(reference: reference, containerSystemConfig: ContainerSystemConfig())
+                let image = try await ClientImage.get(reference: reference, containerSystemConfig: containerSystemConfig)
                 logger.debug("Image exists: \(image.reference)")
                 resolvedRefs.append(image.reference)
             } catch {

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -1,5 +1,5 @@
 import ContainerAPIClient
-import ContainerNetworkService
+import ContainerNetworkClient
 import ContainerResource
 import Foundation
 import Logging
@@ -16,7 +16,7 @@ struct ClientNetworkService: ClientNetworkProtocol {
 
     func list(filters: String? = nil, logger: Logger) async throws -> [RESTNetworkSummary] {
         let networksList = try await networkClient.list()
-        var allNetworks = networksList.map { RESTNetworkSummary(networkState: $0) }
+        var allNetworks = networksList.map { RESTNetworkSummary(networkResource: $0) }
         let containerClient = ClientContainerService()
         let allContainers = try await containerClient.list(showAll: true, filters: [:])
 
@@ -129,42 +129,30 @@ struct ClientNetworkService: ClientNetworkProtocol {
     func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate {
         // NOTE: We will only create networks of type NAT for the time being (mimic the container CLI)
         let configuration = try NetworkConfiguration(
-            id: name,
+            name: name,
             mode: NetworkMode.nat,
             labels: ResourceLabels(labels),
-            pluginInfo: NetworkPluginInfo(plugin: "container-network-vmnet")
+            plugin: "container-network-vmnet"
         )
         _ = try await networkClient.create(configuration: configuration)
-        logger.debug("Created network with id: \(configuration.id)")
-        return RESTNetworkCreate(Id: configuration.id, Warning: "")
+        logger.debug("Created network with id: \(configuration.name)")
+        return RESTNetworkCreate(Id: configuration.name, Warning: "")
     }
 }
 
 extension RESTNetworkSummary {
-    init(networkState: NetworkState) {
-        let id: String
-        let driver: String
+    init(networkResource: NetworkResource) {
+        let id = networkResource.configuration.name
+        let driver = String(describing: networkResource.configuration.mode)
         let options: [String: String] = [:]  // Not provided by Apple container
-        let labels: [String: String]
-        var subnet: String? = nil
-        var gateway: String? = nil
-
-        switch networkState {
-        case .created(let config):
-            id = config.id
-            driver = String(describing: config.mode)
-            subnet = config.ipv4Subnet.map { String(describing: $0) }
-            labels = config.labels.dictionary
-        case .running(let config, let status):
-            id = config.id
-            driver = String(describing: config.mode)
-            subnet = config.ipv4Subnet.map { String(describing: $0) } ?? String(describing: status.ipv4Subnet)
-            gateway = String(describing: status.ipv4Gateway)
-            labels = config.labels.dictionary
-        }
+        let labels = networkResource.configuration.labels.dictionary
+        let subnet =
+            networkResource.configuration.ipv4Subnet.map { String(describing: $0) }
+            ?? String(describing: networkResource.status.ipv4Subnet)
+        let gateway = String(describing: networkResource.status.ipv4Gateway)
 
         let createdTimestamp = AppleContainerTimestampResolver.iso8601Timestamp(
-            AppleContainerTimestampResolver.networkCreationDate(networkState)
+            AppleContainerTimestampResolver.networkCreationDate(networkResource)
         )
 
         self.init(

--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -100,12 +100,12 @@ struct ClientVolumeService: ClientVolumeProtocol {
         return Self.convert(result)
     }
 
-    private static func convert(_ v: ContainerResource.Volume) -> Volume {
+    private static func convert(_ v: ContainerResource.VolumeConfiguration) -> Volume {
         Volume(
             Name: v.name,
             Driver: v.driver,
             Mountpoint: v.source,
-            CreatedAt: ISO8601DateFormatter().string(from: v.createdAt),
+            CreatedAt: ISO8601DateFormatter().string(from: v.creationDate),
             Status: nil,  // we have no mechanism to report status for the time being
             Labels: v.labels,
             Scope: "local",  // Assuming local for now

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -1,5 +1,6 @@
 import ContainerAPIClient
-import ContainerNetworkService
+import ContainerNetworkClient
+import ContainerPersistence
 import ContainerResource
 import Containerization
 import ContainerizationError
@@ -74,7 +75,7 @@ extension ContainerCreateRoute {
 
             // Check if image exists locally
             do {
-                _ = try await ClientImage.get(reference: body.Image)
+                _ = try await ClientImage.get(reference: body.Image, containerSystemConfig: ContainerSystemConfig())
             } catch {
                 throw Abort(.notFound, reason: "No such image: \(body.Image)")
             }
@@ -82,6 +83,7 @@ extension ContainerCreateRoute {
             let img = try await ClientImage.fetch(
                 reference: body.Image,
                 platform: requestedPlatform,
+                containerSystemConfig: ContainerSystemConfig()
             )
 
             // Unpack a fetched image before use
@@ -92,7 +94,8 @@ extension ContainerCreateRoute {
             let kernel = try await ClientKernel.getDefaultKernel(for: .current)
 
             let initImage = try await ClientImage.fetch(
-                reference: ClientImage.initImageRef, platform: .current
+                reference: ContainerSystemConfig().vminit.image, platform: .current,
+                containerSystemConfig: ContainerSystemConfig()
             )
 
             _ = try await initImage.getCreateSnapshot(
@@ -313,7 +316,7 @@ extension ContainerCreateRoute {
                     let existingVolumes = try await ClientVolume.list()
                     let existingVolume = existingVolumes.first { $0.name == parsed.name }
 
-                    let volume: ContainerResource.Volume
+                    let volume: ContainerResource.VolumeConfiguration
                     if let existing = existingVolume {
                         // Volume exists, use it
                         volume = existing
@@ -419,7 +422,7 @@ func convertPortBindings(from portBindings: [String: [PortBinding]]) throws -> [
                 hostPort = UInt16(try findAvailablePort())
             }
 
-            let publishPort = PublishPort(
+            let publishPort = try PublishPort(
                 hostAddress: try IPAddress(hostAddress),
                 hostPort: hostPort,
                 containerPort: containerPort,

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -1,6 +1,7 @@
 import ContainerAPIClient
 import ContainerBuild
 import ContainerImagesServiceClient
+import ContainerPersistence
 import Containerization
 import ContainerizationError
 import ContainerizationOCI
@@ -414,7 +415,8 @@ extension BuildRoute {
             exports: exports,
             cacheIn: [],
             cacheOut: [],
-            pull: pull
+            pull: pull,
+            containerSystemConfig: ContainerSystemConfig()
         )
 
         sendStreamMessage(" ---> Starting build process")

--- a/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerPersistence
 import ContainerResource
 import ContainerizationOCI
 import Vapor
@@ -38,7 +39,6 @@ extension ImageHistoryRoute {
     private static func historyResponseItems(
         for image: ClientImage,
         requestedName: String,
-        details: ImageDetail,
         preferredPlatform: Platform?
     ) async throws -> [RESTImageHistoryResponseItem] {
         let imageIndex = try await image.index()
@@ -86,7 +86,7 @@ extension ImageHistoryRoute {
                     itemSize = 0
                 }
 
-                let tags = index == history.index(before: history.endIndex) ? [details.name] : []
+                let tags = index == history.index(before: history.endIndex) ? [image.reference] : []
 
                 items.append(
                     RESTImageHistoryResponseItem(
@@ -109,7 +109,7 @@ extension ImageHistoryRoute {
                     Id: image.digest,
                     Created: AppleContainerTimestampResolver.unixTimestampSeconds(config.created),
                     CreatedBy: "",
-                    Tags: [details.name],
+                    Tags: [image.reference],
                     Size: manifest.layers.reduce(0) { $0 + $1.size },
                     Comment: ""
                 )
@@ -137,16 +137,14 @@ extension ImageHistoryRoute {
 
             let image: ClientImage
             do {
-                image = try await ClientImage.get(reference: refOrId)
+                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: ContainerSystemConfig())
             } catch {
                 throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
             }
 
-            let details = try await image.details()
             return try await historyResponseItems(
                 for: image,
                 requestedName: refOrId,
-                details: details,
                 preferredPlatform: preferredPlatform
             )
         }

--- a/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerPersistence
 import ContainerResource
 import ContainerizationOCI
 import Vapor
@@ -90,7 +91,13 @@ extension ImageInspectRoute {
         return "\(name)@\(digest)"
     }
 
-    private static func prioritizeVariants(_ variants: [ImageDetail.Variants]) -> [ImageDetail.Variants] {
+    private struct ImageVariant {
+        let platform: Platform
+        let config: ContainerizationOCI.Image
+        let size: Int64
+    }
+
+    private static func prioritizeVariants(_ variants: [ImageVariant]) -> [ImageVariant] {
         let hostPlatform = requestedOrDefaultPlatform(nil)
 
         return variants.enumerated().sorted { leftVariant, rightVariant in
@@ -133,20 +140,37 @@ extension ImageInspectRoute {
 
             let image: ClientImage
             do {
-                image = try await ClientImage.get(reference: refOrId)
+                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: ContainerSystemConfig())
             } catch {
                 throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
             }
 
             let containers = includeManifests ? try await ContainerClient().list() : []
-            let details: ImageDetail = try await image.details()
             let imageIndex = try await image.index()
             let manifests = imageIndex.manifests
-            let availablePlatforms = Set(details.variants.map(\.platform))
+
+            var variants: [ImageVariant] = []
+            for descriptor in manifests {
+                guard let platform = descriptor.platform,
+                    descriptor.annotations?["vnd.docker.reference.type"] != "attestation-manifest"
+                else {
+                    continue
+                }
+                do {
+                    let config = try await image.config(for: platform)
+                    let manifest = try await image.manifest(for: platform)
+                    let variantSize = descriptor.size + manifest.config.size + manifest.layers.reduce(0) { $0 + $1.size }
+                    variants.append(ImageVariant(platform: platform, config: config, size: variantSize))
+                } catch {
+                    continue
+                }
+            }
+
+            let availablePlatforms = Set(variants.map(\.platform))
             var manifestSummaries: [ImageManifestSummary] = []
             let containerIDs =
                 containers
-                .filter { $0.configuration.image.reference == image.reference || $0.configuration.image.reference == details.name }
+                .filter { $0.configuration.image.reference == image.reference }
                 .map(\.id)
 
             for descriptor in manifests {
@@ -202,7 +226,7 @@ extension ImageInspectRoute {
                             Descriptor: makeOCIDescriptor(
                                 from: descriptor,
                                 appSupportURL: appleContainerAppSupportUrl,
-                                parentDigest: details.index.digest
+                                parentDigest: image.descriptor.digest
                             ),
                             Available: available,
                             Kind: kind,
@@ -224,9 +248,9 @@ extension ImageInspectRoute {
 
             let selectedVariant =
                 if let requestedPlatform {
-                    details.variants.first(where: { $0.platform == requestedPlatform })
+                    variants.first(where: { $0.platform == requestedPlatform })
                 } else {
-                    prioritizeVariants(details.variants).first
+                    prioritizeVariants(variants).first
                 }
 
             if let selectedVariant {
@@ -262,12 +286,12 @@ extension ImageInspectRoute {
                 let summary = RESTImageInspect(
                     Id: selectedManifest?.config.digest ?? image.digest,
                     Descriptor: makeOCIDescriptor(
-                        from: details.index,
+                        from: image.descriptor,
                         appSupportURL: appleContainerAppSupportUrl
                     ),
                     Manifests: includeManifests ? manifestSummaries : nil,
-                    RepoTags: [details.name],
-                    RepoDigests: repoDigestReference(name: details.name, digest: selectedDescriptor?.digest).map { [$0] } ?? [],
+                    RepoTags: [image.reference],
+                    RepoDigests: repoDigestReference(name: image.reference, digest: selectedDescriptor?.digest).map { [$0] } ?? [],
                     Parent: "",
                     Comment: selectedVariant.config.history?.last?.comment ?? "",
                     Created: selectedVariant.config.created,

--- a/Sources/socktainer/Routes/Images/ImageListRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageListRoute.swift
@@ -72,7 +72,6 @@ extension ImageListRoute {
             var imagesSummaries: [RESTImageSummary] = []
 
             for image in images {
-                let details: ImageDetail = try await image.details()
                 let imageIndex = try await image.index()
                 let manifests = imageIndex.manifests
                 var manifestSummaries: [ImageManifestSummary] = []
@@ -131,7 +130,7 @@ extension ImageListRoute {
                                 Descriptor: makeOCIDescriptor(
                                     from: descriptor,
                                     appSupportURL: appleContainerAppSupportUrl,
-                                    parentDigest: details.index.digest
+                                    parentDigest: image.descriptor.digest
                                 ),
                                 Available: available,
                                 Kind: "image",
@@ -154,9 +153,9 @@ extension ImageListRoute {
                     }
                 }
 
-                let repoTags = details.name.isEmpty ? [] : [details.name]
+                let repoTags = image.reference.isEmpty ? [] : [image.reference]
                 let repoDigests = includeDigests && image.reference.contains("@sha256:") ? [image.reference] : []
-                let containersUsingImage = containers.filter { $0.configuration.image.reference == image.reference || $0.configuration.image.reference == details.name }
+                let containersUsingImage = containers.filter { $0.configuration.image.reference == image.reference }
                 let summary = RESTImageSummary(
                     Id: image.digest,
                     ParentId: "",
@@ -169,7 +168,7 @@ extension ImageListRoute {
                     Containers: containersUsingImage.count,
                     Manifests: includeManifests ? manifestSummaries : nil,
                     Descriptor: makeOCIDescriptor(
-                        from: details.index,
+                        from: image.descriptor,
                         appSupportURL: appleContainerAppSupportUrl
                     )
                 )

--- a/Sources/socktainer/Routes/Images/ImageTagRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageTagRoute.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerPersistence
 import Vapor
 
 struct ImageTagRoute: RouteCollection {
@@ -24,16 +25,17 @@ extension ImageTagRoute {
             throw Abort(.badRequest, reason: "repo parameter is required")
         }
 
+        let containerSystemConfig = ContainerSystemConfig()
         let targetReference = try {
             if let tag = query.tag, !tag.isEmpty {
-                return try ClientImage.normalizeReference("\(repo):\(tag)")
+                return try ClientImage.normalizeReference("\(repo):\(tag)", containerSystemConfig: containerSystemConfig)
             }
-            return try ClientImage.normalizeReference(repo)
+            return try ClientImage.normalizeReference(repo, containerSystemConfig: containerSystemConfig)
         }()
 
         let sourceImage: ClientImage
         do {
-            sourceImage = try await ClientImage.get(reference: sourceImageName)
+            sourceImage = try await ClientImage.get(reference: sourceImageName, containerSystemConfig: containerSystemConfig)
         } catch {
             throw Abort(.notFound, reason: "No such image: \(sourceImageName)")
         }

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -111,7 +111,6 @@ extension SystemDFRoute {
         try await withThrowingTaskGroup(of: RESTImageSummary.self) { group in
             for image in images {
                 group.addTask {
-                    let details: ImageDetail = try await image.details()
                     let manifests = try await image.index().manifests
                     var created = 0
                     var totalSize: Int64 = 0
@@ -143,7 +142,7 @@ extension SystemDFRoute {
                         totalSize += descriptor.size
                     }
 
-                    let repoTags = details.name.isEmpty ? [] : [details.name]
+                    let repoTags = image.reference.isEmpty ? [] : [image.reference]
                     let repoDigests = image.reference.contains("@sha256:") ? [image.reference] : []
                     let containerCount = usageByImageReference[image.reference] ?? 0
 

--- a/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
+++ b/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
@@ -19,20 +19,11 @@ enum AppleContainerTimestampResolver {
         return legacyLabelCreationDate(from: container.configuration.labels)
     }
 
-    static func networkCreationDate(_ networkState: NetworkState) -> Date? {
-        if networkState.creationDate > epoch {
-            return networkState.creationDate
+    static func networkCreationDate(_ networkResource: NetworkResource) -> Date? {
+        if networkResource.configuration.creationDate > epoch {
+            return networkResource.configuration.creationDate
         }
-
-        let labels: [String: String]
-        switch networkState {
-        case .created(let config):
-            labels = config.labels.dictionary
-        case .running(let config, _):
-            labels = config.labels.dictionary
-        }
-
-        return legacyLabelCreationDate(from: labels)
+        return legacyLabelCreationDate(from: networkResource.configuration.labels.dictionary)
     }
 
     static func legacyLabelCreationDate(from labels: [String: String]) -> Date? {

--- a/Tests/socktainerTests/Network/NetworkResourceMappingTests.swift
+++ b/Tests/socktainerTests/Network/NetworkResourceMappingTests.swift
@@ -1,0 +1,159 @@
+import ContainerResource
+import ContainerizationExtras
+import Foundation
+import Testing
+
+@testable import socktainer
+
+// MARK: - Helpers
+
+private func makeNetworkResource(
+    name: String = "testnet",
+    mode: NetworkMode = .nat,
+    configSubnet: String? = nil,
+    statusSubnet: String = "192.168.100.0/24",
+    gateway: String = "192.168.100.1",
+    labels: [String: String] = [:]
+) throws -> NetworkResource {
+    let configuration = try NetworkConfiguration(
+        name: name,
+        mode: mode,
+        ipv4Subnet: configSubnet.map { try CIDRv4($0) },
+        labels: ResourceLabels(labels),
+        plugin: "container-network-vmnet"
+    )
+    let status = NetworkStatus(
+        ipv4Subnet: try CIDRv4(statusSubnet),
+        ipv4Gateway: try IPv4Address(gateway),
+        ipv6Subnet: nil
+    )
+    return NetworkResource(configuration: configuration, status: status)
+}
+
+/// NetworkConfiguration.init always sets creationDate = Date(), so we go through
+/// Codable with secondsSince1970 to inject a controlled timestamp in tests.
+private func makeNetworkResourceWithDate(
+    name: String = "testnet",
+    labels: [String: String] = [:],
+    creationDate: Date
+) throws -> NetworkResource {
+    let labelsJSON =
+        (try? String(data: JSONSerialization.data(withJSONObject: labels), encoding: .utf8)) ?? "{}"
+    let configJSON = """
+        {"name":"\(name)","mode":"nat","creationDate":\(creationDate.timeIntervalSince1970),"labels":\(labelsJSON),"plugin":"container-network-vmnet","options":{}}
+        """.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .secondsSince1970
+    let configuration = try decoder.decode(NetworkConfiguration.self, from: configJSON)
+    let status = NetworkStatus(
+        ipv4Subnet: try CIDRv4("192.168.100.0/24"),
+        ipv4Gateway: try IPv4Address("192.168.100.1"),
+        ipv6Subnet: nil
+    )
+    return NetworkResource(configuration: configuration, status: status)
+}
+
+// MARK: - RESTNetworkSummary mapping
+
+@Suite("NetworkResource → RESTNetworkSummary mapping")
+struct NetworkResourceMappingTests {
+
+    @Test("Name and Id both come from configuration.name")
+    func nameAndIdFromConfigurationName() throws {
+        let resource = try makeNetworkResource(name: "mynetwork")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Name == "mynetwork")
+        #expect(summary.Id == "mynetwork")
+    }
+
+    @Test("Subnet comes from configuration.ipv4Subnet when present")
+    func subnetFromConfiguration() throws {
+        let resource = try makeNetworkResource(configSubnet: "10.0.0.0/8", statusSubnet: "192.168.0.0/16")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Subnet == "10.0.0.0/8")
+    }
+
+    @Test("Subnet falls back to status.ipv4Subnet when configuration.ipv4Subnet is nil")
+    func subnetFallsBackToStatus() throws {
+        let resource = try makeNetworkResource(configSubnet: nil, statusSubnet: "172.20.0.0/16")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Subnet == "172.20.0.0/16")
+    }
+
+    @Test("Gateway always comes from status.ipv4Gateway")
+    func gatewayFromStatus() throws {
+        let resource = try makeNetworkResource(gateway: "10.0.0.1")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Gateway == "10.0.0.1")
+    }
+
+    @Test("Labels are mapped from configuration.labels")
+    func labelsFromConfiguration() throws {
+        let resource = try makeNetworkResource(labels: ["env": "test", "team": "platform"])
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Labels["env"] == "test")
+        #expect(summary.Labels["team"] == "platform")
+    }
+
+    @Test("Static fields have expected values")
+    func staticFields() throws {
+        let resource = try makeNetworkResource()
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Scope == "local")
+        #expect(summary.EnableIPv4 == true)
+        #expect(summary.EnableIPv6 == false)
+        #expect(summary.Internal == false)
+        #expect(summary.Attachable == false)
+        #expect(summary.Ingress == false)
+    }
+
+    @Test("Containers is nil by default (populated separately in list())")
+    func containersNilByDefault() throws {
+        let resource = try makeNetworkResource()
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.Containers == nil)
+    }
+}
+
+// MARK: - AppleContainerTimestampResolver.networkCreationDate
+
+@Suite("AppleContainerTimestampResolver.networkCreationDate")
+struct NetworkCreationDateTests {
+
+    @Test("Returns configuration.creationDate when it is after the epoch")
+    func returnsConfigurationDateWhenValid() throws {
+        let expectedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let resource = try makeNetworkResourceWithDate(creationDate: expectedDate)
+        let result = AppleContainerTimestampResolver.networkCreationDate(resource)
+        #expect(result == expectedDate)
+    }
+
+    @Test("Falls back to legacy label when creationDate is epoch")
+    func fallsBackToLegacyLabel() throws {
+        let labelTimestamp = 1_600_000_000.0
+        let resource = try makeNetworkResourceWithDate(
+            labels: [AppleContainerTimestampResolver.legacyCreationTimestampLabel: "\(labelTimestamp)"],
+            creationDate: Date(timeIntervalSince1970: 0)
+        )
+        let result = AppleContainerTimestampResolver.networkCreationDate(resource)
+        #expect(result == Date(timeIntervalSince1970: labelTimestamp))
+    }
+
+    @Test("Returns nil when creationDate is epoch and no legacy label is present")
+    func returnsNilWhenNoDateAndNoLabel() throws {
+        let resource = try makeNetworkResourceWithDate(creationDate: Date(timeIntervalSince1970: 0))
+        let result = AppleContainerTimestampResolver.networkCreationDate(resource)
+        #expect(result == nil)
+    }
+
+    @Test("Does not fall back to label when creationDate is valid")
+    func doesNotUseLabelWhenDateIsValid() throws {
+        let configDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let resource = try makeNetworkResourceWithDate(
+            labels: [AppleContainerTimestampResolver.legacyCreationTimestampLabel: "1600000000"],
+            creationDate: configDate
+        )
+        let result = AppleContainerTimestampResolver.networkCreationDate(resource)
+        #expect(result == configDate)
+    }
+}


### PR DESCRIPTION
## Summary

- Bumps `apple/container` 0.12.0 → 1.0.0 and `containerization` 0.31.0 → 0.33.3
- Fixes all compile errors caused by breaking API changes in 1.0.0
- Adds unit tests for the `NetworkResource` mapping logic that replaced the `NetworkState` enum

## Breaking API changes addressed

| Old (0.12.x) | New (1.0.0) |
|---|---|
| `ContainerNetworkService` product | `ContainerNetworkClient` |
| `NetworkState` enum (`.created` / `.running`) | `NetworkResource` struct (always running when returned) |
| `NetworkConfiguration(id:…pluginInfo:)` | `NetworkConfiguration(name:…plugin: String)` |
| `ClientImage.get/pull/fetch/push/save(…)` | Same + required `containerSystemConfig:` param |
| `ClientImage.details()` | Removed — use `image.index()` / `image.reference` |
| `DefaultsStore` | `ContainerSystemConfig` / `BuildConfig` static defaults |
| `Builder.BuildConfig(…)` | Added required `containerSystemConfig:` param |
| `Parser.resources(cpus:memory:)` | Added required `defaultCPUs:defaultMemory:` params |
| `.init(type: .tmpfs/virtiofs, …)` | `Filesystem.tmpfs(…)` / `Filesystem.virtiofs(…)` factory |
| `PublishPort.init(…)` | Now `throws` |
| `VolumeConfiguration.createdAt` | `creationDate` |
| `kill/stop` signal as `Int32` | Signal as `String` directly |

## Known limitation

`ContainerSystemConfig()` uses hardcoded defaults (registry: `docker.io`, no DNS domain) rather than loading the user's TOML config from `~/.config/container/config.toml`. This matches prior behaviour (`DefaultsStore` also used compiled-in defaults). A follow-up can add proper config loading via `ClientHealthCheck.ping()` to resolve paths.

## Tests

Added `Tests/socktainerTests/Network/NetworkResourceMappingTests.swift` (11 tests) covering:
- `RESTNetworkSummary(networkResource:)` field mapping (name/id, subnet fallback, gateway, labels, static fields)
- `AppleContainerTimestampResolver.networkCreationDate()` (valid date, epoch fallback to legacy label, nil when no label)

These cover the `NetworkState` enum logic that was removed and had no prior test coverage.

## Verification

Tested live against Apple Container 1.0.0 on macOS Tahoe / Apple Silicon:
- ✅ `docker network ls/create/inspect/rm`
- ✅ `docker pull` / `docker images` / `docker image inspect`
- ✅ `docker tag` / `docker history`
- ✅ `docker volume create/inspect/ls/rm`
- ✅ `docker system df`
- ✅ Container create + start (reaches `exited`)
- ✅ `ClientBuilderService` invoked (builder connected; build fails inside BuildKit due to pre-existing bind-mount permission limitation in Apple Container, unrelated to this PR)

> This PR was developed with AI assistance (Claude Code).