### PR TITLE
fix(build): parse buildargs and labels as JSON instead of comma-splitting

### DIFF
--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -69,6 +69,18 @@ struct RESTBuildQuery: Vapor.Content {
 }
 
 extension BuildRoute {
+    /// Parses a Docker API build query parameter (`buildargs` or `labels`).
+    ///
+    /// The Docker Engine API sends these as a JSON-encoded `{"KEY":"VALUE"}` map.
+    /// Returns `["KEY=VALUE", ...]` strings suitable for passing to BuildKit.
+    static func parseBuildQueryParam(_ value: String?) -> [String] {
+        guard let value,
+            let data = value.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+        else { return [] }
+        return dict.map { "\($0.key)=\($0.value)" }
+    }
+
     static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             var query = try req.query.decode(RESTBuildQuery.self)
@@ -196,17 +208,8 @@ extension BuildRoute {
                 throw error
             }
 
-            // Parse build arguments
-            let buildArgs: [String] = {
-                guard let buildArgsString = query.buildargs else { return [] }
-                return buildArgsString.split(separator: ",").map(String.init)
-            }()
-
-            // Parse labels
-            let labels: [String] = {
-                guard let labelsString = query.labels else { return [] }
-                return labelsString.split(separator: ",").map(String.init)
-            }()
+            let buildArgs = BuildRoute.parseBuildQueryParam(query.buildargs)
+            let labels = BuildRoute.parseBuildQueryParam(query.labels)
 
             // Create streaming response for build output
             let body = Response.Body { writer in

--- a/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
+++ b/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
@@ -1,0 +1,58 @@
+import Testing
+
+@testable import socktainer
+
+/// The Docker Engine API sends `buildargs` and `labels` as JSON-encoded
+/// dictionaries in the query string, e.g.:
+///   ?buildargs={"FOO":"bar","BAZ":"qux"}
+///   ?labels={"com.example.team":"platform"}
+///
+/// BuildKit expects them as ["KEY=VALUE", ...] strings.
+/// The old code did `string.split(separator: ",")` which breaks on any JSON
+/// with multiple keys — the comma inside the JSON object is not a delimiter.
+@Suite("BuildRoute query param parsing")
+struct BuildQueryParamTests {
+
+    // MARK: - buildargs
+
+    @Test("Single build arg is parsed correctly")
+    func singleBuildArg() {
+        let result = BuildRoute.parseBuildQueryParam(#"{"FOO":"bar"}"#)
+        #expect(result == ["FOO=bar"])
+    }
+
+    @Test("Multiple build args produce KEY=VALUE entries, not a broken comma-split")
+    func multipleBuildArgs() {
+        // Old comma-split would produce: ["{\"FOO\":\"bar\"", "\"BAZ\":\"qux\"}"]
+        // Correct result: ["FOO=bar", "BAZ=qux"]
+        let result = BuildRoute.parseBuildQueryParam(#"{"FOO":"bar","BAZ":"qux"}"#)
+        #expect(result.count == 2)
+        #expect(result.contains("FOO=bar"))
+        #expect(result.contains("BAZ=qux"))
+    }
+
+    @Test("Build arg value containing a comma is preserved intact")
+    func buildArgValueWithComma() {
+        // A value like "a,b" would be destroyed by comma-splitting
+        let result = BuildRoute.parseBuildQueryParam(#"{"LIST":"a,b,c"}"#)
+        #expect(result == ["LIST=a,b,c"])
+    }
+
+    @Test("Nil input returns empty array")
+    func nilInput() {
+        let result = BuildRoute.parseBuildQueryParam(nil)
+        #expect(result == [])
+    }
+
+    @Test("Empty JSON object returns empty array")
+    func emptyObject() {
+        let result = BuildRoute.parseBuildQueryParam("{}")
+        #expect(result == [])
+    }
+
+    @Test("Invalid JSON returns empty array (graceful degradation)")
+    func invalidJson() {
+        let result = BuildRoute.parseBuildQueryParam("not-json")
+        #expect(result == [])
+    }
+}


### PR DESCRIPTION
Fixes #208.

## Problem

The Docker Engine API sends `buildargs` and `labels` as JSON-encoded dictionaries in the query string:
```
POST /build?buildargs={"FOO":"bar","BAZ":"qux"}&labels={"com.example.team":"platform"}
```

The previous code split on commas:
```swift
buildArgsString.split(separator: ",").map(String.init)
```

This corrupts every build arg before it reaches BuildKit:

| Input (what Docker sends) | Old result (broken) | New result (correct) |
|---|---|---|
| `{"FOO":"bar","BAZ":"qux"}` | `["{\"FOO\":\"bar\"", "\"BAZ\":\"qux\"}"]` | `["FOO=bar", "BAZ=qux"]` |
| `{"LIST":"a,b,c"}` | `["{\"LIST\":\"a", "b", "c\"}"]` | `["LIST=a,b,c"]` |
| `{"FOO":"bar"}` | `["{\"FOO\":\"bar\"}"]` | `["FOO=bar"]` |

Every `docker build --build-arg` and `--label` was silently ignored.

## Fix

Extract `parseBuildQueryParam(_:)` as a static function that parses the JSON map and returns `["KEY=VALUE", ...]`. Replace both inline closures with calls to this function.

## Tests

6 regression tests in `BuildQueryParamTests.swift` covering:
- Single key
- Multiple keys (the comma-split failure case)  
- Value containing a comma (would be shredded by comma-split)
- Nil input
- Empty JSON object
- Invalid JSON (graceful degradation)

> This PR was developed with AI assistance (Claude Code).