### PR TITLE
Honor Env, User and WorkingDir in exec requests

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -241,6 +241,15 @@ struct ExecRoute: RouteCollection {
 
             try client.enforceContainerRunning(container: container)
 
+            // Apply the request's Env/User/WorkingDir before marking the exec
+            // started: applying them can throw, and doing so after markStarted
+            // would leave the exec reported as running forever.
+            let baseProcessConfig: ProcessConfiguration = try {
+                var processConfig = container.configuration.initProcess
+                try ExecRoute.applyProcessOverrides(&processConfig, config: config)
+                return processConfig
+            }()
+
             // Reject starting an exec instance more than once (Docker semantics).
             guard await ExecManager.shared.markStarted(id: execId) else {
                 throw Abort(.conflict, reason: "Exec instance \(execId) has already been started")
@@ -262,11 +271,10 @@ struct ExecRoute: RouteCollection {
             if detach {
                 let executable = config.cmd.first!
                 let arguments = Array(config.cmd.dropFirst())
-                var processConfig = container.configuration.initProcess
+                var processConfig = baseProcessConfig
                 processConfig.executable = executable
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
-                try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                 do {
                     let process = try await ContainerClient().createProcess(
@@ -312,11 +320,10 @@ struct ExecRoute: RouteCollection {
 
                     let executable = config.cmd.first!
                     let arguments = Array(config.cmd.dropFirst())
-                    var processConfig = container.configuration.initProcess
+                    var processConfig = baseProcessConfig
                     processConfig.executable = executable
                     processConfig.arguments = arguments
                     processConfig.terminal = tty
-                    try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                     let process = try await ContainerClient().createProcess(
                         containerId: container.id,
@@ -468,11 +475,10 @@ struct ExecRoute: RouteCollection {
                 let executable = config.cmd.first!
                 let arguments = Array(config.cmd.dropFirst())
 
-                var processConfig = container.configuration.initProcess
+                var processConfig = baseProcessConfig
                 processConfig.executable = executable
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
-                try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                 let process = try await ContainerClient().createProcess(
                     containerId: container.id,

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerResource
 import Foundation
 import NIOCore
 import Vapor
@@ -15,6 +16,9 @@ actor ExecManager {
         let attachStderr: Bool
         let tty: Bool
         let detach: Bool
+        let env: [String]
+        let user: String?
+        let workingDir: String?
     }
 
     private var storage: [String: ExecConfig] = [:]
@@ -69,6 +73,9 @@ struct CreateExecRequest: Content {
     let AttachStdout: Bool?
     let AttachStderr: Bool?
     let Tty: Bool?
+    let Env: [String]?
+    let User: String?
+    let WorkingDir: String?
 }
 
 struct CreateExecResponse: Content {
@@ -139,12 +146,12 @@ struct ExecRoute: RouteCollection {
                 ExitCode: recordedExitCode.map { Int($0) },
                 ProcessConfig: ExecInspectResponse.ProcessConfigInfo(
                     privileged: false,
-                    user: "",
+                    user: config.user ?? "",
                     tty: config.tty,
                     entrypoint: config.cmd.first ?? "",
                     arguments: Array(config.cmd.dropFirst()),
-                    workingDir: "",
-                    env: []
+                    workingDir: config.workingDir ?? "",
+                    env: config.env
                 ),
                 OpenStdin: config.attachStdin,
                 OpenStderr: config.attachStderr,
@@ -191,11 +198,30 @@ struct ExecRoute: RouteCollection {
                 attachStdout: body.AttachStdout ?? true,
                 attachStderr: attachStderr,
                 tty: body.Tty ?? false,
-                detach: false
+                detach: false,
+                env: body.Env ?? [],
+                user: body.User,
+                workingDir: body.WorkingDir
             )
 
             let id = await ExecManager.shared.create(config: config)
             return Response(status: .created, body: .init(data: try JSONEncoder().encode(CreateExecResponse(Id: id))))
+        }
+    }
+
+    // Applies the exec request's Env, User and WorkingDir on top of the
+    // container's init process configuration, mirroring how container create
+    // handles the same fields. Without this the Docker API fields are ignored
+    // and execs always run with the container's defaults.
+    static func applyProcessOverrides(_ processConfig: inout ProcessConfiguration, config: ExecManager.ExecConfig) throws {
+        if !config.env.isEmpty {
+            processConfig.environment = try Parser.allEnv(imageEnvs: processConfig.environment, envFiles: [], envs: config.env)
+        }
+        if let workingDir = config.workingDir, !workingDir.isEmpty {
+            processConfig.workingDirectory = workingDir
+        }
+        if let user = config.user, !user.isEmpty {
+            processConfig.user = .raw(userString: user)
         }
     }
 
@@ -240,6 +266,7 @@ struct ExecRoute: RouteCollection {
                 processConfig.executable = executable
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
+                try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                 do {
                     let process = try await ContainerClient().createProcess(
@@ -289,6 +316,7 @@ struct ExecRoute: RouteCollection {
                     processConfig.executable = executable
                     processConfig.arguments = arguments
                     processConfig.terminal = tty
+                    try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                     let process = try await ContainerClient().createProcess(
                         containerId: container.id,
@@ -444,6 +472,7 @@ struct ExecRoute: RouteCollection {
                 processConfig.executable = executable
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
+                try ExecRoute.applyProcessOverrides(&processConfig, config: config)
 
                 let process = try await ContainerClient().createProcess(
                     containerId: container.id,


### PR DESCRIPTION
## Problem

The exec create endpoint only decodes `Cmd` and the attach flags, so the `Env`, `User` and `WorkingDir` fields of the Docker exec API are silently ignored and every exec runs with the container's defaults:

```
$ docker exec -w /workspaces -u root -e FOO=bar c sh -c 'echo "cwd=$(pwd) user=$(id -un) FOO=$FOO"'
cwd=/ user=root FOO=
```

`docker exec -e/-u/-w` is a common shape for programmatic clients (dev containers, CI tooling) that run lifecycle commands through the API.

## Fix

Decode the three fields, keep them on the exec config, and apply them to the process configuration in all three start paths (detached, HTTP streaming, TCP upgrade), mirroring how container create handles the same fields:

- `Env` merges over the container's environment with the request taking precedence (via `Parser.allEnv`)
- `User` maps to `.raw(userString:)`
- `WorkingDir` overrides the initial working directory when non-empty

Exec inspect now reports these values instead of hardcoded empty strings.

This is field-level parity for the exec endpoints tracked in #14 — the endpoints are implemented, but these request fields were dropped.

## Testing

Manually against Apple Container 1.0.0 on macOS 26.5 (Tahoe), via the Docker CLI:

```
$ docker exec -w /workspaces -u root -e FOO=bar c sh -c 'echo "cwd=$(pwd) user=$(id -un) FOO=$FOO"'
cwd=/workspaces user=root FOO=bar

# container env is preserved alongside the request env
$ docker exec -e FOO=bar c sh -c 'echo $PATH; echo $FOO'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
FOO=bar

# exit codes unaffected
$ docker exec c sh -c 'exit 9'; echo $?
9
```
