### PR TITLE
feat: docker compose support

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -155,9 +155,36 @@ struct ClientImageService: ClientImageProtocol {
                     continuation.yield("Image digest: \(image.digest)")
                     continuation.finish()
                 } catch {
-                    logger.error("Failed to pull image \(reference): \(error)")
-                    continuation.yield(String(describing: error))
-                    continuation.finish(throwing: error)
+                    // On arm64 hosts: if the image has no arm64 variant, fall back to amd64 (Rosetta).
+                    // Apple Container enables Rosetta automatically when the container platform is amd64.
+                    let errMsg = String(describing: error)
+                    if platform.architecture == "arm64",
+                        errMsg.contains("does not support required platforms")
+                    {
+                        let amd64 = Platform(arch: "amd64", os: platform.os, variant: nil)
+                        logger.info("arm64 not available for \(reference), retrying with amd64 (Rosetta)")
+                        continuation.yield("linux/arm64 not available — retrying with linux/amd64 (Rosetta)")
+                        do {
+                            let fallbackImage = try await ClientImage.pull(
+                                reference: reference,
+                                platform: amd64,
+                                containerSystemConfig: containerSystemConfig,
+                                progressUpdate: nil
+                            )
+                            try await fallbackImage.unpack(platform: amd64, progressUpdate: nil)
+                            logger.info("Successfully pulled \(reference) for amd64 (Rosetta)")
+                            continuation.yield("Image digest: \(fallbackImage.digest)")
+                            continuation.finish()
+                        } catch let fallbackError {
+                            logger.error("amd64 fallback also failed for \(reference): \(fallbackError)")
+                            continuation.yield(String(describing: fallbackError))
+                            continuation.finish(throwing: fallbackError)
+                        }
+                    } else {
+                        logger.error("Failed to pull image \(reference): \(error)")
+                        continuation.yield(errMsg)
+                        continuation.finish(throwing: error)
+                    }
                 }
             }
         }

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -25,6 +25,13 @@ struct ClientNetworkService: ClientNetworkProtocol {
             let network = allNetworks[i]
             var containersForNetwork: [String: NetworkContainer] = [:]
             for container in allContainers {
+                // Exclude internal Socktainer DNS sidecars from the Docker API view.
+                // If CoreDNS shows up as an attached container, docker compose down
+                // reports "Resource is still in use" and skips the DELETE /networks/{id}
+                // call — preventing our cleanup hook from firing.
+                guard container.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole else {
+                    continue
+                }
                 for attachment in container.networks {
                     if attachment.network == network.Id || attachment.network == network.Name {
                         let nc = NetworkContainer(

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -44,12 +44,17 @@ actor NetworkDNSManager {
     /// Returns the IP of the CoreDNS container for `networkId`, creating it lazily.
     /// Concurrent callers for the same network are coalesced — only one container is created.
     func ensureDNSContainer(networkId: String) async throws -> String {
-        if let ip = containerIPs[networkId] { return ip }
+        if let ip = containerIPs[networkId] {
+            log.info("[dns-manager] reusing cached CoreDNS at \(ip) for network \(networkId)")
+            return ip
+        }
 
         if let pending = pendingCreation[networkId] {
+            log.info("[dns-manager] waiting for in-flight CoreDNS creation for network \(networkId)")
             return try await pending.value
         }
 
+        log.info("[dns-manager] creating CoreDNS container for network \(networkId)")
         let appSupportURL = self.appSupportURL
         let dnsPort = self.dnsPort
         let task = Task<String, Error> {
@@ -61,6 +66,7 @@ actor NetworkDNSManager {
             let ip = try await task.value
             containerIPs[networkId] = ip
             pendingCreation.removeValue(forKey: networkId)
+            log.info("[dns-manager] CoreDNS running at \(ip) for network \(networkId)")
             return ip
         } catch {
             pendingCreation.removeValue(forKey: networkId)
@@ -72,14 +78,30 @@ actor NetworkDNSManager {
     /// Called when a user network is deleted.
     func cleanupDNSContainer(networkId: String) async {
         containerIPs.removeValue(forKey: networkId)
-        let containerId = Self.containerPrefix + networkId
+        let containerId = ContainerNameUtility.sanitize(Self.containerPrefix + networkId)
         let client = ContainerClient()
         do {
-            if let snapshot = try? await client.get(id: containerId), snapshot.status == .running {
+            guard let snapshot = try? await client.get(id: containerId) else {
+                return  // container already gone
+            }
+            if snapshot.status == .running {
                 try? await client.stop(id: containerId)
             }
-            try await client.delete(id: containerId)
-            log.info("[dns-manager] removed DNS container for network \(networkId)")
+            // Retry deletion: Apple Container may need a moment to fully release
+            // the container from the network after stop. Retry up to 3 times with
+            // short gaps rather than a fixed 1s sleep so we stay fast.
+            for attempt in 1...3 {
+                do {
+                    try await client.delete(id: containerId)
+                    log.info("[dns-manager] removed DNS container for network \(networkId)")
+                    return
+                } catch {
+                    guard attempt < 3 else {
+                        throw error
+                    }
+                    try? await Task.sleep(for: .milliseconds(300))
+                }
+            }
         } catch {
             log.warning("[dns-manager] could not remove DNS container \(containerId): \(error)")
         }
@@ -104,7 +126,8 @@ actor NetworkDNSManager {
     /// Runs outside the actor's executor to avoid deadlock with the Task created in ensureDNSContainer.
     private static func createDNSContainerWork(networkId: String, appSupportURL: URL, dnsPort: Int) async throws -> String {
         let containerClient = ContainerClient()
-        let containerId = containerPrefix + networkId
+        // Sanitize to respect Apple Container's 64-char container ID limit
+        let containerId = ContainerNameUtility.sanitize(containerPrefix + networkId)
 
         // Reuse if already running
         if let snapshot = try? await containerClient.get(id: containerId),
@@ -158,7 +181,7 @@ actor NetworkDNSManager {
         config.networks = [
             AttachmentConfiguration(
                 network: networkId,
-                options: AttachmentOptions(hostname: containerPrefix + networkId)
+                options: AttachmentOptions(hostname: ContainerNameUtility.sanitize(containerPrefix + networkId))
             )
         ]
         // Point CoreDNS to the vmnet gateway for upstream resolution

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -1,0 +1,203 @@
+import ContainerAPIClient
+import ContainerNetworkClient
+import ContainerPersistence
+import ContainerResource
+import Containerization
+import ContainerizationError
+import Foundation
+import Logging
+import Vapor
+
+struct NetworkDNSManagerKey: StorageKey {
+    typealias Value = NetworkDNSManager
+}
+
+/// Manages one CoreDNS sidecar container per user-created network.
+///
+/// Each CoreDNS container is configured to forward all DNS queries to
+/// SocktainerDNSServer running on the host (reachable at the network's
+/// gateway IP on port 2054). SocktainerDNSServer resolves container
+/// service names and forwards unknown queries upstream to 1.1.1.1.
+///
+/// DNS containers are identified by the label `socktainer.role=dns` and
+/// named `socktainer-dns-{networkId}`.
+actor NetworkDNSManager {
+    static let dnsRole = "dns"
+    static let roleLabel = "socktainer.role"
+    static let networkLabel = "socktainer.network"
+    static let containerPrefix = "socktainer-dns-"
+    static let dnsPort = 2054
+
+    private let appSupportURL: URL
+    private let dnsPort: Int
+    private var containerIPs: [String: String] = [:]  // networkId → CoreDNS container IP
+    private var pendingCreation: [String: Task<String, Error>] = [:]
+    private var log = Logger(label: "socktainer.dns.manager")
+
+    init(appSupportURL: URL, dnsPort: Int = 2054) {
+        self.appSupportURL = appSupportURL
+        self.dnsPort = dnsPort
+    }
+
+    // MARK: - Public API
+
+    /// Returns the IP of the CoreDNS container for `networkId`, creating it lazily.
+    /// Concurrent callers for the same network are coalesced — only one container is created.
+    func ensureDNSContainer(networkId: String) async throws -> String {
+        if let ip = containerIPs[networkId] { return ip }
+
+        if let pending = pendingCreation[networkId] {
+            return try await pending.value
+        }
+
+        let appSupportURL = self.appSupportURL
+        let dnsPort = self.dnsPort
+        let task = Task<String, Error> {
+            try await Self.createDNSContainerWork(networkId: networkId, appSupportURL: appSupportURL, dnsPort: dnsPort)
+        }
+        pendingCreation[networkId] = task
+
+        do {
+            let ip = try await task.value
+            containerIPs[networkId] = ip
+            pendingCreation.removeValue(forKey: networkId)
+            return ip
+        } catch {
+            pendingCreation.removeValue(forKey: networkId)
+            throw error
+        }
+    }
+
+    /// Removes the CoreDNS container for `networkId` and clears its cached IP.
+    /// Called when a user network is deleted.
+    func cleanupDNSContainer(networkId: String) async {
+        containerIPs.removeValue(forKey: networkId)
+        let containerId = Self.containerPrefix + networkId
+        let client = ContainerClient()
+        do {
+            if let snapshot = try? await client.get(id: containerId), snapshot.status == .running {
+                try? await client.stop(id: containerId)
+            }
+            try await client.delete(id: containerId)
+            log.info("[dns-manager] removed DNS container for network \(networkId)")
+        } catch {
+            log.warning("[dns-manager] could not remove DNS container \(containerId): \(error)")
+        }
+    }
+
+    /// Scans for and removes any stale DNS containers left from a previous Socktainer run.
+    /// Should be called once at startup.
+    func cleanupStaleDNSContainers() async {
+        let client = ContainerClient()
+        guard let containers = try? await client.list() else { return }
+        for container in containers {
+            guard container.configuration.labels[Self.roleLabel] == Self.dnsRole else { continue }
+            log.info("[dns-manager] cleaning up stale DNS container: \(container.id)")
+            if container.status == .running { try? await client.stop(id: container.id) }
+            try? await client.delete(id: container.id)
+        }
+        containerIPs.removeAll()
+    }
+
+    // MARK: - Private implementation
+
+    /// Runs outside the actor's executor to avoid deadlock with the Task created in ensureDNSContainer.
+    private static func createDNSContainerWork(networkId: String, appSupportURL: URL, dnsPort: Int) async throws -> String {
+        let containerClient = ContainerClient()
+        let containerId = containerPrefix + networkId
+
+        // Reuse if already running
+        if let snapshot = try? await containerClient.get(id: containerId),
+            snapshot.status == .running,
+            let attachment = snapshot.networks.first(where: { $0.network == networkId })
+        {
+            return attachment.ipv4Address.address.description
+        }
+
+        // Get the network's gateway IP — needed for the CoreDNS Corefile
+        let networkResource = try await NetworkClient().get(id: networkId)
+        let gatewayIP = networkResource.status.ipv4Gateway.description
+
+        // Write Corefile to a host directory that will be virtiofs-mounted
+        let corefileDir = appSupportURL.appendingPathComponent("dns/\(networkId)")
+        try FileManager.default.createDirectory(at: corefileDir, withIntermediateDirectories: true)
+        let corefileURL = corefileDir.appendingPathComponent("Corefile")
+        let corefile = """
+            . {
+                forward . \(gatewayIP):\(dnsPort)
+                cache 10
+                errors
+            }
+            """
+        try corefile.write(to: corefileURL, atomically: true, encoding: .utf8)
+
+        // Pull CoreDNS image — arm64 native, no Rosetta needed
+        let containerSystemConfig = ContainerSystemConfig()
+        let imageRef = try ClientImage.normalizeReference("docker.io/coredns/coredns:latest", containerSystemConfig: containerSystemConfig)
+        let platform = Platform.current
+        let image = try await ClientImage.fetch(reference: imageRef, platform: platform, containerSystemConfig: containerSystemConfig)
+        _ = try await image.getCreateSnapshot(platform: platform)
+
+        let processConfig = ProcessConfiguration(
+            executable: "/coredns",
+            arguments: ["-conf", "/etc/coredns/Corefile"],
+            environment: [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0)
+        )
+
+        var config = ContainerConfiguration(id: containerId, image: image.description, process: processConfig)
+        config.labels = [
+            roleLabel: dnsRole,
+            networkLabel: networkId,
+        ]
+        config.mounts = [
+            Filesystem.virtiofs(source: corefileDir.path, destination: "/etc/coredns", options: [])
+        ]
+        config.networks = [
+            AttachmentConfiguration(
+                network: networkId,
+                options: AttachmentOptions(hostname: containerPrefix + networkId)
+            )
+        ]
+        // Point CoreDNS to the vmnet gateway for upstream resolution
+        config.dns = ContainerConfiguration.DNSConfiguration(
+            nameservers: [gatewayIP],
+            domain: nil,
+            searchDomains: [],
+            options: []
+        )
+
+        let kernel = try await ClientKernel.getDefaultKernel(for: .current)
+
+        // Remove any stale container first
+        if let existing = try? await containerClient.get(id: containerId) {
+            if existing.status == .running { try? await containerClient.stop(id: containerId) }
+            try? await containerClient.delete(id: containerId)
+        }
+
+        try await containerClient.create(configuration: config, options: .default, kernel: kernel)
+        try await startDNSContainer(id: containerId, client: containerClient)
+
+        let snapshot = try await containerClient.get(id: containerId)
+        guard let attachment = snapshot.networks.first(where: { $0.network == networkId }) else {
+            throw ContainerizationError(.invalidState, message: "DNS container for \(networkId) has no network attachment")
+        }
+        return attachment.ipv4Address.address.description
+    }
+
+    private static func startDNSContainer(id: String, client: ContainerClient) async throws {
+        let io = try ProcessIO.create(tty: false, interactive: false, detach: true)
+        defer { try? io.close() }
+        do {
+            let process = try await client.bootstrap(id: id, stdio: io.stdio)
+            try await process.start()
+            try io.closeAfterStart()
+        } catch {
+            try? await client.stop(id: id)
+            try? await client.delete(id: id)
+            throw ContainerizationError(.internalError, message: "failed to start DNS container: \(error)")
+        }
+    }
+}

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -94,6 +94,8 @@ actor NetworkDNSManager {
                 do {
                     try await client.delete(id: containerId)
                     log.info("[dns-manager] removed DNS container for network \(networkId)")
+                    let corefileDir = appSupportURL.appendingPathComponent("dns/\(networkId)")
+                    try? FileManager.default.removeItem(at: corefileDir)
                     return
                 } catch {
                     guard attempt < 3 else {

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -1,0 +1,276 @@
+import Darwin
+import Foundation
+import Logging
+import Vapor
+
+struct SocktainerDNSServerKey: StorageKey {
+    typealias Value = SocktainerDNSServer
+}
+
+/// UDP DNS server that resolves container service names and forwards unknown queries to 1.1.1.1.
+///
+/// Runs on 0.0.0.0:2054 (covers all interfaces including vmnet gateways).
+/// Port 2053 is reserved by Apple Container's own DNS handler.
+/// Container names are registered after start via register(hostname:ip:) and
+/// unregistered on container removal via unregister(hostname:).
+final class SocktainerDNSServer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String: [UInt8]] = [:]  // normalized hostname → 4-byte IPv4
+    private var log = Logger(label: "socktainer.dns")
+
+    func register(hostname: String, ip: String) {
+        guard let addr = Self.parseIPv4(ip) else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let key = Self.normalize(hostname)
+        entries[key] = addr
+        log.info("[dns] registered \(key) → \(ip)")
+    }
+
+    func unregister(hostname: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        let key = Self.normalize(hostname)
+        if entries.removeValue(forKey: key) != nil {
+            log.info("[dns] unregistered \(key)")
+        }
+    }
+
+    func listEntries() -> [String: String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.mapValues { ip in "\(ip[0]).\(ip[1]).\(ip[2]).\(ip[3])" }
+    }
+
+    /// Tries to bind to `preferredPort`, then `preferredPort+1`, `+2`, up to `maxAttempts`.
+    /// Returns the port that was successfully bound, or nil if all attempts failed.
+    /// The resolved port must be passed to NetworkDNSManager so Corefiles reference the right one.
+    @discardableResult
+    func start(preferredPort: Int = 2054, maxAttempts: Int = 10) -> Int? {
+        for offset in 0..<maxAttempts {
+            let port = preferredPort + offset
+            if canBind(port: port) {
+                Thread.detachNewThread { self.serverLoop(port: port) }
+                return port
+            }
+            log.warning("[dns] port \(port) unavailable, trying \(port + 1)")
+        }
+        log.error("[dns] no available port in \(preferredPort)..<\(preferredPort + maxAttempts)")
+        return nil
+    }
+
+    private func canBind(port: Int) -> Bool {
+        let fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard fd >= 0 else { return false }
+        defer { Darwin.close(fd) }
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(port).bigEndian
+        addr.sin_addr.s_addr = INADDR_ANY
+        return withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+    }
+
+    private func serverLoop(port: Int) {
+        let fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard fd >= 0 else {
+            log.error("[dns] socket() failed: \(String(cString: strerror(errno)))")
+            return
+        }
+        defer { Darwin.close(fd) }
+
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(port).bigEndian
+        addr.sin_addr.s_addr = INADDR_ANY
+
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            log.error("[dns] bind() failed on port \(port): \(String(cString: strerror(errno)))")
+            return
+        }
+
+        log.info("[dns] listening on 0.0.0.0:\(port)")
+
+        var buf = [UInt8](repeating: 0, count: 512)
+
+        // Dispatch each query to a thread so the recvfrom loop is never blocked.
+        // forwardToUpstream() waits up to 2s for 1.1.1.1; without async dispatch
+        // every pending query times out while the loop is stuck on a slow upstream.
+        while true {
+            var clientAddr = sockaddr_in()
+            var clientLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let n = withUnsafeMutablePointer(to: &clientAddr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                    recvfrom(fd, &buf, buf.count, 0, sockPtr, &clientLen)
+                }
+            }
+            guard n > 12 else { continue }
+
+            let packet = Array(buf[0..<n])
+            let capturedAddr = clientAddr
+            let capturedLen = clientLen
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let response = self.handleQuery(packet) else { return }
+                var addr = capturedAddr
+                _ = response.withUnsafeBytes { ptr in
+                    withUnsafePointer(to: &addr) {
+                        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                            sendto(fd, ptr.baseAddress!, response.count, 0, $0, capturedLen)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func handleQuery(_ packet: [UInt8]) -> [UInt8]? {
+        guard packet.count >= 12 else { return nil }
+
+        // Only handle standard queries (QR=0, OPCODE=0)
+        let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
+        guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
+
+        guard let (qname, qtype, _) = parseQuestion(packet, offset: 12) else {
+            return forwardToUpstream(packet)
+        }
+
+        let normalized = Self.normalize(qname)
+
+        if qtype == 1 {  // A record
+            lock.lock()
+            let ip = entries[normalized]
+            lock.unlock()
+            if let ip {
+                log.info("[dns] A \(normalized) → \(ip[0]).\(ip[1]).\(ip[2]).\(ip[3]) (local)")
+                return buildAResponse(packet: packet, ip: ip)
+            }
+        } else if qtype == 28 {  // AAAA — return NODATA for known hosts (prevents musl NXDOMAIN bug)
+            lock.lock()
+            let known = entries[normalized] != nil
+            lock.unlock()
+            if known {
+                return buildNodataResponse(packet: packet)
+            }
+        }
+
+        if !normalized.contains(".") {
+            log.info("[dns] \(normalized) not in table, forwarding to 1.1.1.1")
+        }
+        return forwardToUpstream(packet)
+    }
+
+    private func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
+        var pos = offset
+        var labels: [String] = []
+        while pos < packet.count {
+            let len = Int(packet[pos])
+            pos += 1
+            if len == 0 { break }
+            if (len & 0xC0) == 0xC0 { return nil }
+            guard pos + len <= packet.count else { return nil }
+            labels.append(String(bytes: packet[pos..<(pos + len)], encoding: .utf8) ?? "")
+            pos += len
+        }
+        guard pos + 4 <= packet.count else { return nil }
+        let qtype = (UInt16(packet[pos]) << 8) | UInt16(packet[pos + 1])
+        pos += 4
+        return (labels.joined(separator: "."), qtype, pos)
+    }
+
+    private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {
+        var response = packet
+        let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
+        let rflags: UInt16 = 0x8400 | rd  // QR=1, AA=1
+        response[2] = UInt8(rflags >> 8)
+        response[3] = UInt8(rflags & 0xFF)
+        response[6] = 0
+        response[7] = 1  // ANCOUNT=1
+        response[8] = 0
+        response[9] = 0
+        response[10] = 0
+        response[11] = 0
+        response += [
+            0xC0, 0x0C,  // NAME: pointer to offset 12
+            0x00, 0x01,  // TYPE: A
+            0x00, 0x01,  // CLASS: IN
+            0x00, 0x00, 0x00, 0x1E,  // TTL: 30s
+            0x00, 0x04,  // RDLENGTH: 4
+            ip[0], ip[1], ip[2], ip[3],
+        ]
+        return response
+    }
+
+    private func buildNodataResponse(packet: [UInt8]) -> [UInt8] {
+        var response = packet
+        let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
+        let rflags: UInt16 = 0x8400 | rd
+        response[2] = UInt8(rflags >> 8)
+        response[3] = UInt8(rflags & 0xFF)
+        response[6] = 0
+        response[7] = 0
+        response[8] = 0
+        response[9] = 0
+        response[10] = 0
+        response[11] = 0
+        return response
+    }
+
+    private func forwardToUpstream(_ packet: [UInt8]) -> [UInt8]? {
+        let sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard sockfd >= 0 else { return nil }
+        defer { Darwin.close(sockfd) }
+
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var upstream = sockaddr_in()
+        upstream.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        upstream.sin_family = sa_family_t(AF_INET)
+        upstream.sin_port = UInt16(53).bigEndian
+        inet_pton(AF_INET, "1.1.1.1", &upstream.sin_addr)
+
+        let connected = withUnsafePointer(to: &upstream) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(sockfd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard connected == 0 else { return nil }
+
+        let sent = packet.withUnsafeBytes { send(sockfd, $0.baseAddress!, packet.count, 0) }
+        guard sent == packet.count else { return nil }
+
+        var buf = [UInt8](repeating: 0, count: 512)
+        let received = recv(sockfd, &buf, buf.count, 0)
+        guard received > 0 else { return nil }
+        return Array(buf[0..<received])
+    }
+
+    static func normalize(_ hostname: String) -> String {
+        var s = hostname.lowercased()
+        while s.hasSuffix(".") { s = String(s.dropLast()) }
+        return s
+    }
+
+    private static func parseIPv4(_ ip: String) -> [UInt8]? {
+        let bare = String(ip.split(separator: "/").first ?? ip[...])
+        var addr = in_addr()
+        guard inet_pton(AF_INET, bare, &addr) == 1 else { return nil }
+        return withUnsafeBytes(of: addr.s_addr) { Array($0) }
+    }
+}

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -98,7 +98,13 @@ extension ContainerCreateRoute {
                 {
                     throw ContainerizationError(.notFound, message: "no arm64 content")
                 }
-            } catch  where requestedPlatform.architecture == "arm64" {
+            } catch let fetchError
+                where requestedPlatform.architecture == "arm64"
+                && {
+                    let msg = String(describing: fetchError)
+                    return msg.contains("does not support required platforms") || msg.contains("no arm64 content")
+                }()
+            {
                 let amd64 = Platform(arch: "amd64", os: requestedPlatform.os, variant: nil)
                 req.logger.info("\(body.Image) has no arm64 variant — falling back to amd64 (Rosetta)")
                 img = try await ClientImage.fetch(

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -249,7 +249,38 @@ extension ContainerCreateRoute {
                 searchDomains: searchDomains,
                 options: dnsOptions
             )
-            containerConfiguration.labels = body.Labels ?? [:]
+            // Collect Compose service aliases from EndpointsConfig.
+            // These are stored in a label so the start route can register them
+            // in the DNS server once the container has an IP.
+            let dnsNames =
+                (body.NetworkingConfig?.EndpointsConfig?.values)
+                .map { settings in settings.compactMap(\.Aliases).flatMap { $0 }.filter { !$0.isEmpty } }
+                ?? []
+
+            var containerLabels = body.Labels ?? [:]
+            if !dnsNames.isEmpty {
+                containerLabels["socktainer.dns.names"] = dnsNames.joined(separator: ",")
+
+                // Ensure a CoreDNS container for the first network and point this
+                // container's DNS at it so service names resolve inside the VM.
+                if let dnsManager = req.application.storage[NetworkDNSManagerKey.self],
+                    let firstNetwork = body.NetworkingConfig?.EndpointsConfig?.keys.first
+                {
+                    do {
+                        let dnsIP = try await dnsManager.ensureDNSContainer(networkId: firstNetwork)
+                        let existing = containerConfiguration.dns
+                        containerConfiguration.dns = ContainerConfiguration.DNSConfiguration(
+                            nameservers: [dnsIP],
+                            domain: existing?.domain ?? nil,
+                            searchDomains: existing?.searchDomains ?? [],
+                            options: existing?.options ?? []
+                        )
+                    } catch {
+                        req.logger.warning("Could not start DNS container for \(firstNetwork): \(error)")
+                    }
+                }
+            }
+            containerConfiguration.labels = containerLabels
 
             var resolvedMounts: [Filesystem] = []
 

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -284,6 +284,25 @@ extension ContainerCreateRoute {
 
             var resolvedMounts: [Filesystem] = []
 
+            // Docker creates missing bind-mount source directories on the host automatically.
+            // Parser.mounts() validates that the source path exists and throws if not, so we
+            // must create missing directories BEFORE parsing, not after.
+            if let binds = body.HostConfig?.Binds {
+                for bind in binds {
+                    let parts = bind.split(separator: ":").map(String.init)
+                    if let source = parts.first, source.hasPrefix("/") {
+                        try? FileManager.default.createDirectory(
+                            atPath: source, withIntermediateDirectories: true)
+                    }
+                }
+            }
+            if let mounts = body.HostConfig?.Mounts {
+                for mount in mounts where mount.MountType.lowercased() == "bind" && !mount.Source.isEmpty {
+                    try? FileManager.default.createDirectory(
+                        atPath: mount.Source, withIntermediateDirectories: true)
+                }
+            }
+
             // Process bind mounts from HostConfig.Binds
             var volumesOrFs: [VolumeOrFilesystem] = []
             if let binds = body.HostConfig?.Binds, !binds.isEmpty {

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -71,7 +71,7 @@ extension ContainerCreateRoute {
             try Utility.validEntityName(id)
 
             // Validate the requested platform only if provided
-            let requestedPlatform = try Platform(from: containerPlatform)
+            var requestedPlatform = try Platform(from: containerPlatform)
 
             // Check if image exists locally
             do {
@@ -80,11 +80,34 @@ extension ContainerCreateRoute {
                 throw Abort(.notFound, reason: "No such image: \(body.Image)")
             }
 
-            let img = try await ClientImage.fetch(
-                reference: body.Image,
-                platform: requestedPlatform,
-                containerSystemConfig: ContainerSystemConfig()
-            )
+            // Fetch the image; on arm64 hosts fall back to amd64 (Rosetta) when no arm64
+            // variant is available. Two cases handled:
+            //   1. Fetch fails (image not cached, pull returns "does not support required platforms")
+            //   2. Fetch succeeds but image is cached as amd64 — config(for: arm64) returns nil
+            // containerConfiguration.rosetta is set below when requestedPlatform becomes amd64.
+            var img: ClientImage
+            do {
+                img = try await ClientImage.fetch(
+                    reference: body.Image,
+                    platform: requestedPlatform,
+                    containerSystemConfig: ContainerSystemConfig()
+                )
+                // Case 2: image exists locally but may have been pulled as amd64
+                if requestedPlatform.architecture == "arm64",
+                    (try? await img.config(for: requestedPlatform)) == nil
+                {
+                    throw ContainerizationError(.notFound, message: "no arm64 content")
+                }
+            } catch  where requestedPlatform.architecture == "arm64" {
+                let amd64 = Platform(arch: "amd64", os: requestedPlatform.os, variant: nil)
+                req.logger.info("\(body.Image) has no arm64 variant — falling back to amd64 (Rosetta)")
+                img = try await ClientImage.fetch(
+                    reference: body.Image,
+                    platform: amd64,
+                    containerSystemConfig: ContainerSystemConfig()
+                )
+                requestedPlatform = amd64
+            }
 
             // Unpack a fetched image before use
             try await img.getCreateSnapshot(

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -1,3 +1,4 @@
+import ContainerAPIClient
 import Vapor
 
 struct ContainerDeleteRoute: RouteCollection {
@@ -13,6 +14,16 @@ extension ContainerDeleteRoute {
         { req in
             guard let id = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
+            }
+
+            // Unregister DNS names before deletion
+            if let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
+                let snapshot = try? await ContainerClient().get(id: id),
+                let namesLabel = snapshot.configuration.labels["socktainer.dns.names"]
+            {
+                for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                    dnsServer.unregister(hostname: name)
+                }
             }
 
             // if running, stop it first

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -1,3 +1,4 @@
+import ContainerAPIClient
 import Vapor
 
 struct ContainerStartRoute: RouteCollection {
@@ -49,6 +50,20 @@ extension ContainerStartRoute {
                     throw Abort(.internalServerError, reason: "Failed to start container: \(error)")
                 }
                 req.logger.debug("Container \(id) was already running or bootstrapped")
+            }
+
+            // Register DNS names now that the container has an IP.
+            // Names were stored in the label at create time (Compose service aliases).
+            if let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
+                let snapshot = try? await ContainerClient().get(id: id),
+                snapshot.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole,
+                let namesLabel = snapshot.configuration.labels["socktainer.dns.names"],
+                let firstAttachment = snapshot.networks.first
+            {
+                let ip = firstAttachment.ipv4Address.address.description
+                for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                    dnsServer.register(hostname: name, ip: ip)
+                }
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!

--- a/Sources/socktainer/Routes/Networks/NetworkDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkDeleteRoute.swift
@@ -1,3 +1,4 @@
+import ContainerAPIClient
 import Vapor
 
 struct NetworkDeletetRoute: RouteCollection {

--- a/Sources/socktainer/Routes/Networks/NetworkDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkDeleteRoute.swift
@@ -14,6 +14,11 @@ struct NetworkDeletetRoute: RouteCollection {
             throw Abort(.badRequest, reason: "Missing network id parameter")
         }
         do {
+            // Remove the CoreDNS sidecar BEFORE deleting the network —
+            // the network can't be deleted while the DNS container is still attached.
+            if let dnsManager = req.application.storage[NetworkDNSManagerKey.self] {
+                await dnsManager.cleanupDNSContainer(networkId: id)
+            }
             try await client.delete(id: id, logger: logger)
             return Response(status: .noContent)
         } catch {

--- a/Sources/socktainer/Routes/Networks/NetworkPruneRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkPruneRoute.swift
@@ -27,6 +27,10 @@ struct NetworkPruneRoute: RouteCollection {
                     continue
                 }
                 do {
+                    // Clean up CoreDNS sidecar before deleting the network
+                    if let dnsManager = req.application.storage[NetworkDNSManagerKey.self] {
+                        await dnsManager.cleanupDNSContainer(networkId: network.Id)
+                    }
                     try await networkClient.delete(id: network.Id, logger: req.logger)
                     deletedNetworks.append(network.Id)
                 } catch {

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -166,4 +166,24 @@ func configure(_ app: Application) async throws {
     // Await starting watching
     watcher.startWatching()
 
+    // Initialize inter-container DNS infrastructure.
+    // Port is read from SOCKTAINER_DNS_PORT (default 2054). If the preferred port
+    // is taken, Socktainer auto-increments until a free port is found.
+    let preferredDNSPort =
+        ProcessInfo.processInfo.environment["SOCKTAINER_DNS_PORT"]
+        .flatMap(Int.init) ?? 2054
+    let dnsServer = SocktainerDNSServer()
+    guard let resolvedDNSPort = dnsServer.start(preferredPort: preferredDNSPort) else {
+        app.logger.error("Could not bind DNS server on any port near \(preferredDNSPort) — inter-container DNS disabled")
+        return
+    }
+    app.logger.notice("DNS server listening on port \(resolvedDNSPort)")
+    app.storage[SocktainerDNSServerKey.self] = dnsServer
+
+    let dnsManager = NetworkDNSManager(appSupportURL: appleContainerAppSupportUrl, dnsPort: resolvedDNSPort)
+    app.storage[NetworkDNSManagerKey.self] = dnsManager
+
+    // Clean up any CoreDNS containers left from a previous run
+    await dnsManager.cleanupStaleDNSContainers()
+
 }

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -101,8 +101,10 @@ struct SocktainerDNSServerTests {
         let server = SocktainerDNSServer()
         let port = server.start(preferredPort: 19800, maxAttempts: 5)
         #expect(port != nil)
-        #expect(port != 19800)  // must have fallen back
-        #expect(port! > 19800 && port! < 19805)
+        if let p = port {
+            #expect(p != 19800)  // must have fallen back
+            #expect(p > 19800 && p < 19805)
+        }
     }
 
     // MARK: - Multiple entries

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -1,0 +1,130 @@
+import Darwin
+import Testing
+
+@testable import socktainer
+
+@Suite("SocktainerDNSServer")
+struct SocktainerDNSServerTests {
+
+    // MARK: - Registration
+
+    @Test("Register and retrieve a hostname")
+    func registerAndRetrieve() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "postgres", ip: "192.168.1.10")
+        let entries = server.listEntries()
+        #expect(entries["postgres"] == "192.168.1.10")
+    }
+
+    @Test("Unregister removes the hostname")
+    func unregisterRemoves() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "redis", ip: "192.168.1.20")
+        server.unregister(hostname: "redis")
+        #expect(server.listEntries()["redis"] == nil)
+    }
+
+    @Test("Unregistering unknown hostname is a no-op")
+    func unregisterUnknownIsNoOp() {
+        let server = SocktainerDNSServer()
+        server.unregister(hostname: "nonexistent")  // must not crash
+        #expect(server.listEntries().isEmpty)
+    }
+
+    // MARK: - Normalization
+
+    @Test("Hostname lookup is case-insensitive")
+    func caseInsensitive() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "MyService", ip: "10.0.0.1")
+        let entries = server.listEntries()
+        #expect(entries["myservice"] == "10.0.0.1")
+    }
+
+    @Test("Trailing dot is stripped on normalize")
+    func trailingDotStripped() {
+        #expect(SocktainerDNSServer.normalize("postgres.") == "postgres")
+        #expect(SocktainerDNSServer.normalize("db..") == "db")
+        #expect(SocktainerDNSServer.normalize("svc") == "svc")
+    }
+
+    // MARK: - IP parsing
+
+    @Test("CIDR suffix is stripped before parsing IP")
+    func cidrSuffixStripped() {
+        let server = SocktainerDNSServer()
+        // Apple Container returns IPs as "192.168.1.5/24" — the slash must be stripped
+        server.register(hostname: "db", ip: "192.168.1.5/24")
+        #expect(server.listEntries()["db"] == "192.168.1.5")
+    }
+
+    @Test("Invalid IP is ignored gracefully")
+    func invalidIPIgnored() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "broken", ip: "not-an-ip")
+        #expect(server.listEntries()["broken"] == nil)
+    }
+
+    // MARK: - Port selection
+
+    @Test("start() returns the resolved port")
+    func startReturnsPort() {
+        let server = SocktainerDNSServer()
+        // Pick an unlikely port range for testing; just verify start() returns a non-nil Int
+        let port = server.start(preferredPort: 19900, maxAttempts: 5)
+        #expect(port != nil)
+        if let p = port {
+            #expect(p >= 19900 && p < 19905)
+        }
+    }
+
+    @Test("start() falls back when preferred port is taken")
+    func startFallsBack() throws {
+        // Bind a socket on 19800 to simulate the port being taken
+        let blocker = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard blocker >= 0 else { return }
+        defer { Darwin.close(blocker) }
+        var yes: Int32 = 1
+        setsockopt(blocker, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(19800).bigEndian
+        addr.sin_addr.s_addr = INADDR_ANY
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(blocker, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+        guard bound else { return }  // skip if bind fails (e.g. CI port conflict)
+
+        let server = SocktainerDNSServer()
+        let port = server.start(preferredPort: 19800, maxAttempts: 5)
+        #expect(port != nil)
+        #expect(port != 19800)  // must have fallen back
+        #expect(port! > 19800 && port! < 19805)
+    }
+
+    // MARK: - Multiple entries
+
+    @Test("Multiple hostnames can coexist independently")
+    func multipleEntries() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "postgres", ip: "10.0.0.1")
+        server.register(hostname: "redis", ip: "10.0.0.2")
+        server.register(hostname: "api", ip: "10.0.0.3")
+        let entries = server.listEntries()
+        #expect(entries.count == 3)
+        #expect(entries["postgres"] == "10.0.0.1")
+        #expect(entries["redis"] == "10.0.0.2")
+        #expect(entries["api"] == "10.0.0.3")
+    }
+
+    @Test("Re-registering a hostname overwrites the IP")
+    func reregistrationOverwrites() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "db", ip: "10.0.0.1")
+        server.register(hostname: "db", ip: "10.0.0.99")
+        #expect(server.listEntries()["db"] == "10.0.0.99")
+    }
+}


### PR DESCRIPTION
## What this unlocks

`docker compose up` now works for common multi-service stacks on Apple Container 1.0.0.

Verified: WordPress+MySQL, Prometheus+Grafana, Gitea+Postgres, Redis+Postgres+Adminer,
Confluent Kafka (5 services) — all on macOS Tahoe, Apple Silicon.

## How

**Inter-container DNS** — service names (`postgres`, `redis`, ...) were unresolvable
between containers because each VM has an isolated network stack. One CoreDNS sidecar
per user network forwards queries to a host-side `SocktainerDNSServer` (UDP port 2054,
configurable via `SOCKTAINER_DNS_PORT`). Aliases are registered at container start
and cleaned up on delete or network removal.

Tests: 11 unit tests for SocktainerDNSServer.

**Rosetta fallback** — images with no arm64 variant now transparently retry as amd64,
using Apple Container's built-in Rosetta support.

**Bind-mount auto-create** — Docker silently creates missing bind-mount source paths.
Parser.mounts() throws if they don't exist. Pre-creating them matches Docker's behavior.

**Three live-testing bug fixes:**
- CoreDNS sidecar name exceeded the 64-char container ID limit
- `docker compose down` skipped network deletion when CoreDNS showed up in the network
  inspect's Containers field
- CoreDNS deletion after stop occasionally raced

## Known limitations

- Postgres with named volumes requires `PGDATA=/var/lib/postgresql/data/pgdata`
  (EXT4 volumes have a `lost+found` directory that blocks postgres init)
- `depends_on: service_healthy` not supported (no healthcheck executor yet)
- `/networks/{id}/connect` (post-creation network attachment) not available in Apple Container

> This PR was developed with AI assistance (Claude Code).