### PR TITLE
Return Docker-shaped 64-hex container IDs and resolve truncated references

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -42,6 +42,7 @@ protocol ClientContainerProtocol: Sendable {
 enum ClientContainerError: Error {
     case notFound(id: String)
     case notRunning(id: String)
+    case ambiguousId(reference: String, matches: [String])
 }
 
 struct ClientContainerService: ClientContainerProtocol {
@@ -77,7 +78,11 @@ struct ClientContainerService: ClientContainerProtocol {
             case "name":
                 containers = containers.filter { values.contains($0.id) }
             case "id":
-                containers = containers.filter { values.contains($0.id) }
+                containers = containers.filter { container in
+                    values.contains { value in
+                        container.id == value || DockerContainerID.hexId(for: container).hasPrefix(value)
+                    }
+                }
             case "ancestor":
                 containers = containers.filter { values.contains($0.configuration.image.reference) }
             case "before":
@@ -160,7 +165,19 @@ struct ClientContainerService: ClientContainerProtocol {
         do {
             return try await containerClient.get(id: id)
         } catch let error as ContainerizationError where error.code == .notFound {
-            return nil
+            // The reference may be a Docker-shaped hex ID, or a truncated
+            // prefix of one fed back from `docker ps` output; resolve it
+            // against the derived IDs of all containers.
+            let allContainers = try await containerClient.list()
+            let entries = allContainers.map { (nativeId: $0.id, hexId: DockerContainerID.hexId(for: $0)) }
+            switch DockerContainerID.resolve(reference: id, entries: entries) {
+            case .match(let nativeId):
+                return allContainers.first { $0.id == nativeId }
+            case .ambiguous(let matches):
+                throw ClientContainerError.ambiguousId(reference: id, matches: matches)
+            case .none:
+                return nil
+            }
         }
     }
 
@@ -214,8 +231,7 @@ struct ClientContainerService: ClientContainerProtocol {
 
     func stop(id: String, signal: String?, timeout: Int?) async throws {
         let id = ContainerNameUtility.sanitize(id)
-        let container = try await containerClient.list().filter { $0.id == id }.first
-        guard let container else {
+        guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
 
@@ -227,8 +243,7 @@ struct ClientContainerService: ClientContainerProtocol {
 
     func kill(id: String, signal: String?) async throws {
         let id = ContainerNameUtility.sanitize(id)
-        let container = try await containerClient.list().filter { $0.id == id }.first
-        guard let container else {
+        guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
 
@@ -243,8 +258,7 @@ struct ClientContainerService: ClientContainerProtocol {
 
     func restart(id: String, signal: String?, timeout: Int?) async throws {
         let id = ContainerNameUtility.sanitize(id)
-        let container = try await containerClient.list().filter { $0.id == id }.first
-        guard let container else {
+        guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
 
@@ -257,8 +271,7 @@ struct ClientContainerService: ClientContainerProtocol {
 
     func delete(id: String) async throws {
         let id = ContainerNameUtility.sanitize(id)
-        let container = try await containerClient.list().filter { $0.id == id }.first
-        guard let container else {
+        guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
         try await containerClient.delete(id: container.id)
@@ -268,10 +281,12 @@ struct ClientContainerService: ClientContainerProtocol {
     // code recorded by the background waiter started in start() (or by the
     // stdin-attach bootstrap path).
     func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
-        let id = ContainerNameUtility.sanitize(id)
-        guard (try await containerClient.list().filter { $0.id == id }.first) != nil else {
+        guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
+        // Poll by the native ID; the request reference may have been a hex ID
+        // or a truncated prefix of one.
+        let id = container.id
 
         // `docker run` issues /wait BEFORE /start, so the container is still in
         // `.created` state when we arrive here — we must NOT treat "not running"

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -360,7 +360,7 @@ extension ContainerCreateRoute {
             }
 
             return RESTContainerCreate(
-                Id: container.id,
+                Id: DockerContainerID.hexId(for: container),
                 Warnings: []
             )
         }

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -15,13 +15,20 @@ extension ContainerDeleteRoute {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
-            // if running, stop it first
-            if let container = try await client.getContainer(id: id),
-                container.status == .running
-            {
-                try await client.stop(id: id, signal: nil, timeout: nil)
+            do {
+                // if running, stop it first
+                if let container = try await client.getContainer(id: id),
+                    container.status == .running
+                {
+                    try await client.stop(id: id, signal: nil, timeout: nil)
+                }
+                try await client.delete(id: id)
+            } catch ClientContainerError.notFound {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
             }
-            try await client.delete(id: id)
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
 

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -170,7 +170,7 @@ extension ContainerInspectRoute {
             )
 
             return RESTContainerInspect(
-                Id: container.id,
+                Id: DockerContainerID.hexId(for: container),
                 Created: AppleContainerTimestampResolver.iso8601Timestamp(createdAt),
                 Path: container.configuration.initProcess.executable,
                 Args: container.configuration.initProcess.arguments,

--- a/Sources/socktainer/Routes/Containers/ContainerKillRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerKillRoute.swift
@@ -29,6 +29,9 @@ extension ContainerKillRoute {
                 return Response(status: .noContent)
             } catch ClientContainerError.notFound {
                 return Response(status: .notFound, body: .init(string: "container \(containerId) not found"))
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                return Response(status: .badRequest, body: .init(string: "ambiguous container reference \(reference): matches \(matchList)"))
             } catch ClientContainerError.notRunning {
                 return Response(status: .conflict, body: .init(string: "container \(containerId) is not running"))
             } catch {

--- a/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
@@ -99,7 +99,7 @@ extension ContainerListRoute {
                 )
 
                 return RESTContainerSummary(
-                    Id: container.id,
+                    Id: DockerContainerID.hexId(for: container),
                     Names: ["/" + container.id],
                     Image: container.configuration.image.reference,
                     ImageID: container.configuration.image.digest,

--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -27,6 +27,9 @@ extension ContainerRestartRoute {
                 try await client.restart(id: id, signal: signal, timeout: timeout)
             } catch ClientContainerError.notFound {
                 throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
             } catch {
                 req.logger.error("Failed to restart container \(id): \(error)")
                 throw Abort(.internalServerError, reason: "Failed to restart container: \(error)")

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -54,8 +54,11 @@ extension ContainerStartRoute {
 
             // Register DNS names now that the container has an IP.
             // Names were stored in the label at create time (Compose service aliases).
+            // Resolve through getContainer: clients commonly start containers by
+            // the hex ID returned from create, which the native lookup rejects.
+            let startedSnapshot = (try? await client.getContainer(id: id)) ?? nil
             if let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
-                let snapshot = try? await ContainerClient().get(id: id),
+                let snapshot = startedSnapshot,
                 snapshot.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole,
                 let namesLabel = snapshot.configuration.labels["socktainer.dns.names"],
                 let firstAttachment = snapshot.networks.first

--- a/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
@@ -23,7 +23,14 @@ extension ContainerStopRoute {
             let signal = query.signal
             let timeout = query.t
 
-            try await client.stop(id: id, signal: signal, timeout: timeout)
+            do {
+                try await client.stop(id: id, signal: signal, timeout: timeout)
+            } catch ClientContainerError.notFound {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
+            }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
 

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -33,8 +33,13 @@ struct ContainerWaitRoute: RouteCollection {
             // Preflight before flushing headers so a missing container returns a
             // real 404 instead of a streamed `200 {"StatusCode":0}` — the latter
             // would make "no such container" indistinguishable from a clean exit.
-            guard try await client.getContainer(id: containerId) != nil else {
-                throw Abort(.notFound, reason: "No such container: \(containerId)")
+            do {
+                guard try await client.getContainer(id: containerId) != nil else {
+                    throw Abort(.notFound, reason: "No such container: \(containerId)")
+                }
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
             }
 
             var headers = HTTPHeaders()

--- a/Sources/socktainer/Utilities/DockerContainerID.swift
+++ b/Sources/socktainer/Utilities/DockerContainerID.swift
@@ -1,0 +1,55 @@
+import ContainerResource
+import CryptoKit
+import Foundation
+
+/// Docker clients expect container IDs to be 64-character hex digests and
+/// freely truncate them — `docker ps` shows only the first 12 characters,
+/// even with `-q` or `--format '{{.ID}}'`, and feeds them back into
+/// `inspect`/`exec`/`stop`. Apple container identifies containers by name,
+/// so socktainer derives a stable Docker-shaped ID from the native ID and
+/// resolves hex references back to native IDs.
+enum DockerContainerID {
+    /// Returns the Docker-shaped ID for a container: the SHA-256 digest of
+    /// its native ID and creation date, hex-encoded (64 lowercase
+    /// characters). Deriving instead of storing keeps the mapping stable
+    /// across restarts and covers containers created outside socktainer.
+    /// Including the creation date preserves Docker's semantics that
+    /// recreating a container under the same name yields a new ID.
+    static func hexId(for container: ContainerSnapshot) -> String {
+        hexId(nativeId: container.id, createdAt: AppleContainerTimestampResolver.containerCreationDate(container))
+    }
+
+    static func hexId(nativeId: String, createdAt: Date?) -> String {
+        var input = nativeId
+        if let createdAt {
+            input += "\n\(createdAt.timeIntervalSince1970)"
+        }
+        return SHA256.hash(data: Data(input.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    enum Resolution: Equatable {
+        case match(String)
+        case ambiguous([String])
+        case none
+    }
+
+    /// Resolves a client-supplied reference — a native ID/name, a full hex
+    /// ID, or a hex ID prefix — against `(nativeId, hexId)` entries. Mirrors
+    /// the Docker daemon's behavior of rejecting prefixes that match more
+    /// than one container.
+    static func resolve(reference: String, entries: [(nativeId: String, hexId: String)]) -> Resolution {
+        if entries.contains(where: { $0.nativeId == reference }) {
+            return .match(reference)
+        }
+        // Only lowercase hex strings can be (truncated) Docker IDs.
+        guard !reference.isEmpty, reference.allSatisfy({ $0.isHexDigit && !$0.isUppercase }) else {
+            return .none
+        }
+        let matches = entries.filter { $0.hexId.hasPrefix(reference) }.map(\.nativeId)
+        switch matches.count {
+        case 0: return .none
+        case 1: return .match(matches[0])
+        default: return .ambiguous(matches)
+        }
+    }
+}

--- a/Sources/socktainer/Utilities/DockerContainerID.swift
+++ b/Sources/socktainer/Utilities/DockerContainerID.swift
@@ -41,11 +41,13 @@ enum DockerContainerID {
         if entries.contains(where: { $0.nativeId == reference }) {
             return .match(reference)
         }
-        // Only lowercase hex strings can be (truncated) Docker IDs.
-        guard !reference.isEmpty, reference.allSatisfy({ $0.isHexDigit && !$0.isUppercase }) else {
+        // Only hex strings can be (truncated) Docker IDs; normalize to
+        // lowercase so callers can supply uppercase or mixed-case references.
+        guard !reference.isEmpty, reference.allSatisfy({ $0.isHexDigit }) else {
             return .none
         }
-        let matches = entries.filter { $0.hexId.hasPrefix(reference) }.map(\.nativeId)
+        let refLower = reference.lowercased()
+        let matches = entries.filter { $0.hexId.hasPrefix(refLower) }.map(\.nativeId)
         switch matches.count {
         case 0: return .none
         case 1: return .match(matches[0])

--- a/Tests/socktainerTests/Utilitites/DockerContainerIDTests.swift
+++ b/Tests/socktainerTests/Utilitites/DockerContainerIDTests.swift
@@ -103,6 +103,16 @@ struct DockerContainerIDTests {
         #expect(Set(matches) == Set([first, second]))
     }
 
+    @Test("Resolves an uppercase hex prefix case-insensitively")
+    func resolvesUppercaseHexId() {
+        let truncated = String(DockerContainerID.hexId(nativeId: "exampleproject-web-1", createdAt: created).prefix(12)).uppercased()
+        let result = DockerContainerID.resolve(
+            reference: truncated,
+            entries: entries(["exampleproject-web-1", "exampleproject-db-1"])
+        )
+        #expect(result == .match("exampleproject-web-1"))
+    }
+
     @Test("Non-hex references never resolve as ID prefixes")
     func nonHexReference() {
         // A truncated *name* (the bug this type exists to prevent) contains

--- a/Tests/socktainerTests/Utilitites/DockerContainerIDTests.swift
+++ b/Tests/socktainerTests/Utilitites/DockerContainerIDTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("Docker container ID derivation and resolution")
+struct DockerContainerIDTests {
+    private let created = Date(timeIntervalSince1970: 1_765_500_000)
+
+    private func entries(_ ids: [String]) -> [(nativeId: String, hexId: String)] {
+        ids.map { ($0, DockerContainerID.hexId(nativeId: $0, createdAt: created)) }
+    }
+
+    // MARK: - hexId
+
+    @Test("Derived ID is 64 lowercase hex characters")
+    func hexIdShape() {
+        let id = DockerContainerID.hexId(nativeId: "exampleproject-web-1", createdAt: created)
+        #expect(id.count == 64)
+        #expect(id.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test("Derivation is deterministic and distinct per native ID")
+    func hexIdDeterministic() {
+        #expect(
+            DockerContainerID.hexId(nativeId: "a", createdAt: created) == DockerContainerID.hexId(nativeId: "a", createdAt: created)
+        )
+        #expect(
+            DockerContainerID.hexId(nativeId: "a", createdAt: created) != DockerContainerID.hexId(nativeId: "b", createdAt: created)
+        )
+    }
+
+    @Test("Recreating a container under the same name yields a new ID")
+    func recreationChangesId() {
+        let recreated = created.addingTimeInterval(42)
+        #expect(
+            DockerContainerID.hexId(nativeId: "web-1", createdAt: created) != DockerContainerID.hexId(nativeId: "web-1", createdAt: recreated)
+        )
+    }
+
+    @Test("Missing creation date still derives a stable ID")
+    func missingCreationDate() {
+        let id = DockerContainerID.hexId(nativeId: "web-1", createdAt: nil)
+        #expect(id.count == 64)
+        #expect(id == DockerContainerID.hexId(nativeId: "web-1", createdAt: nil))
+    }
+
+    // MARK: - resolve
+
+    @Test("Resolves an exact native ID")
+    func resolvesNativeId() {
+        let result = DockerContainerID.resolve(
+            reference: "exampleproject-web-1",
+            entries: entries(["exampleproject-web-1", "exampleproject-db-1"])
+        )
+        #expect(result == .match("exampleproject-web-1"))
+    }
+
+    @Test("Resolves a full hex ID")
+    func resolvesFullHexId() {
+        let hex = DockerContainerID.hexId(nativeId: "exampleproject-web-1", createdAt: created)
+        let result = DockerContainerID.resolve(
+            reference: hex,
+            entries: entries(["exampleproject-web-1", "exampleproject-db-1"])
+        )
+        #expect(result == .match("exampleproject-web-1"))
+    }
+
+    @Test("Resolves a truncated 12-character hex ID as docker ps emits it")
+    func resolvesTruncatedHexId() {
+        let truncated = String(DockerContainerID.hexId(nativeId: "exampleproject-web-1", createdAt: created).prefix(12))
+        let result = DockerContainerID.resolve(
+            reference: truncated,
+            entries: entries(["exampleproject-web-1", "exampleproject-db-1"])
+        )
+        #expect(result == .match("exampleproject-web-1"))
+    }
+
+    @Test("Rejects a prefix matching more than one container")
+    func rejectsAmbiguousPrefix() {
+        // Find two native IDs whose derived hex IDs share the first
+        // character, so a one-character reference is genuinely ambiguous.
+        let first = "container-0"
+        let firstChar = DockerContainerID.hexId(nativeId: first, createdAt: created).prefix(1)
+        var other: String?
+        for index in 1...1000 {
+            let candidate = "container-\(index)"
+            if DockerContainerID.hexId(nativeId: candidate, createdAt: created).prefix(1) == firstChar {
+                other = candidate
+                break
+            }
+        }
+        guard let second = other else {
+            Issue.record("No colliding first hex character found in 1000 candidates")
+            return
+        }
+
+        let result = DockerContainerID.resolve(reference: String(firstChar), entries: entries([first, second]))
+        guard case .ambiguous(let matches) = result else {
+            Issue.record("Expected .ambiguous, got \(result)")
+            return
+        }
+        #expect(Set(matches) == Set([first, second]))
+    }
+
+    @Test("Non-hex references never resolve as ID prefixes")
+    func nonHexReference() {
+        // A truncated *name* (the bug this type exists to prevent) contains
+        // non-hex characters and must not accidentally prefix-match.
+        let result = DockerContainerID.resolve(
+            reference: "zed_dc_test-",
+            entries: entries(["zed_dc_test-app-1", "zed_dc_test-db-1"])
+        )
+        #expect(result == .none)
+    }
+
+    @Test("Empty and unknown references resolve to none")
+    func emptyAndUnknown() {
+        #expect(DockerContainerID.resolve(reference: "", entries: entries(["a"])) == .none)
+        #expect(DockerContainerID.resolve(reference: "deadbeef", entries: entries(["a"])) == .none)
+    }
+}


### PR DESCRIPTION
Fixes #211

## Problem

socktainer uses container names as the `Id` value in API responses. The Docker CLI
assumes IDs are 64-character hex digests and truncates them to 12 characters in
`docker ps` output (including `-q` and `--format '{{.ID}}'`), so feeding the
truncated value back into `inspect`/`exec`/`stop` fails, and all containers of a
compose project display the same indistinguishable ID. See #211 for the full
reproduction.

## Approach

Derive the `Id` as the SHA-256 digest of the native ID and the container's
creation date, hex-encoded (64 lowercase characters). Container names remain
exposed through `Names`/`Name`.

- Deriving instead of storing keeps the mapping stable across socktainer restarts
  and covers containers created outside socktainer.
- Including the creation date preserves Docker's semantics that recreating a
  container under the same name yields a new ID.

References are resolved as native ID first, then full hex ID, then unique hex
prefix; ambiguous prefixes are rejected, like the Docker daemon does.

## Changes

- New `DockerContainerID` utility: ID derivation and reference resolution.
- `ClientContainerService.getContainer` falls back to hex/prefix resolution; it is
  the lookup used by the container routes, so `inspect`/`exec`/`logs`/`archive`
  and friends all accept hex references.
- `stop`/`kill`/`restart`/`delete`/`wait` previously bypassed `getContainer` with
  exact-match lookups and now resolve through it (this is what `docker compose
  down` uses).
- The `id` list filter matches hex prefixes as well.
- `containers/json`, `containers/{id}/json` and `containers/create` emit the
  derived hex `Id`.

## Testing

- 10 unit tests for derivation and resolution (`DockerContainerIDTests`), covering
  the 12-character truncation case, ambiguous-prefix rejection, and the
  recreation-changes-ID semantics.
- Manual verification against Apple Container 1.0.0 on macOS 26.5 with Docker CLI
  29.5.3 / Compose v5.1.4 — the reproduction from #211 now passes:

```
$ docker ps --format '{{.ID}}  {{.Names}}'
c0f8579db92a  exampleproject-db-1
1ba8fe297334  exampleproject-web-1      <- distinct IDs now

$ docker inspect $(docker ps -q | head -1) --format '{{.Id}} {{.State.Running}}'
c0f8579db92aaf7d66615c3f48f411272f71a2e38d55afa90161b0dd5faf6a33 true

$ docker exec 1ba8fe297334 echo ok      <- exec by truncated ID
ok
```

  Lookups by name still work, `docker compose down` deletes by hex ID, and
  recreating the project assigns new IDs.

- As an end-to-end check, a dev container client (Zed) that previously failed at
  container discovery — it feeds the truncated IDs from `docker ps` back into
  `inspect` — now completes its create → discover → exec flow against socktainer.
