### PR TITLE
feat(context): auto-install 'socktainer' Docker context on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,49 @@ FolderWatcher] Started watching $HOME/Library/Application Support/com.apple.cont
 
 ### Using Docker CLI 🐳
 
-Export the socket path as `DOCKER_HOST`:
+Socktainer automatically registers a `socktainer` Docker context on startup.
+Activate it once:
 
 ```bash
-export DOCKER_HOST=unix://$HOME/.socktainer/container.sock
+docker context use socktainer
+```
+
+Then use Docker normally — no `DOCKER_HOST` needed:
+
+```bash
 docker ps        # List running containers
 docker ps -a     # List all containers
 docker images    # List available images
+```
+
+Switch back to another runtime at any time:
+
+```bash
+docker context use colima    # or "default", etc.
+```
+
+<details>
+<summary>Opt out of automatic context creation</summary>
+
+Pass `--no-docker-context` to skip writing the context file on startup — useful
+in CI or when managing Docker contexts manually:
+
+```bash
+socktainer --no-docker-context
+```
+
+Note: this flag skips **creating** the context but does not remove one that was
+already created. To remove it: `docker context rm socktainer`.
+
+</details>
+
+<details>
+<summary>Alternative: set DOCKER_HOST manually</summary>
+
+```bash
+export DOCKER_HOST=unix://$HOME/.socktainer/container.sock
+docker ps
+docker images
 ```
 
 Or inline without exporting:
@@ -74,13 +110,15 @@ DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker ps
 DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker images
 ```
 
+</details>
+
 ---
 
 ## Key Features ✨
 
 - Built on **Apple’s Container Framework** 🍏
 - Provides **Docker REST API compatibility** 🔄 (partial)
-- Listens on a Unix domain socket `$HOME/.socktainer/container.sock`
+- Listens on a Unix domain socket `$HOME/.socktainer/container.sock` and auto-registers a `socktainer` Docker context
 - Supports container lifecycle operations: inspect, stop, remove 🛠️
 - Supports image listing, pulling, deletion, logs, health checks. Exec without interactive mode 📄
 - Broadcasts container events for client liveness monitoring 📡

--- a/Sources/socktainer/Utilities/DockerContextSetup.swift
+++ b/Sources/socktainer/Utilities/DockerContextSetup.swift
@@ -1,0 +1,50 @@
+import CryptoKit
+import Foundation
+import Logging
+
+/// Creates (or updates) a Docker context named "socktainer" pointing at the
+/// local Unix socket, so users can run `docker context use socktainer` instead
+/// of exporting DOCKER_HOST on every session.
+///
+/// Docker stores contexts under ~/.docker/contexts/meta/<sha256(name)>/meta.json.
+/// The TLS directory must also exist (empty) for Docker CLI to accept the context.
+enum DockerContextSetup {
+    static let contextName = "socktainer"
+    /// SHA256 hex digest of `contextName` — the directory name Docker uses for context storage.
+    static let contextDirName: String = {
+        let hash = SHA256.hash(data: Data(contextName.utf8))
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }()
+    private static let log = Logger(label: "socktainer.context")
+
+    static func install(homeDirectory: String) {
+        let socketPath = "\(homeDirectory)/.socktainer/container.sock"
+        let dirName = contextDirName
+
+        let metaDir = "\(homeDirectory)/.docker/contexts/meta/\(dirName)"
+        let tlsDir = "\(homeDirectory)/.docker/contexts/tls/\(dirName)/docker"
+        let metaFile = "\(metaDir)/meta.json"
+
+        let payload: [String: Any] = [
+            "Name": contextName,
+            "Metadata": ["Description": "Socktainer — Docker API over Apple Container"],
+            "Endpoints": [
+                "docker": [
+                    "Host": "unix://\(socketPath)",
+                    "SkipTLSVerify": false,
+                ]
+            ],
+        ]
+
+        do {
+            let fm = FileManager.default
+            try fm.createDirectory(atPath: metaDir, withIntermediateDirectories: true)
+            try fm.createDirectory(atPath: tlsDir, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: metaFile))
+            log.info("Docker context '\(contextName)' ready — run: docker context use \(contextName)")
+        } catch {
+            log.warning("Could not install Docker context '\(contextName)': \(error)")
+        }
+    }
+}

--- a/Sources/socktainer/main.swift
+++ b/Sources/socktainer/main.swift
@@ -10,6 +10,9 @@ struct CLIOptions: ParsableArguments {
 
     @ArgumentParser.Flag(name: .long, inversion: .prefixedNo, help: "Check Apple Container compatibility and exit")
     var checkCompatibility: Bool = true
+
+    @ArgumentParser.Flag(name: .long, inversion: .prefixedNo, help: "Create or update the 'socktainer' Docker context on startup")
+    var dockerContext: Bool = true
 }
 
 // Parse CLI before starting the app
@@ -34,7 +37,14 @@ try LoggingSystem.bootstrap(from: &env)
 
 // Create and configure the Vapor application
 let app = try await Application.make(env)
-try prepareUnixSocket(for: app, homeDirectory: ProcessInfo.processInfo.environment["HOME"])
+let homeDirectory = ProcessInfo.processInfo.environment["HOME"]
+try prepareUnixSocket(for: app, homeDirectory: homeDirectory)
+if options.dockerContext,
+    let homeDir = homeDirectory,
+    !homeDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+{
+    DockerContextSetup.install(homeDirectory: homeDir)
+}
 try await configure(app)
 
 // Start the app

--- a/Tests/socktainerTests/Utilitites/DockerContextSetupTests.swift
+++ b/Tests/socktainerTests/Utilitites/DockerContextSetupTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("DockerContextSetup")
+struct DockerContextSetupTests {
+
+    // MARK: - Helpers
+
+    /// Returns a fresh temp directory and cleans it up after the test.
+    private func withTempHome(_ body: (String) throws -> Void) throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("socktainer-ctx-test-\(UUID().uuidString)")
+            .path
+        try FileManager.default.createDirectory(atPath: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        try body(tmp)
+    }
+
+    private func metaJSON(homeDir: String) throws -> [String: Any] {
+        let hash = DockerContextSetup.contextDirName
+        let path = "\(homeDir)/.docker/contexts/meta/\(hash)/meta.json"
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let obj = try JSONSerialization.jsonObject(with: data)
+        guard let dict = obj as? [String: Any] else {
+            throw NSError(
+                domain: "DockerContextSetupTests", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "meta.json root is not a JSON object — got \(type(of: obj))"])
+        }
+        return dict
+    }
+
+    // MARK: - Tests
+
+    @Test("meta.json is created under the correct SHA256-named directory")
+    func contextFileIsCreated() throws {
+        try withTempHome { home in
+            DockerContextSetup.install(homeDirectory: home)
+            let hash = DockerContextSetup.contextDirName
+            let metaPath = "\(home)/.docker/contexts/meta/\(hash)/meta.json"
+            #expect(FileManager.default.fileExists(atPath: metaPath))
+        }
+    }
+
+    @Test("Context Name field is 'socktainer'")
+    func contextHasCorrectName() throws {
+        try withTempHome { home in
+            DockerContextSetup.install(homeDirectory: home)
+            let json = try metaJSON(homeDir: home)
+            #expect(json["Name"] as? String == DockerContextSetup.contextName)
+        }
+    }
+
+    @Test("Endpoints.docker.Host points at the correct socket path")
+    func contextHasCorrectSocketPath() throws {
+        try withTempHome { home in
+            DockerContextSetup.install(homeDirectory: home)
+            let json = try metaJSON(homeDir: home)
+            let endpoints = json["Endpoints"] as? [String: Any]
+            let docker = endpoints?["docker"] as? [String: Any]
+            let host = docker?["Host"] as? String
+            #expect(host == "unix://\(home)/.socktainer/container.sock")
+        }
+    }
+
+    @Test("TLS directory exists alongside meta directory")
+    func tlsDirExists() throws {
+        try withTempHome { home in
+            DockerContextSetup.install(homeDirectory: home)
+            let hash = DockerContextSetup.contextDirName
+            let tlsDir = "\(home)/.docker/contexts/tls/\(hash)/docker"
+            #expect(FileManager.default.fileExists(atPath: tlsDir))
+        }
+    }
+
+    @Test("install() is idempotent — calling twice produces the same result")
+    func contextIsIdempotent() throws {
+        try withTempHome { home in
+            DockerContextSetup.install(homeDirectory: home)
+            DockerContextSetup.install(homeDirectory: home)
+            let json = try metaJSON(homeDir: home)
+            #expect(json["Name"] as? String == DockerContextSetup.contextName)
+        }
+    }
+
+    @Test("Works when ~/.docker/contexts/ does not exist yet")
+    func contextHandlesMissingDockerDir() throws {
+        try withTempHome { home in
+            // temp dir exists but has no .docker subdirectory
+            DockerContextSetup.install(homeDirectory: home)
+            let json = try metaJSON(homeDir: home)
+            #expect(json["Name"] as? String == DockerContextSetup.contextName)
+        }
+    }
+
+    @Test("Does not throw on an unwritable path — logs warning and returns")
+    func contextHandlesUnwritablePath() throws {
+        // Pass a path that cannot be created (root-owned directory)
+        DockerContextSetup.install(homeDirectory: "/nonexistent/path/that/cannot/be/created")
+        // If we reach here without crashing, the error was handled gracefully
+    }
+}


### PR DESCRIPTION
## What this does

On startup, Socktainer writes a Docker context named `socktainer` to `~/.docker/contexts/`, pointing at the local Unix socket. Users can then run:

```sh
docker context use socktainer
```

...and all subsequent `docker` commands work without needing `export DOCKER_HOST=...` in every session.

Closes #26

## Behaviour

- **Does not activate the context** — `docker context use socktainer` remains a deliberate user action
- **Idempotent** — safe to call on every startup; overwrites with the same content
- **Opt-out flag** — `socktainer --no-docker-context` skips writing the file entirely (useful in CI or for users who manage their own Docker contexts). Note: the flag does not delete an already-created context; use `docker context rm socktainer` for that
- **Socket path** — currently hardcoded to `~/.socktainer/container.sock` (consistent with the rest of the codebase); if the path ever becomes configurable, `DockerContextSetup.install()` will need to receive it as a parameter

## Switching between runtimes

```sh
docker context use socktainer   # → Socktainer
docker context use colima       # → Colima
docker context use default      # → system Docker
```

The context persists across terminal sessions and Socktainer restarts.

## Tests

7 tests in `DockerContextSetupTests`: file creation, correct name, correct socket path, TLS directory, idempotency, missing `~/.docker/` dir, unwritable path.