### PR TITLE
feat(stats): implement GET /containers/{id}/stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker images
 - Provides **Docker REST API compatibility** 🔄 (partial)
 - Listens on a Unix domain socket `$HOME/.socktainer/container.sock`
 - Supports container lifecycle operations: inspect, stop, remove 🛠️
-- Supports image listing, pulling, deletion, logs, health checks. Exec without interactive mode 📄
+- Supports image listing, pulling, deletion, logs, health checks, container stats. Exec without interactive mode 📄
+- `docker stats` reports memory against the Apple Container VM limit (default 1 GiB), not the host RAM
 - Broadcasts container events for client liveness monitoring 📡
 
 ---

--- a/Sources/socktainer/Models/RESTContainerStats.swift
+++ b/Sources/socktainer/Models/RESTContainerStats.swift
@@ -1,0 +1,152 @@
+import ContainerResource
+import Foundation
+import Vapor
+
+// MARK: - Docker /containers/{id}/stats response model
+
+struct RESTContainerStats: Content {
+    let id: String
+    let read: String  // ISO8601 timestamp of this sample
+    let preread: String  // ISO8601 timestamp of previous sample
+
+    let cpu_stats: CPUStats
+    let precpu_stats: CPUStats
+    let memory_stats: MemoryStats
+    let networks: [String: NetworkStats]?
+    let blkio_stats: BlkioStats
+    let pids_stats: PidsStats
+
+    struct CPUStats: Content {
+        let cpu_usage: CPUUsage
+        let system_cpu_usage: UInt64
+        let online_cpus: Int
+        let throttling_data: ThrottlingData
+
+        struct CPUUsage: Content {
+            let total_usage: UInt64  // nanoseconds
+            let usage_in_kernelmode: UInt64
+            let usage_in_usermode: UInt64
+        }
+
+        struct ThrottlingData: Content {
+            let throttled_periods: UInt64
+            let throttled_time: UInt64
+            let throttling_periods: UInt64
+        }
+    }
+
+    struct MemoryStats: Content {
+        let usage: UInt64?
+        let limit: UInt64?
+        let stats: [String: UInt64]?
+    }
+
+    struct NetworkStats: Content {
+        let rx_bytes: UInt64
+        let rx_packets: UInt64
+        let rx_errors: UInt64
+        let rx_dropped: UInt64
+        let tx_bytes: UInt64
+        let tx_packets: UInt64
+        let tx_errors: UInt64
+        let tx_dropped: UInt64
+    }
+
+    struct BlkioStats: Content {
+        let io_service_bytes_recursive: [BlkioEntry]?
+
+        struct BlkioEntry: Content {
+            let major: UInt64
+            let minor: UInt64
+            let op: String
+            let value: UInt64
+        }
+    }
+
+    struct PidsStats: Content {
+        let current: UInt64?
+    }
+}
+
+// MARK: - Builder
+
+extension RESTContainerStats {
+    nonisolated(unsafe) private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    /// Builds a Docker-compatible stats response from two Apple Container samples.
+    /// `prev` is the earlier sample (maps to precpu_stats), `curr` is the latest.
+    /// CPU total_usage is derived from cpuUsageUsec × 1000 (µs → ns).
+    /// system_cpu_usage is synthesised as numCPUs × elapsed nanoseconds so Docker
+    /// clients can compute the standard CPU% formula without dividing by zero.
+    static func build(
+        id: String,
+        prev: ContainerResource.ContainerStats,
+        curr: ContainerResource.ContainerStats,
+        prevRead: Date,
+        currRead: Date
+    ) -> RESTContainerStats {
+        let numCPUs = hostCPUCoreCount()
+        let elapsedNs = UInt64(max(0, currRead.timeIntervalSince(prevRead) * 1_000_000_000))
+        let systemCPU = UInt64(numCPUs) * elapsedNs
+
+        func cpuStats(from sample: ContainerResource.ContainerStats, systemCPU: UInt64) -> CPUStats {
+            let totalNs = (sample.cpuUsageUsec ?? 0) * 1000
+            return CPUStats(
+                cpu_usage: CPUStats.CPUUsage(
+                    total_usage: totalNs,
+                    usage_in_kernelmode: 0,
+                    usage_in_usermode: totalNs
+                ),
+                system_cpu_usage: systemCPU,
+                online_cpus: numCPUs,
+                throttling_data: CPUStats.ThrottlingData(
+                    throttled_periods: 0,
+                    throttled_time: 0,
+                    throttling_periods: 0
+                )
+            )
+        }
+
+        let blkioEntries: [BlkioStats.BlkioEntry]? =
+            (curr.blockReadBytes != nil || curr.blockWriteBytes != nil)
+            ? [
+                BlkioStats.BlkioEntry(major: 8, minor: 0, op: "read", value: curr.blockReadBytes ?? 0),
+                BlkioStats.BlkioEntry(major: 8, minor: 0, op: "write", value: curr.blockWriteBytes ?? 0),
+            ]
+            : nil
+
+        let networks: [String: NetworkStats]?
+        if curr.networkRxBytes != nil || curr.networkTxBytes != nil {
+            networks = [
+                "eth0": NetworkStats(
+                    rx_bytes: curr.networkRxBytes ?? 0,
+                    rx_packets: 0, rx_errors: 0, rx_dropped: 0,
+                    tx_bytes: curr.networkTxBytes ?? 0,
+                    tx_packets: 0, tx_errors: 0, tx_dropped: 0
+                )
+            ]
+        } else {
+            networks = nil
+        }
+
+        return RESTContainerStats(
+            id: id,
+            read: iso8601.string(from: currRead),
+            preread: iso8601.string(from: prevRead),
+            cpu_stats: cpuStats(from: curr, systemCPU: systemCPU),
+            precpu_stats: cpuStats(from: prev, systemCPU: 0),
+            memory_stats: MemoryStats(
+                usage: curr.memoryUsageBytes,
+                limit: curr.memoryLimitBytes ?? hostPhysicalMemory(),
+                stats: nil
+            ),
+            networks: networks,
+            blkio_stats: BlkioStats(io_service_bytes_recursive: blkioEntries),
+            pids_stats: PidsStats(current: curr.numProcesses)
+        )
+    }
+}

--- a/Sources/socktainer/Routes/Containers/ContainerStatsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStatsRoute.swift
@@ -1,11 +1,77 @@
+import ContainerAPIClient
+import Foundation
 import Vapor
 
 struct ContainerStatsRoute: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/containers/{id}/stats", use: ContainerStatsRoute.handler)
+        try routes.registerVersionedRoute(
+            .GET, pattern: "/containers/{id}/stats", use: ContainerStatsRoute.handler)
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/stats", req.method.rawValue)
+        guard let id = req.parameters.get("id") else {
+            throw Abort(.badRequest, reason: "Missing container ID")
+        }
+
+        let stream = (req.query["stream"] as String?) != "false"
+        let client = ContainerClient()
+
+        // Verify container exists before starting to stream
+        guard (try? await client.get(id: id)) != nil else {
+            throw Abort(.notFound, reason: "No such container: \(id)")
+        }
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "application/json")
+
+        let body = Response.Body { writer in
+            Task.detached {
+                defer { _ = writer.write(.end) }
+
+                do {
+                    var prevSample = try await client.stats(id: id)
+                    var prevRead = Date()
+
+                    if stream {
+                        // Streaming mode: emit one JSON object per second indefinitely
+                        // until the client disconnects or the container stops.
+                        while true {
+                            try await Task.sleep(nanoseconds: 1_000_000_000)
+                            guard let currSample = try? await client.stats(id: id) else { break }
+                            let currRead = Date()
+                            let stats = RESTContainerStats.build(
+                                id: id, prev: prevSample, curr: currSample,
+                                prevRead: prevRead, currRead: currRead)
+                            if let data = try? JSONEncoder().encode(stats) {
+                                var buf = sharedAllocator.buffer(capacity: data.count + 1)
+                                buf.writeBytes(data)
+                                buf.writeString("\n")
+                                _ = writer.write(.buffer(buf))
+                            }
+                            prevSample = currSample
+                            prevRead = currRead
+                        }
+                    } else {
+                        // One-shot mode: take two samples 1s apart to get a CPU delta,
+                        // then return a single JSON object and close.
+                        try await Task.sleep(nanoseconds: 1_000_000_000)
+                        guard let currSample = try? await client.stats(id: id) else { return }
+                        let currRead = Date()
+                        let stats = RESTContainerStats.build(
+                            id: id, prev: prevSample, curr: currSample,
+                            prevRead: prevRead, currRead: currRead)
+                        if let data = try? JSONEncoder().encode(stats) {
+                            var buf = sharedAllocator.buffer(capacity: data.count)
+                            buf.writeBytes(data)
+                            _ = writer.write(.buffer(buf))
+                        }
+                    }
+                } catch {
+                    // Container gone or stats unavailable — close stream cleanly
+                }
+            }
+        }
+
+        return Response(status: .ok, headers: headers, body: body)
     }
 }

--- a/Tests/socktainerTests/Routes/ContainerStatsTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStatsTests.swift
@@ -1,0 +1,164 @@
+import ContainerResource
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("ContainerStats")
+struct ContainerStatsTests {
+
+    // MARK: - Helpers
+
+    private func makeSample(
+        cpuUsec: UInt64 = 0,
+        memUsage: UInt64? = nil,
+        memLimit: UInt64? = nil,
+        netRx: UInt64? = nil,
+        netTx: UInt64? = nil,
+        blkRead: UInt64? = nil,
+        blkWrite: UInt64? = nil,
+        pids: UInt64? = nil
+    ) -> ContainerStats {
+        ContainerStats(
+            id: "test",
+            memoryUsageBytes: memUsage,
+            memoryLimitBytes: memLimit,
+            cpuUsageUsec: cpuUsec,
+            networkRxBytes: netRx,
+            networkTxBytes: netTx,
+            blockReadBytes: blkRead,
+            blockWriteBytes: blkWrite,
+            numProcesses: pids
+        )
+    }
+
+    // MARK: - Model builder
+
+    @Test("CPU total_usage converts µs to ns (× 1000)")
+    func cpuUsecToNs() {
+        let prev = makeSample(cpuUsec: 1_000_000)
+        let curr = makeSample(cpuUsec: 2_000_000)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: prev, curr: curr, prevRead: t0, currRead: t1)
+        #expect(stats.cpu_stats.cpu_usage.total_usage == 2_000_000_000)
+        #expect(stats.precpu_stats.cpu_usage.total_usage == 1_000_000_000)
+    }
+
+    @Test("precpu_stats system_cpu_usage is 0 (no elapsed time for baseline)")
+    func precpuSystemIsZero() {
+        let sample = makeSample(cpuUsec: 500_000)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: sample, curr: sample, prevRead: t0, currRead: t1)
+        #expect(stats.precpu_stats.system_cpu_usage == 0)
+    }
+
+    @Test("system_cpu_usage equals numCPUs × elapsed nanoseconds")
+    func systemCPUUsage() {
+        let sample = makeSample()
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: sample, curr: sample, prevRead: t0, currRead: t1)
+        let expected = UInt64(hostCPUCoreCount()) * 1_000_000_000
+        // Allow ±5ms tolerance for timing
+        #expect(abs(Int64(stats.cpu_stats.system_cpu_usage) - Int64(expected)) < 5_000_000)
+    }
+
+    @Test("online_cpus matches host CPU count")
+    func onlineCPUs() {
+        let sample = makeSample()
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: sample, curr: sample, prevRead: t0, currRead: t1)
+        #expect(stats.cpu_stats.online_cpus == hostCPUCoreCount())
+    }
+
+    @Test("memory_stats usage and limit are passed through")
+    func memoryStats() {
+        let curr = makeSample(memUsage: 128_000_000, memLimit: 4_000_000_000)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: curr, prevRead: t0, currRead: t1)
+        #expect(stats.memory_stats.usage == 128_000_000)
+        #expect(stats.memory_stats.limit == 4_000_000_000)
+    }
+
+    @Test("memory limit falls back to host physical memory when nil")
+    func memoryLimitFallback() {
+        let curr = makeSample(memUsage: 64_000_000, memLimit: nil)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: curr, prevRead: t0, currRead: t1)
+        #expect(stats.memory_stats.limit == hostPhysicalMemory())
+    }
+
+    @Test("networks eth0 rx/tx bytes are populated when available")
+    func networkStats() {
+        let curr = makeSample(netRx: 1_234, netTx: 5_678)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: curr, prevRead: t0, currRead: t1)
+        #expect(stats.networks?["eth0"]?.rx_bytes == 1_234)
+        #expect(stats.networks?["eth0"]?.tx_bytes == 5_678)
+    }
+
+    @Test("networks is nil when no network data available")
+    func networkStatsNil() {
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: makeSample(), prevRead: t0, currRead: t1)
+        #expect(stats.networks == nil)
+    }
+
+    @Test("blkio_stats contains read and write entries when available")
+    func blkioStats() {
+        let curr = makeSample(blkRead: 10_000, blkWrite: 20_000)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: curr, prevRead: t0, currRead: t1)
+        let entries = stats.blkio_stats.io_service_bytes_recursive
+        #expect(entries?.first(where: { $0.op == "read" })?.value == 10_000)
+        #expect(entries?.first(where: { $0.op == "write" })?.value == 20_000)
+    }
+
+    @Test("pids_stats current is passed through")
+    func pidsStats() {
+        let curr = makeSample(pids: 7)
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: curr, prevRead: t0, currRead: t1)
+        #expect(stats.pids_stats.current == 7)
+    }
+
+    @Test("read and preread timestamps are ISO8601 strings")
+    func timestamps() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let t1 = Date(timeIntervalSince1970: 1_000_001)
+        let stats = RESTContainerStats.build(id: "c1", prev: makeSample(), curr: makeSample(), prevRead: t0, currRead: t1)
+        #expect(stats.read.contains("T"))
+        #expect(stats.preread.contains("T"))
+        #expect(stats.read != stats.preread)
+    }
+
+    @Test("model serializes to JSON without errors")
+    func jsonSerialization() throws {
+        let t0 = Date()
+        let t1 = Date(timeIntervalSince1970: t0.timeIntervalSince1970 + 1)
+        let stats = RESTContainerStats.build(
+            id: "c1",
+            prev: makeSample(cpuUsec: 1_000_000, memUsage: 64_000_000, memLimit: 2_000_000_000),
+            curr: makeSample(
+                cpuUsec: 2_000_000, memUsage: 128_000_000, memLimit: 2_000_000_000,
+                netRx: 1234, netTx: 5678, blkRead: 100, blkWrite: 200, pids: 5),
+            prevRead: t0, currRead: t1
+        )
+        let data = try JSONEncoder().encode(stats)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["id"] as? String == "c1")
+        #expect(json?["cpu_stats"] != nil)
+        #expect(json?["memory_stats"] != nil)
+        #expect(json?["networks"] != nil)
+        #expect(json?["pids_stats"] != nil)
+    }
+}


### PR DESCRIPTION
## What this does

Implements the Docker-compatible `GET /containers/{id}/stats` endpoint using `ContainerClient.stats(id:)`, available since Apple Container 1.0.0 (merged [apple/container#851](https://github.com/apple/container/pull/851)).

Closes #153

## Behaviour

Supports both Docker modes:

- **`?stream=false`** — takes two samples 1 second apart to compute a CPU delta, returns one JSON object and closes
- **`?stream=true`** (default) — emits one JSON object per second indefinitely; stops cleanly when the container stops or the client disconnects

Verified against Colima with `docker stats --no-stream`:

```
=== Colima postgres ===
CONTAINER ID   NAME          CPU %   MEM USAGE / LIMIT     NET I/O           BLOCK I/O        PIDS
9d55e456f29d   busy_euclid   0.01%   290.7MiB / 15.58GiB   32.8MB / 34.9MB   36.8MB / 988MB   7

=== Socktainer postgres ===
CONTAINER ID   NAME   CPU %   MEM USAGE / LIMIT   NET I/O         BLOCK I/O         PIDS
hcfinal-db-1   --     0.94%   127.3MiB / 1GiB     1.16MB / 602B   67.7MB / 42.2MB   6
```

## CPU% formula

Apple Container provides `cpuUsageUsec` (cumulative µs). Converted to nanoseconds (×1000) for `total_usage`. `system_cpu_usage` is synthesised as `numCPUs × elapsedNs` so Docker clients can apply the standard formula:

```
cpuPercent = (cpuDelta / systemDelta) × onlineCPUs × 100
```

## Known differences from Colima

- **Memory limit** — shows the Apple Container VM limit (default 1 GiB) rather than host RAM. This is the effective constraint for the container and is documented in the README.
- **kernel/user CPU split** — Apple Container does not expose this; both are reported as 0 / total respectively
- **Throttling data** — not available from Apple Container; all zeros

## Tests

12 new tests in `ContainerStatsTests`:
- CPU µs→ns conversion
- `system_cpu_usage` synthesis and timing tolerance
- `online_cpus` matches host
- Memory usage/limit passthrough and fallback
- Network nil when unavailable
- Block I/O read/write entries
- PIDs passthrough
- ISO8601 timestamps
- JSON serialization