### PR TITLE
Load OCI-layout image tarballs directly on docker load

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -446,19 +446,36 @@ struct ClientImageService: ClientImageProtocol {
             try? FileManager.default.removeItem(at: tempDir)
         }
 
-        let dockerFormatPath = tempDir.appendingPathComponent("docker-format")
-        try FileManager.default.createDirectory(at: dockerFormatPath, withIntermediateDirectories: true)
+        let extractedPath = tempDir.appendingPathComponent("extracted")
+        try FileManager.default.createDirectory(at: extractedPath, withIntermediateDirectories: true)
 
-        try ArchiveUtility.extract(tarPath: tarballPath, to: dockerFormatPath)
+        try ArchiveUtility.extract(tarPath: tarballPath, to: extractedPath)
 
-        let ociLayoutPath = tempDir.appendingPathComponent("oci-layout")
-        try FileManager.default.createDirectory(at: ociLayoutPath, withIntermediateDirectories: true)
+        // `docker buildx build --load`, the containerd "docker" exporter, and
+        // `docker save` on modern Docker emit a tarball that is already a valid
+        // OCI image layout (an `oci-layout` marker, an `index.json`, and blobs
+        // under `blobs/sha256/`). Such tarballs also include a legacy
+        // `manifest.json` for backwards compatibility, but its `Config`/`Layers`
+        // entries point at `blobs/sha256/<digest>` rather than the legacy
+        // `<digest>.json` / `<digest>/layer.tar` paths, so the docker-archive
+        // converter cannot consume them. Load the OCI layout directly and only
+        // fall back to conversion for genuinely legacy docker-archive tarballs.
+        let ociLayoutPath: URL
+        let hasOCILayout =
+            FileManager.default.fileExists(atPath: extractedPath.appendingPathComponent("oci-layout").path)
+            && FileManager.default.fileExists(atPath: extractedPath.appendingPathComponent("index.json").path)
 
-        let loadedImages = try await ContainerImageUtility.convertDockerTarToOCI(
-            dockerFormatPath: dockerFormatPath,
-            ociLayoutPath: ociLayoutPath,
-            logger: logger
-        )
+        if hasOCILayout {
+            ociLayoutPath = extractedPath
+        } else {
+            ociLayoutPath = tempDir.appendingPathComponent("oci-layout")
+            try FileManager.default.createDirectory(at: ociLayoutPath, withIntermediateDirectories: true)
+            _ = try await ContainerImageUtility.convertDockerTarToOCI(
+                dockerFormatPath: extractedPath,
+                ociLayoutPath: ociLayoutPath,
+                logger: logger
+            )
+        }
 
         let images = try await imageStore.load(
             from: ociLayoutPath,
@@ -468,6 +485,7 @@ struct ClientImageService: ClientImageProtocol {
                 }
             })
 
+        let loadedImages = images.map { $0.reference }
         for image in loadedImages {
             logger.info("Loaded image: \(image)")
         }


### PR DESCRIPTION
## Problem

`docker buildx build --load` (and `docker save` on modern Docker, and the containerd "docker" exporter) fails to load through socktainer with a client-side `unexpected EOF`. socktainer logs:

```
Failed to load images: "The file "<config-digest>" doesn't exist."
  source:      .../docker-format/blobs/sha256/<config-digest>
  destination: .../oci-layout/blobs/sha256/blobs/sha256/<config-digest>
```

Note the doubled `blobs/sha256/blobs/sha256/` in the destination.

## Cause

These tools emit a tarball that is **already a valid OCI image layout** — it contains an `oci-layout` marker, an `index.json`, and all blobs under `blobs/sha256/`. For backwards compatibility the tarball also includes a legacy `manifest.json`, but its `Config`/`Layers` entries point at `blobs/sha256/<digest>` rather than the legacy `<digest>.json` / `<digest>/layer.tar` paths.

`convertDockerTarToOCI` assumed the legacy docker-archive layout and derived the blob digest by stripping `.json` / `/layer.tar`. For the OCI-style paths nothing is stripped, so the digest becomes `blobs/sha256/<digest>` and the destination path doubles up — the copy then fails and the load aborts.

## Fix

After extracting the tarball, detect whether it is already an OCI layout (presence of `oci-layout` + `index.json`) and hand it to `imageStore.load` directly. `imageStore.load` already reads `index.json` and resolves image references from its annotations, so no conversion is needed. The docker-archive conversion path is kept as a fallback for genuinely legacy `docker save` tarballs.

Loading the OCI layout directly also avoids redundantly copying and re-hashing every blob, and preserves the exact media types from the source manifest.

## Testing

- `docker buildx build --load` of a multi-layer image now loads successfully and the image is runnable.
- Legacy docker-archive tarballs still load via the fallback path.

Release Notes:

- Fixed `docker load` / `docker buildx build --load` failing with "unexpected EOF" for OCI-layout image tarballs