### PR TITLE
Accept build contexts whose tar omits trailing block padding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "47de8369a8f87d87a5a96bb2d7cb3b21d73e728d2a33469fb1a379204adf1524",
+  "originHash" : "e94fe9965b3333056fef3185f0c1cb2d0d183db968d746c6ff22eb7731692799",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "a2a1add6c7e1a1665e5397edc49d925c49090b3a",
         "version" : "0.33.3"
+      }
+    },
+    {
+      "identity" : "datacompression",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mw99/DataCompression.git",
+      "state" : {
+        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
+        "version" : "3.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
+        .package(url: "https://github.com/mw99/DataCompression.git", from: "3.9.0"),
     ],
     targets: [
         .executableTarget(
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "DataCompression", package: "DataCompression"),
                 "BuildInfo",
             ],
         ),

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -81,6 +81,34 @@ extension BuildRoute {
         return dict.map { "\($0.key)=\($0.value)" }
     }
 
+    /// A 38-byte gzip member that decompresses to 4096 zero bytes. Appending it
+    /// to a gzip-compressed tar yields a valid concatenated gzip stream whose
+    /// inflated output gains a completed final block and end-of-archive marker.
+    private static let gzipZeroTerminator: [UInt8] = [
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xed, 0xc1, 0x01, 0x0d, 0x00, 0x00,
+        0x00, 0xc2, 0xa0, 0xf7, 0x4f, 0x6d, 0x0f, 0x07, 0x14, 0x00, 0x00, 0x00, 0xf0, 0x6e, 0x11, 0x00,
+        0x1c, 0xc7, 0x00, 0x10, 0x00, 0x00,
+    ]
+
+    /// Appends a zero-filled end-of-archive terminator to a received build
+    /// context tar so libarchive accepts contexts that omit the trailing
+    /// block padding (notably `docker compose build` with the classic builder).
+    /// For a gzip-compressed context a second gzip member of zeros is appended
+    /// (gzip streams concatenate); for a plain tar, raw zero bytes are appended.
+    static func appendTarTerminator(to tarPath: URL) throws {
+        let handle = try FileHandle(forReadingFrom: tarPath)
+        let magic = try handle.read(upToCount: 2)
+        try handle.close()
+
+        let isGzip = magic == Data([0x1f, 0x8b])
+        let terminator = isGzip ? Data(gzipZeroTerminator) : Data(count: 4096)
+
+        let writeHandle = try FileHandle(forWritingTo: tarPath)
+        defer { try? writeHandle.close() }
+        try writeHandle.seekToEnd()
+        try writeHandle.write(contentsOf: terminator)
+    }
+
     static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             var query = try req.query.decode(RESTBuildQuery.self)
@@ -180,6 +208,17 @@ extension BuildRoute {
                             req.logger.error("Tar file is missing or empty after writing \(totalBytesWritten) bytes")
                             throw Abort(.badRequest, reason: "Failed to write tar archive to disk")
                         }
+
+                        // `docker compose build` (classic builder) streams a build
+                        // context whose final tar entry is not padded out to a 512-byte
+                        // block and which omits the end-of-archive marker. The Docker
+                        // daemon's Go tar reader tolerates this, but libarchive treats
+                        // the short final block as a truncated archive and aborts
+                        // extraction. Append a terminator of zero bytes so the last
+                        // entry's block is completed and a valid end-of-archive marker
+                        // is present. Trailing zeros after a well-formed archive are
+                        // ignored, so this is safe for already-terminated contexts too.
+                        try Self.appendTarTerminator(to: tarPath)
 
                         // Extract the tar archive
                         let extractDir = tempContextDir.appendingPathComponent("context")

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -6,6 +6,7 @@ import Containerization
 import ContainerizationError
 import ContainerizationOCI
 import ContainerizationOS
+import DataCompression
 import Foundation
 import NIO
 import TerminalProgress
@@ -81,27 +82,21 @@ extension BuildRoute {
         return dict.map { "\($0.key)=\($0.value)" }
     }
 
-    /// A 38-byte gzip member that decompresses to 4096 zero bytes. Appending it
-    /// to a gzip-compressed tar yields a valid concatenated gzip stream whose
-    /// inflated output gains a completed final block and end-of-archive marker.
-    private static let gzipZeroTerminator: [UInt8] = [
-        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xed, 0xc1, 0x01, 0x0d, 0x00, 0x00,
-        0x00, 0xc2, 0xa0, 0xf7, 0x4f, 0x6d, 0x0f, 0x07, 0x14, 0x00, 0x00, 0x00, 0xf0, 0x6e, 0x11, 0x00,
-        0x1c, 0xc7, 0x00, 0x10, 0x00, 0x00,
-    ]
-
     /// Appends a zero-filled end-of-archive terminator to a received build
     /// context tar so libarchive accepts contexts that omit the trailing
     /// block padding (notably `docker compose build` with the classic builder).
     /// For a gzip-compressed context a second gzip member of zeros is appended
-    /// (gzip streams concatenate); for a plain tar, raw zero bytes are appended.
+    /// (gzip streams concatenate, so the inflated output gains the missing
+    /// padding); for a plain tar, raw zero bytes are appended.
     static func appendTarTerminator(to tarPath: URL) throws {
         let handle = try FileHandle(forReadingFrom: tarPath)
         let magic = try handle.read(upToCount: 2)
         try handle.close()
 
+        let zeros = Data(count: 4096)
+        // `gzip()` of a fixed in-memory buffer is infallible.
         let isGzip = magic == Data([0x1f, 0x8b])
-        let terminator = isGzip ? Data(gzipZeroTerminator) : Data(count: 4096)
+        let terminator = isGzip ? zeros.gzip()! : zeros
 
         let writeHandle = try FileHandle(forWritingTo: tarPath)
         defer { try? writeHandle.close() }

--- a/Tests/socktainerTests/Routes/BuildContextTarTests.swift
+++ b/Tests/socktainerTests/Routes/BuildContextTarTests.swift
@@ -63,18 +63,16 @@ struct BuildContextTarTests {
         // inside the gzip stream, matching what `docker compose build` sends
         // (Content-Type: application/x-tar, gzip payload).
         let gzTar = plainTar.deletingLastPathComponent().appendingPathComponent("context.tar.gz")
+        FileManager.default.createFile(atPath: gzTar.path, contents: nil)
+        let out = try FileHandle(forWritingTo: gzTar)
         let gzip = Process()
-        gzip.executableURL = URL(fileURLWithPath: "/usr/bin/gzip")
-        gzip.arguments = ["-c", plainTar.path]
-        let out = try FileHandle(
-            forWritingTo: {
-                FileManager.default.createFile(atPath: gzTar.path, contents: nil)
-                return gzTar
-            }())
+        gzip.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        gzip.arguments = ["gzip", "-c", plainTar.path]
         gzip.standardOutput = out
         try gzip.run()
         gzip.waitUntilExit()
         try out.close()
+        #expect(gzip.terminationStatus == 0)
 
         let destBefore = gzTar.deletingLastPathComponent().appendingPathComponent("gzbefore")
         #expect(throws: (any Error).self) {

--- a/Tests/socktainerTests/Routes/BuildContextTarTests.swift
+++ b/Tests/socktainerTests/Routes/BuildContextTarTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// `docker compose build` with the classic builder streams a build-context tar
+/// whose final entry is not padded to a 512-byte block and which omits the
+/// end-of-archive marker. The Docker daemon's Go tar reader tolerates this, but
+/// libarchive (used by `ArchiveUtility.extract`) treats the short final block as
+/// a truncated archive and aborts. `BuildRoute.appendTarTerminator` repairs such
+/// a context by appending a zero-filled terminator before extraction.
+@Suite("Build context tar terminator")
+struct BuildContextTarTests {
+
+    /// Build a tar of a single file, then strip the trailing zero bytes so the
+    /// last entry's block is unpadded and the end-of-archive marker is gone —
+    /// reproducing the classic-builder context tar that libarchive rejects.
+    private func makeUnpaddedTar() throws -> (tar: URL, cleanup: () -> Void) {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let cleanup: () -> Void = { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = tmp.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "hello".data(using: .utf8)!.write(to: source.appendingPathComponent("file.txt"))
+
+        let fullTar = tmp.appendingPathComponent("full.tar")
+        try ArchiveUtility.create(tarPath: fullTar, from: source)
+
+        var bytes = try Data(contentsOf: fullTar)
+        while bytes.last == 0 {
+            bytes.removeLast()
+        }
+        let unpadded = tmp.appendingPathComponent("context.tar")
+        try bytes.write(to: unpadded)
+        return (unpadded, cleanup)
+    }
+
+    @Test("A plain tar missing its trailing padding fails to extract until terminated")
+    func plainTarTerminator() throws {
+        let (tar, cleanup) = try makeUnpaddedTar()
+        defer { cleanup() }
+
+        let destBefore = tar.deletingLastPathComponent().appendingPathComponent("before")
+        #expect(throws: (any Error).self) {
+            try ArchiveUtility.extract(tarPath: tar, to: destBefore)
+        }
+
+        try BuildRoute.appendTarTerminator(to: tar)
+
+        let destAfter = tar.deletingLastPathComponent().appendingPathComponent("after")
+        try ArchiveUtility.extract(tarPath: tar, to: destAfter)
+        let extracted = try String(contentsOf: destAfter.appendingPathComponent("file.txt"), encoding: .utf8)
+        #expect(extracted == "hello")
+    }
+
+    @Test("A gzip-compressed tar missing its trailing padding fails to extract until terminated")
+    func gzipTarTerminator() throws {
+        let (plainTar, cleanup) = try makeUnpaddedTar()
+        defer { cleanup() }
+
+        // Compress the unpadded tar so the missing end-of-archive marker is
+        // inside the gzip stream, matching what `docker compose build` sends
+        // (Content-Type: application/x-tar, gzip payload).
+        let gzTar = plainTar.deletingLastPathComponent().appendingPathComponent("context.tar.gz")
+        let gzip = Process()
+        gzip.executableURL = URL(fileURLWithPath: "/usr/bin/gzip")
+        gzip.arguments = ["-c", plainTar.path]
+        let out = try FileHandle(forWritingTo: {
+            FileManager.default.createFile(atPath: gzTar.path, contents: nil)
+            return gzTar
+        }())
+        gzip.standardOutput = out
+        try gzip.run()
+        gzip.waitUntilExit()
+        try out.close()
+
+        let destBefore = gzTar.deletingLastPathComponent().appendingPathComponent("gzbefore")
+        #expect(throws: (any Error).self) {
+            try ArchiveUtility.extract(tarPath: gzTar, to: destBefore)
+        }
+
+        try BuildRoute.appendTarTerminator(to: gzTar)
+
+        let destAfter = gzTar.deletingLastPathComponent().appendingPathComponent("gzafter")
+        try ArchiveUtility.extract(tarPath: gzTar, to: destAfter)
+        let extracted = try String(contentsOf: destAfter.appendingPathComponent("file.txt"), encoding: .utf8)
+        #expect(extracted == "hello")
+    }
+
+    @Test("Terminating an already well-formed tar leaves it extractable")
+    func wellFormedTarStaysValid() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = tmp.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "world".data(using: .utf8)!.write(to: source.appendingPathComponent("file.txt"))
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try ArchiveUtility.create(tarPath: tar, from: source)
+
+        // Appending to a complete archive is a no-op for readers: trailing zeros
+        // after the end-of-archive marker are ignored.
+        try BuildRoute.appendTarTerminator(to: tar)
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+        let extracted = try String(contentsOf: dest.appendingPathComponent("file.txt"), encoding: .utf8)
+        #expect(extracted == "world")
+    }
+}

--- a/Tests/socktainerTests/Routes/BuildContextTarTests.swift
+++ b/Tests/socktainerTests/Routes/BuildContextTarTests.swift
@@ -66,10 +66,11 @@ struct BuildContextTarTests {
         let gzip = Process()
         gzip.executableURL = URL(fileURLWithPath: "/usr/bin/gzip")
         gzip.arguments = ["-c", plainTar.path]
-        let out = try FileHandle(forWritingTo: {
-            FileManager.default.createFile(atPath: gzTar.path, contents: nil)
-            return gzTar
-        }())
+        let out = try FileHandle(
+            forWritingTo: {
+                FileManager.default.createFile(atPath: gzTar.path, contents: nil)
+                return gzTar
+            }())
         gzip.standardOutput = out
         try gzip.run()
         gzip.waitUntilExit()


### PR DESCRIPTION
## Problem

`docker build` / `docker compose build` with the **classic builder** fails through socktainer when the Dockerfile lives outside the build context (so the builder injects it as a `.dockerfile.<hash>` entry):

```
Error response from daemon: {"error":true,"reason":"Failed to extract tar archive: ... (socktainer.ArchiveUtilityError error 1.)"}
```

socktainer logs:

```
Tar extraction failed: archiveReadFailed("... (ContainerizationArchive.ArchiveError error 9.)")   # unableToCloseArchive
```

## Cause

The classic builder streams a context tar whose **final entry is not padded out to a 512-byte block and which omits the end-of-archive marker**. `bsdtar`/GNU `tar` and the Docker daemon's Go tar reader tolerate this (they extract the entry and warn), but libarchive — used by `ArchiveUtility.extract` — treats the short final block as a truncated archive and aborts (`unableToCloseArchive`), so the whole build fails before any image is built.

Inspecting the captured context confirms it (the trailing block of the injected dockerfile entry is short):

```
.dockerfile.<hash>: Truncated input file (needed 2560 bytes, only 2422 available)
```

## Fix

Append a zero-filled terminator to the received context tar before extraction so the final entry's block is completed and a valid end-of-archive marker is present:

- **gzip-compressed context** (Compose sends `Content-Type: application/x-tar` with a gzip payload): append a small gzip member that inflates to zeros — gzip streams concatenate, so the decompressed output gains the missing padding.
- **plain tar**: append raw zero bytes.

Trailing zeros after a well-formed archive are ignored by the reader, so the terminator is also safe for already-terminated contexts. socktainer's hardened, path-traversal-safe `ArchiveReader` extraction path is preserved (the input is normalized rather than swapping in an external extractor).

## Reproduction (no devcontainer needed)

```sh
mkdir -p /tmp/repro/ctx && echo hi > /tmp/repro/ctx/file
printf 'FROM alpine\nCOPY file /file\n' > /tmp/repro/external.Dockerfile   # Dockerfile OUTSIDE the context
cat > /tmp/repro/compose.yaml <<'YAML'
services:
  app:
    build:
      context: ./ctx
      dockerfile: /tmp/repro/external.Dockerfile
YAML

cd /tmp/repro
DOCKER_HOST=unix://$HOME/.socktainer/container.sock \
  DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
  docker compose build
# before: "Failed to extract tar archive"
# after:  builds successfully
```

## Testing

- New unit tests in `BuildContextTarTests` cover the plain-tar and gzip cases (extraction fails on an unpadded tar, succeeds after `appendTarTerminator`) and verify a well-formed tar stays extractable.
- Verified end-to-end: a real `docker compose build` with an external Dockerfile that previously failed now builds.

Release Notes:

- Fixed `docker build` / `docker compose build` with the classic builder failing with "Failed to extract tar archive" when the Dockerfile is outside the build context