### PR TITLE
fix(labels): normalize label keys for Apple Container compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,26 @@ We welcome contributions!
 - Docker API compatibility is **partial**, focused on commonly used endpoints. See `Sources/socktainer/Routes/` for implemented routes
 - Private registry auth currently depends on Apple `container` behavior. If login succeeds but private pulls/builds still fail, a manual workaround may be required. See [apple/container#816 comment 3534438608](https://github.com/apple/container/issues/816#issuecomment-3534438608) and [comment 3503618765](https://github.com/apple/container/issues/816#issuecomment-3503618765).
 
+### Label key normalization
+
+Apple Container only accepts lowercase label keys matching `[a-z0-9](?:[a-z0-9\-\.\/]*[a-z0-9])?`. Docker allows mixed-case, underscores, and other characters. Socktainer automatically normalizes label keys at create time:
+
+- Uppercase → lowercase (`sessionId` → `sessionid`)
+- Underscores → hyphens (`my_key` → `my-key`)
+- Other invalid characters are dropped
+- An `INFO` log is emitted for every key that is changed
+- A `WARNING` is logged when a key becomes empty after normalization (dropped) or when two keys normalize to the same string (collision, last value wins)
+
+Original keys are preserved via an internal mapping label (`socktainer.label-original-keys`) that is stored alongside the normalized keys and stripped from all API responses. As a result, `docker inspect`, filter lookups, and Go-template label access all return and match the original key exactly:
+
+```bash
+# Works — original key is restored transparently
+docker inspect --format '{{index .Config.Labels "MyApp"}}' <container>
+docker ps --filter label=MyApp=value
+```
+
+The one edge case: if two keys normalize to the same string (e.g. `MyKey` and `mykey`), the last one wins — a `WARNING` is logged so the loss is visible in Socktainer's output.
+
 ---
 
 ## Community 💬

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -69,11 +69,11 @@ struct ClientContainerService: ClientContainerProtocol {
                     let labels = container.configuration.labels
                     return values.allSatisfy { labelFilter in
                         guard let eqIdx = labelFilter.firstIndex(of: "=") else {
-                            return labels.keys.contains(labelFilter)
+                            return LabelNormalization.filterContainsKey(labelFilter, in: labels)
                         }
                         let k = String(labelFilter.prefix(upTo: eqIdx))
                         let v = String(labelFilter.suffix(from: labelFilter.index(after: eqIdx)))
-                        return labels[k] == v
+                        return LabelNormalization.filterValue(in: labels, forKey: k) == v
                     }
                 }
             case "name":
@@ -372,23 +372,23 @@ struct ClientContainerService: ClientContainerProtocol {
                     return values.allSatisfy { labelFilter in
                         if labelFilter.contains("!=") {
                             if let eqIdx = labelFilter.range(of: "!=") {
-                                let prefix = String(labelFilter.prefix(upTo: eqIdx.lowerBound))
+                                let key = String(labelFilter.prefix(upTo: eqIdx.lowerBound))
                                 let suffix = String(labelFilter.suffix(from: eqIdx.upperBound))
                                 guard suffix.isEmpty else {
-                                    return labels[prefix] != suffix
+                                    return LabelNormalization.filterValue(in: labels, forKey: key) != suffix
                                 }
-                                return !labels.keys.contains(prefix)
+                                return !LabelNormalization.filterContainsKey(key, in: labels)
                             }
                             return false
                         } else if labelFilter.contains("=") {
                             if let eqIdx = labelFilter.firstIndex(of: "=") {
                                 let k = String(labelFilter.prefix(upTo: eqIdx))
                                 let v = String(labelFilter.suffix(from: labelFilter.index(after: eqIdx)))
-                                return labels[k] == v
+                                return LabelNormalization.filterValue(in: labels, forKey: k) == v
                             }
                             return false
                         } else {
-                            return labels.keys.contains(labelFilter)
+                            return LabelNormalization.filterContainsKey(labelFilter, in: labels)
                         }
                     }
                 }

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -98,9 +98,13 @@ struct ClientNetworkService: ClientNetworkProtocol {
                         let parts = label.split(separator: "=", maxSplits: 1)
                         let key = String(parts[0])
                         let value = String(parts[1])
-                        if network.Labels[key] != value { excludedReason = "label key=value mismatch" }
+                        if LabelNormalization.filterValue(in: network.Labels, forKey: key) != value {
+                            excludedReason = "label key=value mismatch"
+                        }
                     } else {
-                        if network.Labels[label] == nil { excludedReason = "label key missing" }
+                        if !LabelNormalization.filterContainsKey(label, in: network.Labels) {
+                            excludedReason = "label key missing"
+                        }
                     }
                 }
             }
@@ -152,7 +156,7 @@ extension RESTNetworkSummary {
         let id = networkResource.configuration.name
         let driver = String(describing: networkResource.configuration.mode)
         let options: [String: String] = [:]  // Not provided by Apple container
-        let labels = networkResource.configuration.labels.dictionary
+        let labels = LabelNormalization.restore(networkResource.configuration.labels.dictionary)
         let subnet =
             networkResource.configuration.ipv4Subnet.map { String(describing: $0) }
             ?? String(describing: networkResource.status.ipv4Subnet)

--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -67,11 +67,11 @@ struct ClientVolumeService: ClientVolumeProtocol {
             if let labels = parsedFilters["label"], !labels.isEmpty, let volumeLabels = volume.Labels {
                 let labelMatches = labels.contains { labelFilter in
                     guard let eqIdx = labelFilter.firstIndex(of: "=") else {
-                        return volumeLabels.keys.contains(labelFilter)
+                        return LabelNormalization.filterContainsKey(labelFilter, in: volumeLabels)
                     }
                     let key = String(labelFilter[..<eqIdx])
                     let value = String(labelFilter[labelFilter.index(after: eqIdx)...])
-                    return volumeLabels[key] == value
+                    return LabelNormalization.filterValue(in: volumeLabels, forKey: key) == value
                 }
                 matches = matches && labelMatches
             }
@@ -107,7 +107,7 @@ struct ClientVolumeService: ClientVolumeProtocol {
             Mountpoint: v.source,
             CreatedAt: ISO8601DateFormatter().string(from: v.creationDate),
             Status: nil,  // we have no mechanism to report status for the time being
-            Labels: v.labels,
+            Labels: LabelNormalization.restore(v.labels),
             Scope: "local",  // Assuming local for now
             ClusterVolume: nil,
             Options: v.options,

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -286,7 +286,14 @@ extension ContainerCreateRoute {
                 .map { settings in settings.compactMap(\.Aliases).flatMap { $0 }.filter { !$0.isEmpty } }
                 ?? []
 
-            var containerLabels = body.Labels ?? [:]
+            let originalLabels = body.Labels ?? [:]
+            guard !LabelNormalization.containsReservedKey(originalLabels) else {
+                throw Abort(.badRequest, reason: "Label key '\(LabelNormalization.mappingKey)' is reserved for internal use")
+            }
+            var containerLabels = LabelNormalization.sanitize(originalLabels)
+            if let mapping = LabelNormalization.buildMapping(originalLabels) {
+                containerLabels[LabelNormalization.mappingKey] = mapping
+            }
 
             // Persist the requested healthcheck across create → start so the
             // start route can launch the probe loop and inspect can return it

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -68,7 +68,10 @@ extension ContainerInspectRoute {
                 NetworkDisabled: container.networks.isEmpty,
                 MacAddress: nil,  // no mechanism to derive this value
                 OnBuild: nil,  // no mechanism to derive this value
-                Labels: container.configuration.labels.isEmpty ? nil : container.configuration.labels,
+                Labels: {
+                    let restored = LabelNormalization.restore(container.configuration.labels)
+                    return restored.isEmpty ? nil : restored
+                }(),
                 StopSignal: nil,  // no mechanism to derive this value
                 StopTimeout: nil,  // no mechanism to derive this value
                 Shell: nil  // no mechanism to derive this value

--- a/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
@@ -152,7 +152,7 @@ extension ContainerListRoute {
                     Ports: ports,
                     SizeRw: nil,  // there is no mechanism to retrieve this value from apple container
                     SizeRootFs: nil,  // there is no mechanism to retrieve this value from apple container
-                    Labels: container.configuration.labels,
+                    Labels: LabelNormalization.restore(container.configuration.labels),
                     State: mobyState,
                     Status: statusStr,
                     HostConfig: ContainerHostConfig(NetworkMode: networkMode, Annotations: nil),

--- a/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
@@ -28,7 +28,14 @@ struct NetworkCreateRoute: RouteCollection {
         let logger = req.logger
         let query = try req.content.decode(NetworksCreateQuery.self)
         // only pass network name and labels for now
-        let labels = query.Labels ?? [:]
+        let originalLabels = query.Labels ?? [:]
+        guard !LabelNormalization.containsReservedKey(originalLabels) else {
+            throw Abort(.badRequest, reason: "Label key '\(LabelNormalization.mappingKey)' is reserved for internal use")
+        }
+        var labels = LabelNormalization.sanitize(originalLabels)
+        if let mapping = LabelNormalization.buildMapping(originalLabels) {
+            labels[LabelNormalization.mappingKey] = mapping
+        }
         let response = try await client.create(name: query.Name, labels: labels, logger: logger)
         return try await response.encodeResponse(for: req)
     }

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -212,7 +212,7 @@ extension SystemDFRoute {
                         Mountpoint: volume.Mountpoint,
                         CreatedAt: volume.CreatedAt,
                         Status: volume.Status,
-                        Labels: volume.Labels,
+                        Labels: volume.Labels,  // already restored by ClientVolumeService.convert()
                         Scope: volume.Scope,
                         ClusterVolume: volume.ClusterVolume,
                         Options: volume.Options,
@@ -316,7 +316,7 @@ extension SystemDFRoute {
             Ports: ports,
             SizeRw: size,
             SizeRootFs: size,
-            Labels: container.configuration.labels,
+            Labels: LabelNormalization.restore(container.configuration.labels),
             State: container.status.mobyState,
             Status: container.status.mobyState,
             HostConfig: ContainerHostConfig(NetworkMode: networkMode, Annotations: nil),

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -20,7 +20,14 @@ struct VolumeCreateRoute: RouteCollection {
         // Socktainer-specific) and persist it as a label so ContainerCreateRoute
         // can apply the right Filesystem.SyncMode when mounting this volume.
         var driverOpts = createRequest.DriverOpts ?? [:]
-        var labels = createRequest.Labels ?? [:]
+        let originalLabels = createRequest.Labels ?? [:]
+        guard !LabelNormalization.containsReservedKey(originalLabels) else {
+            throw Abort(.badRequest, reason: "Label key '\(LabelNormalization.mappingKey)' is reserved for internal use")
+        }
+        var labels = LabelNormalization.sanitize(originalLabels)
+        if let mapping = LabelNormalization.buildMapping(originalLabels) {
+            labels[LabelNormalization.mappingKey] = mapping
+        }
         if let syncValue = driverOpts.removeValue(forKey: "sync") {
             guard Filesystem.SyncMode(rawString: syncValue) != nil else {
                 throw Abort(.badRequest, reason: "Invalid sync mode '\(syncValue)'. Valid values: nosync, fsync, full")

--- a/Sources/socktainer/Routes/Volumes/VolumeListRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeListRoute.swift
@@ -32,7 +32,7 @@ struct VolumeListRoute: RouteCollection {
             VolumeInfo(
                 CreatedAt: v.CreatedAt ?? "",
                 Driver: v.Driver,
-                Labels: v.Labels,
+                Labels: v.Labels,  // already restored by ClientVolumeService.convert()
                 Mountpoint: v.Mountpoint,
                 Name: v.Name,
                 Options: v.Options,

--- a/Sources/socktainer/Utilities/LabelUtility.swift
+++ b/Sources/socktainer/Utilities/LabelUtility.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Logging
+
+/// Handles normalization of Docker label keys to comply with Apple Container's
+/// stricter validation rules, while preserving original keys transparently so
+/// that `docker inspect` and filter lookups return exactly what the client sent.
+///
+/// Apple Container only accepts keys matching `[a-z0-9](?:[a-z0-9\-\.\/]*[a-z0-9])?`
+/// (Docker format) or the OCI format which additionally allows `/`.
+/// Docker clients routinely send mixed-case keys (e.g. `org.testcontainers.sessionId`)
+/// that would otherwise cause a 500 error.
+enum LabelNormalization {
+
+    /// Internal label used to store the reverse mapping normalized → original key.
+    /// Stripped from all Docker API responses so it is invisible to clients.
+    static let mappingKey = "socktainer.label-original-keys"
+
+    private static let log = Logger(label: "socktainer.labels")
+
+    // MARK: - Normalization
+
+    /// Normalizes a single label key. Also used when comparing filter keys so
+    /// both sides of a label filter lookup are on equal footing.
+    ///
+    /// Single-pass O(n) normalization:
+    ///   1. Lowercase + underscore → hyphen on each character
+    ///   2. Drop characters outside `[a-z0-9-./]`
+    ///   3. Collapse any run of consecutive separators (including mixed `-./`) to the first one
+    ///   4. Strip leading and trailing separators
+    static func sanitizeKey(_ key: String) -> String {
+        let separators: Set<Character> = ["-", ".", "/"]
+        let allowedChars: Set<Character> = Set("abcdefghijklmnopqrstuvwxyz0123456789").union(separators)
+
+        var output: [Character] = []
+        // Initialized to `true` so any leading separators are skipped without a second trim pass.
+        var prevIsSeparator = true
+
+        for char in key.lowercased() {
+            let normalized: Character = char == "_" ? "-" : char
+            guard allowedChars.contains(normalized) else { continue }
+            let isSeparator = separators.contains(normalized)
+            if isSeparator && prevIsSeparator { continue }
+            output.append(normalized)
+            prevIsSeparator = isSeparator
+        }
+
+        // Trim any trailing separator left by the loop.
+        while let last = output.last, separators.contains(last) {
+            output.removeLast()
+        }
+
+        return String(output)
+    }
+
+    /// Normalizes all keys in a label dict. Keys that are already valid pass through
+    /// unchanged. Keys that become empty after normalization are dropped with a WARNING log.
+    /// A WARNING is also logged when two distinct original keys normalize to the same string
+    /// (last value wins, earlier value is silently lost without this warning).
+    static func sanitize(_ labels: [String: String]) -> [String: String] {
+        var normalizedLabels: [String: String] = [:]
+        for (key, value) in labels {
+            let normalizedKey = sanitizeKey(key)
+            // Empty check is unconditional: covers both originally-empty keys ("" → "")
+            // and keys that become empty after normalization.
+            guard !normalizedKey.isEmpty else {
+                log.warning(
+                    "Label key dropped — empty after normalization for Apple Container compatibility",
+                    metadata: ["original": "\(key)"]
+                )
+                continue
+            }
+            if normalizedKey != key {
+                log.info(
+                    "Label key normalized for Apple Container compatibility",
+                    metadata: ["original": "\(key)", "normalized": "\(normalizedKey)"]
+                )
+            }
+            if normalizedLabels[normalizedKey] != nil {
+                log.warning(
+                    "Label key collision — two keys normalized to the same string, last value wins",
+                    metadata: ["normalized-key": "\(normalizedKey)", "value-kept": "\(value)"]
+                )
+            }
+            normalizedLabels[normalizedKey] = value
+        }
+        return normalizedLabels
+    }
+
+    /// Returns true if the labels dict contains the reserved internal mapping key.
+    /// Create routes must reject such inputs to prevent silent data loss.
+    static func containsReservedKey(_ labels: [String: String]) -> Bool {
+        labels[mappingKey] != nil
+    }
+
+    // MARK: - Mapping: build and restore
+
+    /// Builds a JSON mapping of normalized key → original key for all keys that changed.
+    /// Returns nil when no keys needed normalization (nothing to store).
+    static func buildMapping(_ original: [String: String]) -> String? {
+        var normalizedToOriginal: [String: String] = [:]
+        for originalKey in original.keys {
+            let normalizedKey = sanitizeKey(originalKey)
+            guard normalizedKey != originalKey, !normalizedKey.isEmpty else { continue }
+            normalizedToOriginal[normalizedKey] = originalKey
+        }
+        guard !normalizedToOriginal.isEmpty,
+            let jsonData = try? JSONEncoder().encode(normalizedToOriginal),
+            let jsonString = String(data: jsonData, encoding: .utf8)
+        else { return nil }
+        return jsonString
+    }
+
+    // MARK: - Filter helpers
+
+    /// Looks up a label value using both the filter key as-is and its normalized form.
+    /// Handles resources with restored original keys (new) and those with only normalized
+    /// keys stored (created before this feature).
+    static func filterValue(in labels: [String: String], forKey filterKey: String) -> String? {
+        labels[filterKey] ?? labels[sanitizeKey(filterKey)]
+    }
+
+    /// Returns true if the labels dict contains the given filter key (original or normalized).
+    static func filterContainsKey(_ filterKey: String, in labels: [String: String]) -> Bool {
+        labels[filterKey] != nil || labels[sanitizeKey(filterKey)] != nil
+    }
+
+    /// Restores original label keys using the hidden mapping label, then strips it.
+    /// Resources created before this feature have no mapping → returns labels unchanged
+    /// (the mapping key is always stripped regardless).
+    static func restore(_ labels: [String: String]) -> [String: String] {
+        var labelsWithoutMappingKey = labels
+        labelsWithoutMappingKey.removeValue(forKey: mappingKey)
+
+        guard let mappingJSON = labels[mappingKey],
+            let mappingData = mappingJSON.data(using: .utf8),
+            let normalizedToOriginal = try? JSONDecoder().decode([String: String].self, from: mappingData)
+        else { return labelsWithoutMappingKey }
+
+        var restoredLabels: [String: String] = [:]
+        for (normalizedKey, value) in labelsWithoutMappingKey {
+            let originalKey = normalizedToOriginal[normalizedKey] ?? normalizedKey
+            restoredLabels[originalKey] = value
+        }
+        return restoredLabels
+    }
+}

--- a/Tests/socktainerTests/Utilitites/LabelUtilityTests.swift
+++ b/Tests/socktainerTests/Utilitites/LabelUtilityTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("LabelNormalization")
+struct LabelNormalizationTests {
+
+    // MARK: - sanitizeKey
+
+    @Test("Lowercase-only keys pass through unchanged")
+    func lowercaseKeysUnchanged() {
+        #expect(LabelNormalization.sanitizeKey("org.example.key") == "org.example.key")
+        #expect(LabelNormalization.sanitizeKey("foo") == "foo")
+    }
+
+    @Test("Mixed-case keys are lowercased")
+    func mixedCaseKeyLowercased() {
+        #expect(LabelNormalization.sanitizeKey("org.testcontainers.sessionId") == "org.testcontainers.sessionid")
+    }
+
+    @Test("Underscores are replaced with hyphens")
+    func underscoresReplacedWithHyphens() {
+        #expect(LabelNormalization.sanitizeKey("my_label_key") == "my-label-key")
+    }
+
+    @Test("Underscore + uppercase combination is handled")
+    func underscoreAndUppercase() {
+        #expect(LabelNormalization.sanitizeKey("My_Label_Key") == "my-label-key")
+    }
+
+    @Test("Characters outside [a-z0-9-./] are dropped")
+    func invalidCharsDropped() {
+        #expect(LabelNormalization.sanitizeKey("my@label") == "mylabel")
+        #expect(LabelNormalization.sanitizeKey("my label") == "mylabel")
+    }
+
+    @Test("Forward slash is preserved (OCI label format)")
+    func slashPreserved() {
+        #expect(LabelNormalization.sanitizeKey("io.buildpacks/runtime") == "io.buildpacks/runtime")
+    }
+
+    @Test("Consecutive hyphens are collapsed to single hyphen")
+    func consecutiveHyphensCollapsed() {
+        #expect(LabelNormalization.sanitizeKey("a--b") == "a-b")
+        #expect(LabelNormalization.sanitizeKey("my__key") == "my-key")  // __ → -- → -
+    }
+
+    @Test("Consecutive dots are collapsed to single dot")
+    func consecutiveDotsCollapsed() {
+        #expect(LabelNormalization.sanitizeKey("a..b") == "a.b")
+        #expect(LabelNormalization.sanitizeKey("a...b") == "a.b")
+    }
+
+    @Test("Consecutive slashes are collapsed to single slash")
+    func consecutiveSlashesCollapsed() {
+        #expect(LabelNormalization.sanitizeKey("io.buildpacks//runtime") == "io.buildpacks/runtime")
+        #expect(LabelNormalization.sanitizeKey("a///b") == "a/b")
+    }
+
+    @Test("Leading and trailing separators are stripped — hyphens, dots, and slashes")
+    func leadingTrailingSeparatorsStripped() {
+        #expect(LabelNormalization.sanitizeKey("-my-key") == "my-key")
+        #expect(LabelNormalization.sanitizeKey("my-key-") == "my-key")
+        #expect(LabelNormalization.sanitizeKey(".my.key.") == "my.key")
+        #expect(LabelNormalization.sanitizeKey("/my/key/") == "my/key")
+        #expect(LabelNormalization.sanitizeKey("//my//key//") == "my/key")
+    }
+
+    @Test("Key of only invalid characters returns empty string")
+    func onlyInvalidCharsReturnsEmpty() {
+        #expect(LabelNormalization.sanitizeKey("@@@") == "")
+        #expect(LabelNormalization.sanitizeKey("---") == "")
+    }
+
+    // MARK: - sanitize (dict)
+
+    @Test("Empty labels return empty dict")
+    func emptyLabels() {
+        #expect(LabelNormalization.sanitize([:]).isEmpty)
+    }
+
+    @Test("Key that becomes empty after normalization is dropped")
+    func emptyKeyDropped() {
+        #expect(LabelNormalization.sanitize(["@@@": "value"]).isEmpty)
+    }
+
+    @Test("Originally-empty key is dropped unconditionally (regression: empty key bypassed guard)")
+    func originallyEmptyKeyDropped() {
+        // "" normalizes to "" — the guard must fire even when normalizedKey == key
+        #expect(LabelNormalization.sanitize(["": "value"]).isEmpty)
+    }
+
+    @Test("Reserved mapping key in input is detected by containsReservedKey")
+    func reservedMappingKeyDetected() {
+        let labels = [LabelNormalization.mappingKey: "anything"]
+        #expect(LabelNormalization.containsReservedKey(labels) == true)
+        #expect(LabelNormalization.containsReservedKey(["normal-key": "value"]) == false)
+    }
+
+    @Test("Collision on lowercase keeps last value")
+    func collisionKeepsLast() {
+        let result = LabelNormalization.sanitize(["Key": "first", "key": "second"])
+        #expect(result.count == 1)
+        #expect(result["key"] != nil)
+    }
+
+    @Test("Values are preserved as-is")
+    func valuesPreserved() {
+        let result = LabelNormalization.sanitize(["Key": "MixedCaseValue"])
+        #expect(result["key"] == "MixedCaseValue")
+    }
+
+    // MARK: - buildMapping
+
+    @Test("No mapping produced when no keys are changed")
+    func noMappingForCleanKeys() {
+        #expect(LabelNormalization.buildMapping(["clean-key": "value"]) == nil)
+    }
+
+    @Test("Mapping produced for changed keys")
+    func mappingProducedForChangedKeys() {
+        let json = LabelNormalization.buildMapping(["sessionId": "abc"])
+        #expect(json != nil)
+        if let data = json?.data(using: .utf8),
+            let map = try? JSONDecoder().decode([String: String].self, from: data)
+        {
+            #expect(map["sessionid"] == "sessionId")
+        }
+    }
+
+    @Test("Mapping excludes unchanged keys")
+    func mappingExcludesUnchangedKeys() {
+        let json = LabelNormalization.buildMapping(["clean-key": "a", "MyKey": "b"])
+        if let data = json?.data(using: .utf8),
+            let map = try? JSONDecoder().decode([String: String].self, from: data)
+        {
+            #expect(map["clean-key"] == nil)
+            #expect(map["mykey"] == "MyKey")
+        }
+    }
+
+    // MARK: - restore
+
+    @Test("Mapping label is always stripped from output")
+    func mappingLabelStripped() {
+        let labels = [LabelNormalization.mappingKey: "{}", "foo": "bar"]
+        let result = LabelNormalization.restore(labels)
+        #expect(result[LabelNormalization.mappingKey] == nil)
+        #expect(result["foo"] == "bar")
+    }
+
+    @Test("Original keys are restored from mapping")
+    func originalKeysRestored() throws {
+        let mappingData = try JSONEncoder().encode(["sessionid": "sessionId"])
+        guard let mappingJSON = String(data: mappingData, encoding: .utf8) else {
+            Issue.record("Failed to encode mapping to UTF-8 string")
+            return
+        }
+        let stored = [LabelNormalization.mappingKey: mappingJSON, "sessionid": "abc"]
+        let result = LabelNormalization.restore(stored)
+        #expect(result["sessionId"] == "abc")
+        #expect(result["sessionid"] == nil)
+        #expect(result[LabelNormalization.mappingKey] == nil)
+    }
+
+    @Test("No mapping label = labels returned as-is (backwards compatibility)")
+    func noMappingReturnsLabelsAsIs() {
+        let labels = ["already-clean": "value"]
+        #expect(LabelNormalization.restore(labels) == labels)
+    }
+
+    // MARK: - Full round-trip
+
+    @Test("testcontainers sessionId round-trips transparently through sanitize + restore")
+    func testcontainersRoundTrip() {
+        let original = ["org.testcontainers.sessionId": "abc", "org.example.version": "1.0"]
+        var stored = LabelNormalization.sanitize(original)
+        if let mapping = LabelNormalization.buildMapping(original) {
+            stored[LabelNormalization.mappingKey] = mapping
+        }
+        let restored = LabelNormalization.restore(stored)
+        #expect(restored["org.testcontainers.sessionId"] == "abc")
+        #expect(restored["org.example.version"] == "1.0")
+        #expect(restored[LabelNormalization.mappingKey] == nil)
+    }
+
+    @Test("Filter lookup works via sanitized key comparison against raw stored labels")
+    func filterLookupWorksViaSanitizedKey() {
+        var stored = LabelNormalization.sanitize(["org.testcontainers.sessionId": "abc"])
+        if let mapping = LabelNormalization.buildMapping(["org.testcontainers.sessionId": "abc"]) {
+            stored[LabelNormalization.mappingKey] = mapping
+        }
+        // Raw stored labels use normalized keys — filter should normalize to match
+        let filterKey = LabelNormalization.sanitizeKey("org.testcontainers.sessionId")
+        #expect(stored[filterKey] == "abc")
+    }
+
+    // MARK: - Collision warning
+
+    @Test("Collision: two keys normalizing to same string — last value wins")
+    func collisionLastValueWins() {
+        let result = LabelNormalization.sanitize(["MyKey": "first", "mykey": "second"])
+        #expect(result.count == 1)
+        #expect(result["mykey"] != nil)
+    }
+
+    // MARK: - filterValue / filterContainsKey helpers
+
+    @Test("filterValue finds value by original key in restored labels (new resources)")
+    func filterValueFindsOriginalKey() {
+        // Simulate restored labels from a new resource (mapping was stored)
+        let original = ["org.Test.Volume": "vol1"]
+        var stored = LabelNormalization.sanitize(original)
+        if let mapping = LabelNormalization.buildMapping(original) {
+            stored[LabelNormalization.mappingKey] = mapping
+        }
+        let restored = LabelNormalization.restore(stored)
+
+        #expect(LabelNormalization.filterValue(in: restored, forKey: "org.Test.Volume") == "vol1")
+    }
+
+    @Test("filterValue finds value by normalized key in old resources (no mapping)")
+    func filterValueFindsNormalizedKeyForOldResources() {
+        // Simulate old resource without mapping (pre-existing normalized labels)
+        let oldStored = ["org.test.volume": "vol1"]
+
+        #expect(LabelNormalization.filterValue(in: oldStored, forKey: "org.Test.Volume") == "vol1")
+    }
+
+    @Test("filterValue returns nil when key not found in either form")
+    func filterValueReturnsNilWhenNotFound() {
+        let labels = ["other.key": "value"]
+        #expect(LabelNormalization.filterValue(in: labels, forKey: "org.Test.Volume") == nil)
+    }
+
+    @Test("filterContainsKey finds key in restored labels (new resources)")
+    func filterContainsKeyInRestoredLabels() {
+        let original = ["MyVolume": "true"]
+        var stored = LabelNormalization.sanitize(original)
+        if let mapping = LabelNormalization.buildMapping(original) {
+            stored[LabelNormalization.mappingKey] = mapping
+        }
+        let restored = LabelNormalization.restore(stored)
+
+        #expect(LabelNormalization.filterContainsKey("MyVolume", in: restored))
+        #expect(!LabelNormalization.filterContainsKey("OtherKey", in: restored))
+    }
+
+    @Test("filterContainsKey finds normalized key in old resources (no mapping)")
+    func filterContainsKeyInOldResources() {
+        let oldStored = ["myvolume": "true"]
+        #expect(LabelNormalization.filterContainsKey("MyVolume", in: oldStored))
+    }
+}


### PR DESCRIPTION
## What this does

### The bug

Apple Container rejects label keys that contain uppercase letters, underscores, or other characters it considers invalid — returning a `500 Internal Server Error` instead of creating the resource. The immediate symptom:

```
[ WARNING ] invalidArgument: "invalid label key: org.testcontainers.sessionId"
```

Any Docker client that uses mixed-case label keys (testcontainers, some CI runners, custom tooling) is broken against Socktainer today.

### The deeper concern

Socktainer's contract is **transparent Docker compatibility** — tools that work with Docker should work with Socktainer without modification. Silently rejecting or mangling label keys breaks that contract. Simply lowercasing keys would fix the 500 error but introduce a subtler breakage: `docker inspect --format '{{index .Config.Labels "sessionId"}}'` would return empty, and filter lookups by original-case key would miss. The fix therefore has to be invisible end-to-end, not just at the storage layer.

### The solution

Normalize keys to satisfy Apple Container, but store a reverse mapping (`socktainer.label-original-keys`) so every response path can restore original keys before returning them. From the client's perspective nothing changes — the same key they sent comes back in inspect, filters, and Go-template lookups.

Closes #164

## Normalization pipeline — single-pass O(n)

1. Lowercase all characters
2. Underscores → hyphens
3. Drop characters outside `[a-z0-9-./]`
4. Collapse consecutive separators (`--` `..` `//` and mixed runs) to the first one
5. Strip leading/trailing separators

Keys that are already valid (Docker Compose `com.docker.compose.*`, devcontainer `devcontainer.metadata`, etc.) pass through unchanged.

## Transparent round-trip — original keys preserved

Original keys are stored via a hidden `socktainer.label-original-keys` mapping label. All response paths strip this label and restore original keys before returning. Clients see exactly the keys they sent:

```bash
# Mixed-case keys — restored transparently
docker inspect --format '{{index .Config.Labels "org.testcontainers.sessionId"}}' <c>  # → session value
docker ps --filter label=org.testcontainers.sessionId=abc                               # → found

# Lowercase keys — pass through unchanged, also work as before
docker ps --filter label=com.docker.compose.service=web                                 # → found
docker network ls --filter label=mynet                                                   # → found
docker volume ls --filter label=myvolume=true                                            # → found
```

Resources created before this fix have no mapping → labels returned as stored (backward compatible).

## Coverage: containers, networks, volumes

`LabelNormalization.filterValue` / `filterContainsKey` are used consistently for all filter lookups (list, prune) across containers, networks, and volumes — works on both raw and restored labels transparently.

## Logging

- **INFO** — key changed (e.g. `sessionId` → `sessionid`)
- **WARNING** — key dropped (empty after normalization) or collision (two keys normalize to same string)

## Developer guide

```swift
// At create time (ContainerCreateRoute, NetworkCreateRoute, VolumeCreateRoute):
var labels = LabelNormalization.sanitize(body.Labels ?? [:])  // normalize keys
if let mapping = LabelNormalization.buildMapping(body.Labels ?? [:]) {
    labels[LabelNormalization.mappingKey] = mapping           // persist original key map
}

// At response time (Inspect/List routes):
let visibleLabels = LabelNormalization.restore(storedLabels)  // restore originals + strip mapping key

// At filter time (all label filter comparisons):
LabelNormalization.filterValue(in: labels, forKey: filterKey) == expectedValue
LabelNormalization.filterContainsKey(filterKey, in: labels)
// Works on both raw (normalized) and restored (original) label dicts.
```

## Tests

29 unit tests in `LabelNormalizationTests` covering normalization rules, round-trip, filter helpers, collision, and backward compatibility. 13 real-world tests across container/network/volume create, inspect, list filter, Go-template lookup, and mapping label invisibility.