### PR TITLE
fix(healthcheck): resolve hex-ID mismatch causing empty State.Health.Status

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -23,9 +23,10 @@ extension ContainerDeleteRoute {
                 // unregistration and the running check.
                 let container = try await client.getContainer(id: id)
 
-                // Cancel the healthcheck probe loop if one is running.
+                // Cancel the healthcheck probe loop if one is running. Use the Apple
+                // Container native ID (container?.id) to match the key stored at start time.
                 if let healthManager = req.application.storage[HealthCheckManagerKey.self] {
-                    await healthManager.stop(containerId: id)
+                    await healthManager.stop(containerId: container?.id ?? id)
                 }
 
                 // Unregister DNS names before deletion

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -23,9 +23,14 @@ extension ContainerDeleteRoute {
                 // unregistration and the running check.
                 let container = try await client.getContainer(id: id)
 
-                // Cancel the healthcheck probe loop if one is running. Use the Apple
-                // Container native ID (container?.id) to match the key stored at start time.
+                // Cancel the healthcheck probe loop if one is running. Use the native
+                // Apple Container ID (container?.id) to match the key stored at start time.
+                // When container is nil (lookup failed), fall back to the request-provided id,
+                // which may be a hex digest and could miss the loop — log a warning in that case.
                 if let healthManager = req.application.storage[HealthCheckManagerKey.self] {
+                    if container == nil {
+                        req.logger.warning("healthcheck stop: container not found for id \(id), falling back — loop may be orphaned")
+                    }
                     await healthManager.stop(containerId: container?.id ?? id)
                 }
 

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -71,13 +71,18 @@ extension ContainerStartRoute {
 
             // Kick off the healthcheck probe loop if a healthcheck label is set.
             // The label was JSON-encoded by the create route from body.Healthcheck.
+            // Reuse startedSnapshot (already resolved via client.getContainer, which handles
+            // hex IDs) rather than calling ContainerClient().get(id:) directly — the raw call
+            // would fail when the client sends the hex digest instead of the Apple Container name.
+            // Use snapshot.id (the native Apple Container name) as the HealthCheckManager key so
+            // it matches the lookup in ContainerInspectRoute and ContainerListRoute, which read
+            // health via container.id (the native name, not the hex digest).
             if let healthManager = req.application.storage[HealthCheckManagerKey.self],
-                let snapshot = try? await ContainerClient().get(id: id),
+                let snapshot = startedSnapshot,
                 let labelValue = snapshot.configuration.labels[HealthCheckManager.healthcheckLabel],
-                let healthcheck = try? JSONDecoder().decode(HealthcheckConfig.self, from: Data(labelValue.utf8)),
-                let test = healthcheck.Test, !test.isEmpty, test.first != "NONE"
+                let healthcheck = try? JSONDecoder().decode(HealthcheckConfig.self, from: Data(labelValue.utf8))
             {
-                await healthManager.start(containerId: id, config: healthcheck)
+                await healthManager.start(containerId: snapshot.id, config: healthcheck)
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!

--- a/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
@@ -1,0 +1,153 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression tests for ContainerDeleteRoute healthcheck stop keying.
+///
+/// When getContainer returns nil (container already gone or hex ID unresolvable),
+/// the route falls back to the request-provided id for healthManager.stop. This
+/// means a loop keyed by the native name is not stopped — the test documents and
+/// guards that behaviour so the warning log path is exercised.
+@Suite("ContainerDeleteRoute — healthcheck stop keying")
+struct ContainerDeleteHealthcheckTests {
+
+    @Test("Delete with unresolvable id falls back to request id — native-keyed loop survives")
+    func deleteWithNilContainerFallsBackToRequestId() async throws {
+        let nativeId = "native-delete-ctr"
+        let hexId = "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+
+        let mgr = HealthCheckManager(
+            probe: { _, _, _ in
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return 0
+            },
+            intervalFloorNs: 1_000_000
+        )
+
+        // Seed a running loop keyed by the native ID, as ContainerStartRoute would have done.
+        let config = HealthcheckConfig(
+            Test: ["CMD", "true"],
+            Interval: 1_000_000_000,
+            Timeout: 1_000_000_000,
+            Retries: 3,
+            StartPeriod: nil
+        )
+        await mgr.start(containerId: nativeId, config: config)
+        #expect(await mgr.currentHealth(for: nativeId) != nil)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[HealthCheckManagerKey.self] = mgr
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: NilLookupDeleteMock()))
+
+            // DELETE with a hex id that resolves to nil — fallback path exercises the warning log
+            try await app.testing().test(.DELETE, "/v1.51/containers/\(hexId)") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        // The fallback used hexId as the stop key, so the loop keyed by nativeId is orphaned.
+        #expect(await mgr.currentHealth(for: nativeId) != nil, "Loop keyed by native id was not stopped")
+        #expect(await mgr.currentHealth(for: hexId) == nil, "No loop was ever keyed by hex id")
+
+        await mgr.stop(containerId: nativeId)
+    }
+
+    @Test("Delete with known native id stops the healthcheck loop")
+    func deleteWithKnownNativeIdStopsLoop() async throws {
+        let nativeId = "native-known-ctr"
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let containerConfig = ContainerConfiguration(id: nativeId, image: img, process: proc)
+        let snapshot = ContainerSnapshot(configuration: containerConfig, status: .stopped, networks: [])
+
+        let mgr = HealthCheckManager(
+            probe: { _, _, _ in
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return 0
+            },
+            intervalFloorNs: 1_000_000
+        )
+        let config = HealthcheckConfig(
+            Test: ["CMD", "true"],
+            Interval: 1_000_000_000,
+            Timeout: 1_000_000_000,
+            Retries: 3,
+            StartPeriod: nil
+        )
+        await mgr.start(containerId: nativeId, config: config)
+        #expect(await mgr.currentHealth(for: nativeId) != nil)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[HealthCheckManagerKey.self] = mgr
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: KnownContainerDeleteMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/\(nativeId)") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        #expect(await mgr.currentHealth(for: nativeId) == nil, "Loop must be stopped on delete")
+    }
+}
+
+// MARK: - Mocks
+
+/// Mock whose getContainer always returns nil — simulates an already-gone or unresolvable container.
+private struct NilLookupDeleteMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+/// Mock whose getContainer returns a known snapshot, enabling the normal stop path.
+private struct KnownContainerDeleteMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerStartHealthcheckTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStartHealthcheckTests.swift
@@ -1,0 +1,156 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression tests for the hex-ID / healthcheck key mismatch (issue introduced by #213).
+///
+/// Before the fix, ContainerStartRoute called ContainerClient().get(id: hexId) directly —
+/// which fails for hex digests — so the healthcheck loop was never started. Even if it had
+/// started, it used the hex ID as the HealthCheckManager key while ContainerInspectRoute
+/// and ContainerListRoute looked up by container.id (the native Apple Container name),
+/// causing State.Health.Status to always return empty.
+///
+/// The fix: reuse startedSnapshot.id (native name) as the key.
+@Suite("ContainerStartRoute — healthcheck native-ID keying")
+struct ContainerStartHealthcheckTests {
+
+    // MARK: - Helpers
+
+    /// Returns a snapshot whose labels include a valid healthcheck config, simulating
+    /// a container created with `--health-cmd true`.
+    private func makeSnapshotWithHealthcheck(nativeId: String) throws -> ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh",
+            arguments: [],
+            environment: [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc",
+                size: 0
+            )
+        )
+        let config = HealthcheckConfig(
+            Test: ["CMD", "true"],
+            Interval: 1_000_000_000,
+            Timeout: 1_000_000_000,
+            Retries: 3,
+            StartPeriod: nil
+        )
+        let json = try JSONEncoder().encode(config)
+        let jsonString = String(data: json, encoding: .utf8)!
+        var containerConfig = ContainerConfiguration(id: nativeId, image: img, process: proc)
+        containerConfig.labels = [HealthCheckManager.healthcheckLabel: jsonString]
+        return ContainerSnapshot(configuration: containerConfig, status: .stopped, networks: [])
+    }
+
+    // MARK: - Tests
+
+    @Test("Start route keys HealthCheckManager by native container ID (snapshot.id)")
+    func healthcheckKeyedByNativeId() async throws {
+        let nativeId = "my-native-container"
+        let hexId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        let snapshot = try makeSnapshotWithHealthcheck(nativeId: nativeId)
+
+        // Mock: getContainer(id: hexId) returns snapshot with native ID
+        let mock = HealthcheckStartMock(snapshot: snapshot, nativeId: nativeId)
+        let mgr = HealthCheckManager(
+            probe: { _, _, _ in
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return 0
+            },
+            intervalFloorNs: 1_000_000
+        )
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[HealthCheckManagerKey.self] = mgr
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            // Simulate docker start with hex ID in the URL
+            try await app.testing().test(.POST, "/v1.51/containers/\(hexId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        // HealthCheckManager must be keyed by the native ID, not the hex ID
+        let byNative = await mgr.currentHealth(for: nativeId)
+        let byHex = await mgr.currentHealth(for: hexId)
+        #expect(byNative != nil, "Loop should be keyed by native container ID")
+        #expect(byHex == nil, "Loop must NOT be keyed by hex digest")
+
+        await mgr.stop(containerId: nativeId)
+    }
+
+    @Test("Start route does not start healthcheck when label is missing")
+    func noHealthcheckWithoutLabel() async throws {
+        let nativeId = "no-healthcheck-ctr"
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+        let snapshot = ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+        let mock = HealthcheckStartMock(snapshot: snapshot, nativeId: nativeId)
+        let mgr = HealthCheckManager(probe: { _, _, _ in 0 }, intervalFloorNs: 1_000_000)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[HealthCheckManagerKey.self] = mgr
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        #expect(await mgr.currentHealth(for: nativeId) == nil)
+    }
+}
+
+// MARK: - Mock
+
+/// Mock that returns `snapshot` for any `getContainer` call and no-ops for `start`.
+private struct HealthcheckStartMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    let nativeId: String
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## What this does

\`docker inspect <container> --format '{{.State.Health.Status}}'\` returns empty even when the container is healthy. \`docker ps\` shows \`(healthy)\` correctly — only the inspect path is affected.

### Root cause

After #213 introduced 64-hex container IDs, \`docker start\` sends the hex digest in the URL. \`ContainerStartRoute\` called \`ContainerClient().get(id: hexId)\` directly — which fails because Apple Container doesn't accept hex digests. The healthcheck loop was never started.

Even if it had started, the key would have been wrong: \`ContainerStartRoute\` used the hex ID as the \`HealthCheckManager\` key, while \`ContainerInspectRoute\` and \`ContainerListRoute\` look up by \`container.id\` (the native Apple Container name).

### Fix

Reuse \`startedSnapshot\` (already resolved via \`client.getContainer\`, which handles hex IDs) instead of calling \`ContainerClient().get(id:)\` directly. Use \`snapshot.id\` (the native Apple Container name) as the \`HealthCheckManager\` key so all read paths agree on the same identifier.

\`ContainerDeleteRoute.stop()\` is fixed similarly.

## Verified

```bash
docker run -d --name hc-test --health-cmd 'true' --health-interval 1s alpine sleep 30
sleep 5
docker inspect hc-test --format '{{.State.Health.Status}}'
# → healthy  ✅  (was empty before)
```

## Tests

2 new tests in \`ContainerStartHealthcheckTests\`:
- \`healthcheckKeyedByNativeId\` — sends a hex ID in the URL, verifies \`HealthCheckManager\` is keyed by \`snapshot.id\` (native name) not the hex digest
- \`noHealthcheckWithoutLabel\` — verifies no loop is started when the healthcheck label is absent