### PR TITLE
feat(events): include container labels in Docker event Actor.Attributes

### DIFF
--- a/Sources/socktainer/Events/EventBroadcaster.swift
+++ b/Sources/socktainer/Events/EventBroadcaster.swift
@@ -4,15 +4,9 @@ struct EventBroadcasterKey: StorageKey {
     typealias Value = EventBroadcaster
 }
 
-struct ActorAttributes: Codable {
-    let containerExitCode: String
-    let image: String
-    let name: String
-}
-
 struct DockerActor: Codable {
     let ID: String
-    let Attributes: ActorAttributes
+    let Attributes: [String: String]
 }
 
 struct DockerEvent: Codable {
@@ -28,25 +22,28 @@ struct DockerEvent: Codable {
 }
 
 extension DockerEvent {
-    static func simpleEvent(id: String, type: String, status: String) -> DockerEvent {
+    static func simpleEvent(
+        id: String,
+        type: String,
+        status: String,
+        image: String = "",
+        name: String = "",
+        labels: [String: String] = [:]
+    ) -> DockerEvent {
         let now = Date()
         let timeSeconds = Int(now.timeIntervalSince1970)
         let timeNano = UInt64(now.timeIntervalSince1970 * 1_000_000_000)
 
-        let actorAttributes = ActorAttributes(
-            containerExitCode: "",  // empty if unknown
-            image: "",
-            name: id
-        )
-        let actor = DockerActor(
-            ID: id,
-            Attributes: actorAttributes
-        )
+        var attributes = labels
+        attributes["image"] = image
+        attributes["name"] = name.isEmpty ? id : name
+
+        let actor = DockerActor(ID: id, Attributes: attributes)
 
         return DockerEvent(
             status: status,
             id: id,
-            from: "",
+            from: image,
             Type: type,
             Action: status,
             Actor: actor,

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -1,5 +1,6 @@
 import ContainerAPIClient
 import ContainerResource
+import ContainerizationError
 import Foundation
 import NIOCore
 import NIOHTTP1
@@ -105,6 +106,7 @@ extension ContainerAttachRoute {
                 // eliminates the race condition for fast-exiting containers (#220).
                 return try await attachStoppedOutputOnly(
                     req: req,
+                    hexId: id,
                     container: container,
                     query: query,
                     isTTY: isTTY,
@@ -237,6 +239,7 @@ extension ContainerAttachRoute {
     // Uses pipes instead of log-file polling to eliminate the race for fast-exiting containers.
     private static func attachStoppedOutputOnly(
         req: Request,
+        hexId: String,
         container: ContainerSnapshot,
         query: ContainerAttachQuery,
         isTTY: Bool,
@@ -308,6 +311,36 @@ extension ContainerAttachRoute {
                         try? stdinPipe.fileHandleForReading.close()
                         try? await Task.sleep(nanoseconds: Self.outputFlushGraceNs)
                         await ContainerExitCodeStore.shared.set(id: container.id, code: code)
+                        await ContainerExitCodeStore.shared.set(id: hexId, code: code)
+
+                        // docker run --rm: Apple Container auto-removes the container so
+                        // DELETE never arrives and ContainerDeleteRoute never fires.
+                        // Detect auto-removal and emit the "remove" event here instead.
+                        try? await Task.sleep(nanoseconds: 100_000_000)
+                        let autoRemoved: Bool
+                        do {
+                            autoRemoved = try await ContainerClient().get(id: container.id) == nil
+                        } catch let error as ContainerizationError where error.code == .notFound {
+                            autoRemoved = true
+                        } catch {
+                            autoRemoved = false
+                        }
+                        if autoRemoved {
+                            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                                let cached = await ContainerInfoCache.shared.get(id: hexId)
+                                await broadcaster.broadcast(
+                                    DockerEvent.simpleEvent(
+                                        id: hexId,
+                                        type: "container",
+                                        status: "remove",
+                                        image: cached?.image ?? container.configuration.image.reference,
+                                        name: cached?.nativeId ?? container.id,
+                                        labels: cached?.labels
+                                            ?? LabelNormalization.restore(container.configuration.labels)
+                                    ))
+                                await ContainerInfoCache.shared.remove(id: hexId)
+                            }
+                        }
                     }
 
                     // Stdout reader

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -17,16 +17,28 @@ extension ContainerDeleteRoute {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
+            let snapshot = try? await client.getContainer(id: id)
+            let cached = await ContainerInfoCache.shared.get(id: id)
+
+            let eventImage = snapshot?.configuration.image.reference ?? cached?.image ?? ""
+            let eventName = snapshot?.id ?? cached?.nativeId ?? id
+            let eventLabels =
+                snapshot.map { LabelNormalization.restore($0.configuration.labels) }
+                ?? cached?.labels ?? [:]
+
+            func broadcastRemove() async {
+                let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+                await broadcaster.broadcast(
+                    DockerEvent.simpleEvent(
+                        id: id, type: "container", status: "remove",
+                        image: eventImage, name: eventName, labels: eventLabels
+                    ))
+                await ContainerInfoCache.shared.remove(id: id)
+            }
+
             do {
-                // Resolve the reference once — it may be a hex ID or a
-                // truncated prefix — and reuse the snapshot for DNS
-                // unregistration and the running check.
                 let container = try await client.getContainer(id: id)
 
-                // Cancel the healthcheck probe loop if one is running. Use the native
-                // Apple Container ID (container?.id) to match the key stored at start time.
-                // When container is nil (lookup failed), fall back to the request-provided id,
-                // which may be a hex digest and could miss the loop — log a warning in that case.
                 if let healthManager = req.application.storage[HealthCheckManagerKey.self] {
                     if container == nil {
                         req.logger.warning("healthcheck stop: container not found for id \(id), falling back — loop may be orphaned")
@@ -34,7 +46,6 @@ extension ContainerDeleteRoute {
                     await healthManager.stop(containerId: container?.id ?? id)
                 }
 
-                // Unregister DNS names before deletion
                 if let container,
                     let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
                     let namesLabel = container.configuration.labels["socktainer.dns.names"]
@@ -44,22 +55,21 @@ extension ContainerDeleteRoute {
                     }
                 }
 
-                // if running, stop it first
                 if let container, container.status == .running {
                     try await client.stop(id: id, signal: nil, timeout: nil)
                 }
                 try await client.delete(id: id)
             } catch ClientContainerError.notFound {
+                if snapshot != nil || cached != nil {
+                    await broadcastRemove()
+                }
                 throw Abort(.notFound, reason: "No such container: \(id)")
             } catch ClientContainerError.ambiguousId(let reference, let matches) {
                 let matchList = matches.joined(separator: ", ")
                 throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
             }
 
-            let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-            let event = DockerEvent.simpleEvent(id: id, type: "container", status: "remove")
-            await broadcaster.broadcast(event)
-
+            await broadcastRemove()
             return .ok
         }
     }

--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -23,6 +23,8 @@ extension ContainerRestartRoute {
             let signal = query.signal
             let timeout = query.t
 
+            let snapshot = try? await client.getContainer(id: id)
+
             do {
                 try await client.restart(id: id, signal: signal, timeout: timeout)
             } catch ClientContainerError.notFound {
@@ -36,10 +38,15 @@ extension ContainerRestartRoute {
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-
-            // Broadcast restart event (or both stop and start events)
-            let restartEvent = DockerEvent.simpleEvent(id: id, type: "container", status: "restart")
-            await broadcaster.broadcast(restartEvent)
+            let event = DockerEvent.simpleEvent(
+                id: id,
+                type: "container",
+                status: "restart",
+                image: snapshot?.configuration.image.reference ?? "",
+                name: snapshot?.id ?? id,
+                labels: LabelNormalization.restore(snapshot?.configuration.labels ?? [:])
+            )
+            await broadcaster.broadcast(event)
 
             return .noContent
         }

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -85,13 +85,26 @@ extension ContainerStartRoute {
                 await healthManager.start(containerId: snapshot.id, config: healthcheck)
             }
 
+            if let snap = startedSnapshot {
+                await ContainerInfoCache.shared.set(
+                    hexId: id,
+                    nativeId: snap.id,
+                    image: snap.configuration.image.reference,
+                    labels: LabelNormalization.restore(snap.configuration.labels)
+                )
+            }
+
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-
-            let event = DockerEvent.simpleEvent(id: id, type: "container", status: "start")
-
+            let event = DockerEvent.simpleEvent(
+                id: id,
+                type: "container",
+                status: "start",
+                image: startedSnapshot?.configuration.image.reference ?? "",
+                name: startedSnapshot?.id ?? id,
+                labels: LabelNormalization.restore(startedSnapshot?.configuration.labels ?? [:])
+            )
             await broadcaster.broadcast(event)
 
-            // should return 204 HTTP code
             return .noContent
         }
     }

--- a/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
@@ -23,6 +23,8 @@ extension ContainerStopRoute {
             let signal = query.signal
             let timeout = query.t
 
+            let snapshot = try? await client.getContainer(id: id)
+
             do {
                 try await client.stop(id: id, signal: signal, timeout: timeout)
             } catch ClientContainerError.notFound {
@@ -33,9 +35,14 @@ extension ContainerStopRoute {
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-
-            let event = DockerEvent.simpleEvent(id: id, type: "container", status: "stop")
-
+            let event = DockerEvent.simpleEvent(
+                id: id,
+                type: "container",
+                status: "stop",
+                image: snapshot?.configuration.image.reference ?? "",
+                name: snapshot?.id ?? id,
+                labels: LabelNormalization.restore(snapshot?.configuration.labels ?? [:])
+            )
             await broadcaster.broadcast(event)
 
             return .noContent

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -48,71 +48,78 @@ struct ContainerWaitRoute: RouteCollection {
             var headers = HTTPHeaders()
             headers.add(name: "Content-Type", value: "application/json")
 
-            // `docker run` reads the /wait response HEAD before it sends /start,
-            // then reads the body once the container exits. If we withhold the
-            // head until the body is ready (the default when returning a Content
-            // value), /start is never sent and the run deadlocks. So flush the
-            // head immediately with an empty write, then stream the exit-code
-            // JSON once client.wait() resolves (it blocks until the init process
-            // actually exits and its real code is recorded).
-            let body = Response.Body { writer in
-                Task.detached {
-                    defer { _ = writer.write(.end) }
+            // Flush the response head before the body so docker run can issue /start
+            // without waiting for the container to exit first.
+            let body = Response.Body(asyncStream: { writer in
+                _ = try? await writer.write(.buffer(sharedAllocator.buffer(capacity: 0)))
 
-                    _ = writer.write(.buffer(sharedAllocator.buffer(capacity: 0)))
-
-                    let result: RESTContainerWait
-                    do {
-                        if condition == .healthy {
-                            // Poll HealthCheckManager until the container becomes healthy
-                            // or stops running (in which case it can never reach healthy).
-                            var statusCode: Int64 = 0
-                            if let manager = req.application.storage[HealthCheckManagerKey.self] {
-                                while true {
-                                    let health = await manager.currentHealth(for: containerId)
-                                    if health?.Status == "healthy" { break }
-                                    // health==nil means no probe loop was registered for this container.
-                                    // HealthCheckManager.start() is called by ContainerStartRoute after
-                                    // container.start() returns, so there is a brief window where the
-                                    // container is running but health is still nil. We break here because
-                                    // by the next poll (500ms later) start() would have run; if it's still
-                                    // nil then, it means no HEALTHCHECK was configured and the container
-                                    // can never become healthy.
-                                    if health == nil {
-                                        statusCode = 1
-                                        break
-                                    }
-                                    // Container stopped — return its real exit code
-                                    guard let c = try? await client.getContainer(id: containerId),
-                                        c.status == .running
-                                    else {
-                                        let code = await ContainerExitCodeStore.shared.get(id: containerId) ?? 1
-                                        statusCode = Int64(code)
-                                        break
-                                    }
-                                    try await Task.sleep(nanoseconds: ContainerWaitCondition.healthyPollIntervalNs)
+                let result: RESTContainerWait
+                do {
+                    if condition == .healthy {
+                        var statusCode: Int64 = 0
+                        if let manager = req.application.storage[HealthCheckManagerKey.self] {
+                            while true {
+                                let health = await manager.currentHealth(for: containerId)
+                                if health?.Status == "healthy" { break }
+                                if health == nil {
+                                    statusCode = 1
+                                    break
                                 }
-                            } else {
-                                // HealthCheckManager unavailable — healthchecks not supported
-                                statusCode = 1
+                                guard let container = try? await client.getContainer(id: containerId),
+                                    container.status == .running
+                                else {
+                                    let code = await ContainerExitCodeStore.shared.get(id: containerId) ?? 1
+                                    statusCode = Int64(code)
+                                    break
+                                }
+                                try await Task.sleep(nanoseconds: ContainerWaitCondition.healthyPollIntervalNs)
                             }
-                            result = RESTContainerWait(statusCode: statusCode)
                         } else {
-                            result = try await client.wait(id: containerId, condition: condition)
+                            statusCode = 1
                         }
-                    } catch {
-                        // Emit a 0-status body so the client unblocks rather than
-                        // hanging on a half-open stream.
-                        result = RESTContainerWait(statusCode: 0)
+                        result = RESTContainerWait(statusCode: statusCode)
+                    } else if condition == .removed {
+                        result = try await client.wait(id: containerId, condition: condition)
+                    } else {
+                        // Race native wait against ContainerExitCodeStore polling.
+                        // Pipe-bootstrapped containers (docker run) may not surface
+                        // their exit through client.wait(), so we poll the store in
+                        // parallel and take whichever resolves first.
+                        result = await withTaskGroup(of: RESTContainerWait?.self) { group in
+                            group.addTask {
+                                try? await client.wait(id: containerId, condition: condition)
+                            }
+                            group.addTask {
+                                let pollIntervalNs: UInt64 = 100_000_000
+                                let maxPolls = Int(30_000_000_000 / pollIntervalNs)
+                                for _ in 0..<maxPolls {
+                                    if let code = await ContainerExitCodeStore.shared.get(id: containerId) {
+                                        return RESTContainerWait(statusCode: Int64(code))
+                                    }
+                                    try? await Task.sleep(nanoseconds: pollIntervalNs)
+                                }
+                                return nil
+                            }
+                            for await waitResult in group {
+                                if let waitResult {
+                                    group.cancelAll()
+                                    return waitResult
+                                }
+                            }
+                            return RESTContainerWait(statusCode: 0)
+                        }
                     }
-
-                    if let data = try? JSONEncoder().encode(result) {
-                        var buf = sharedAllocator.buffer(capacity: data.count)
-                        buf.writeBytes(data)
-                        _ = writer.write(.buffer(buf))
-                    }
+                } catch {
+                    result = RESTContainerWait(statusCode: 0)
                 }
-            }
+
+                if let data = try? JSONEncoder().encode(result) {
+                    var buf = sharedAllocator.buffer(capacity: data.count)
+                    buf.writeBytes(data)
+                    _ = try? await writer.write(.buffer(buf))
+                }
+                _ = try? await writer.write(.end)
+            })
 
             return Response(status: .ok, headers: headers, body: body)
         }

--- a/Sources/socktainer/Routes/Server/EventsRoute.swift
+++ b/Sources/socktainer/Routes/Server/EventsRoute.swift
@@ -21,27 +21,25 @@ extension EventsRoute {
             response.headers.add(name: .contentType, value: "application/json")
 
             response.body = .init(asyncStream: { writer in
-                Task {
-                    for await event in stream {
-                        if let json = try? JSONEncoder().encode(event) {
-                            var buffer = req.application.allocator.buffer(capacity: json.count + 1)
-                            buffer.writeBytes(json)
-                            buffer.writeString("\n")
-                            do {
-                                try await writer.write(.buffer(buffer))
-                            } catch is IOError {
-                                req.logger.debug("Client disconnected (broken pipe)")
-                                break
-                            } catch let error as ChannelError where error == .ioOnClosedChannel {
-                                req.logger.debug("Client disconnected (closed channel)")
-                                break
-                            } catch {
-                                // NOTE: Consider improving logging
-                                req.logger.warning("\(event) raised '\(error)'")
-                            }
+                for await event in stream {
+                    if let json = try? JSONEncoder().encode(event) {
+                        var buffer = req.application.allocator.buffer(capacity: json.count + 1)
+                        buffer.writeBytes(json)
+                        buffer.writeString("\n")
+                        do {
+                            try await writer.write(.buffer(buffer))
+                        } catch is IOError {
+                            req.logger.debug("Client disconnected (broken pipe)")
+                            break
+                        } catch let error as ChannelError where error == .ioOnClosedChannel {
+                            req.logger.debug("Client disconnected (closed channel)")
+                            break
+                        } catch {
+                            req.logger.warning("\(event) raised '\(error)'")
                         }
                     }
                 }
+                _ = try? await writer.write(.end)
             })
 
             return response

--- a/Sources/socktainer/Utilities/ContainerInfoCache.swift
+++ b/Sources/socktainer/Utilities/ContainerInfoCache.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+actor ContainerInfoCache {
+    static let shared = ContainerInfoCache()
+
+    struct Info {
+        let hexId: String
+        let nativeId: String
+        let image: String
+        let labels: [String: String]
+    }
+
+    private var store: [String: Info] = [:]
+
+    func set(hexId: String, nativeId: String, image: String, labels: [String: String]) {
+        let info = Info(hexId: hexId, nativeId: nativeId, image: image, labels: labels)
+        store[hexId] = info
+        store[nativeId] = info
+    }
+
+    func get(id: String) -> Info? {
+        store[id]
+    }
+
+    func remove(id: String) {
+        if let info = store[id] {
+            store.removeValue(forKey: info.hexId)
+            store.removeValue(forKey: info.nativeId)
+        }
+    }
+}

--- a/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
+++ b/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
@@ -1,0 +1,216 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+// MARK: - Stop
+
+@Suite("ContainerStopRoute — event label forwarding")
+struct ContainerStopEventLabelTests {
+
+    @Test("Stop event Actor.Attributes carries container labels, image, and name")
+    func stopEventCarriesLabels() async throws {
+        let id = "stop-ctr-hex"
+        let nativeId = "stop-native"
+        let snapshot = makeSnapshot(nativeId: nativeId, image: "redis:7", labels: ["svc": "cache"])
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "stop" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerStopRoute(client: EventMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(id)/stop") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        captureTask.cancel()
+        let event = await captureTask.value
+        #expect(event?.Actor.Attributes["svc"] == "cache")
+        #expect(event?.Actor.Attributes["image"] == "redis:7")
+        #expect(event?.Actor.Attributes["name"] == nativeId)
+    }
+}
+
+// MARK: - Restart
+
+@Suite("ContainerRestartRoute — event label forwarding")
+struct ContainerRestartEventLabelTests {
+
+    @Test("Restart event Actor.Attributes carries container labels, image, and name")
+    func restartEventCarriesLabels() async throws {
+        let id = "restart-ctr-hex"
+        let nativeId = "restart-native"
+        let snapshot = makeSnapshot(nativeId: nativeId, image: "nginx:latest", labels: ["role": "proxy"])
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "restart" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerRestartRoute(client: EventMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(id)/restart") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        captureTask.cancel()
+        let event = await captureTask.value
+        #expect(event?.Actor.Attributes["role"] == "proxy")
+        #expect(event?.Actor.Attributes["image"] == "nginx:latest")
+        #expect(event?.Actor.Attributes["name"] == nativeId)
+    }
+}
+
+// MARK: - Delete (success path)
+
+@Suite("ContainerDeleteRoute — event label forwarding")
+struct ContainerDeleteEventLabelTests {
+
+    @Test("Remove event carries labels from snapshot when container exists")
+    func removeEventFromSnapshot() async throws {
+        let id = "del-ctr-hex"
+        let nativeId = "del-native"
+        let snapshot = makeSnapshot(nativeId: nativeId, image: "postgres:17", labels: ["db": "main"])
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "remove" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerDeleteRoute(client: EventMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/\(id)") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        captureTask.cancel()
+        let event = await captureTask.value
+        #expect(event?.Actor.Attributes["db"] == "main")
+        #expect(event?.Actor.Attributes["image"] == "postgres:17")
+        #expect(event?.Actor.Attributes["name"] == nativeId)
+    }
+
+    @Test("Remove event uses ContainerInfoCache when container is already gone (docker run --rm)")
+    func removeEventFromCacheWhenNotFound() async throws {
+        let hexId = "rm-ctr-hex"
+        let nativeId = "rm-native"
+
+        // Seed the cache as if ContainerStartRoute had run earlier.
+        await ContainerInfoCache.shared.set(
+            hexId: hexId, nativeId: nativeId,
+            image: "alpine:latest", labels: ["app": "ephemeral"]
+        )
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "remove" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerDeleteRoute(client: NotFoundMock()))
+
+            // Returns 404 because the container is already gone, but the event must fire.
+            try await app.testing().test(.DELETE, "/v1.51/containers/\(hexId)") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+
+        captureTask.cancel()
+        let event = await captureTask.value
+        #expect(event?.Actor.Attributes["app"] == "ephemeral")
+        #expect(event?.Actor.Attributes["image"] == "alpine:latest")
+        #expect(event?.Actor.Attributes["name"] == nativeId)
+        // Cache must be cleared after the event.
+        #expect(await ContainerInfoCache.shared.get(id: hexId) == nil)
+    }
+}
+
+// MARK: - Shared helpers
+
+private func makeSnapshot(nativeId: String, image: String, labels: [String: String]) -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: image,
+        descriptor: Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: "sha256:abc", size: 0
+        )
+    )
+    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+    config.labels = labels
+    return ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+}
+
+/// Mock returning a fixed snapshot and succeeding on all mutations.
+private struct EventMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+/// Mock whose getContainer and delete both throw notFound — simulates an auto-removed container.
+private struct NotFoundMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws { throw ClientContainerError.notFound(id: id) }
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Events/ContainerInfoCacheTests.swift
+++ b/Tests/socktainerTests/Events/ContainerInfoCacheTests.swift
@@ -1,0 +1,59 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("ContainerInfoCache")
+struct ContainerInfoCacheTests {
+
+    @Test("get returns nil for unknown id")
+    func getUnknownId() async {
+        let cache = ContainerInfoCache()
+        let result = await cache.get(id: "unknown")
+        #expect(result == nil)
+    }
+
+    @Test("set stores info retrievable by both hex and native id")
+    func setStoredByBothIds() async {
+        let cache = ContainerInfoCache()
+        await cache.set(hexId: "hex123", nativeId: "native-name", image: "alpine", labels: ["app": "test"])
+
+        let byHex = await cache.get(id: "hex123")
+        let byNative = await cache.get(id: "native-name")
+
+        #expect(byHex?.image == "alpine")
+        #expect(byHex?.labels["app"] == "test")
+        #expect(byNative?.image == "alpine")
+        #expect(byNative?.nativeId == "native-name")
+    }
+
+    @Test("remove clears both hex and native entries")
+    func removeCleansBothKeys() async {
+        let cache = ContainerInfoCache()
+        await cache.set(hexId: "hex123", nativeId: "native-name", image: "alpine", labels: [:])
+
+        await cache.remove(id: "hex123")
+
+        #expect(await cache.get(id: "hex123") == nil)
+        #expect(await cache.get(id: "native-name") == nil)
+    }
+
+    @Test("remove by native id also clears hex entry")
+    func removeByNativeIdClearsHex() async {
+        let cache = ContainerInfoCache()
+        await cache.set(hexId: "hex123", nativeId: "native-name", image: "alpine", labels: [:])
+
+        await cache.remove(id: "native-name")
+
+        #expect(await cache.get(id: "hex123") == nil)
+        #expect(await cache.get(id: "native-name") == nil)
+    }
+
+    @Test("remove unknown id is a no-op")
+    func removeUnknownIdIsNoOp() async {
+        let cache = ContainerInfoCache()
+        await cache.set(hexId: "hex123", nativeId: "native-name", image: "alpine", labels: [:])
+        await cache.remove(id: "other-id")
+
+        #expect(await cache.get(id: "hex123") != nil)
+    }
+}

--- a/Tests/socktainerTests/Events/ContainerStartEventLabelTests.swift
+++ b/Tests/socktainerTests/Events/ContainerStartEventLabelTests.swift
@@ -1,0 +1,90 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+@Suite("ContainerStartRoute — event label forwarding")
+struct ContainerStartEventLabelTests {
+
+    @Test("Start event Actor.Attributes carries container labels, image, and name")
+    func startEventCarriesLabels() async throws {
+        let hexId = "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222"
+        let nativeId = "my-labeled-container"
+        let snapshot = makeSnapshot(nativeId: nativeId, labels: ["app": "myapp", "env": "prod"])
+        let broadcaster = EventBroadcaster()
+
+        // Subscribe before the route fires so the buffered event is not missed.
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "start" {
+                return event
+            }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerStartRoute(client: StartMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(hexId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        // The route awaited broadcaster.broadcast() before returning, so the event is
+        // already in the stream buffer. captureTask picks it up on its next iteration.
+        captureTask.cancel()  // unblock the for-await after we take the value
+        let event = await captureTask.value
+
+        let attrs = event?.Actor.Attributes
+        #expect(attrs?["app"] == "myapp")
+        #expect(attrs?["env"] == "prod")
+        #expect(attrs?["image"] == "alpine:latest")
+        #expect(attrs?["name"] == nativeId)
+    }
+}
+
+// MARK: - Helpers
+
+private func makeSnapshot(nativeId: String, labels: [String: String]) -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: "sha256:abc", size: 0
+        )
+    )
+    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+    config.labels = labels
+    return ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+}
+
+private struct StartMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Events/DockerEventTests.swift
+++ b/Tests/socktainerTests/Events/DockerEventTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("DockerEvent — label forwarding in Actor.Attributes")
+struct DockerEventTests {
+
+    @Test("simpleEvent includes user labels in Attributes")
+    func simpleEventIncludesLabels() {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-1",
+            type: "container",
+            status: "start",
+            image: "alpine:latest",
+            name: "my-container",
+            labels: ["app": "myapp", "version": "2.0"]
+        )
+
+        #expect(event.Actor.Attributes["app"] == "myapp")
+        #expect(event.Actor.Attributes["version"] == "2.0")
+    }
+
+    @Test("simpleEvent merges image and name into Attributes")
+    func simpleEventMergesImageAndName() {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-1",
+            type: "container",
+            status: "start",
+            image: "alpine:latest",
+            name: "my-container",
+            labels: [:]
+        )
+
+        #expect(event.Actor.Attributes["image"] == "alpine:latest")
+        #expect(event.Actor.Attributes["name"] == "my-container")
+        #expect(event.from == "alpine:latest")
+    }
+
+    @Test("simpleEvent falls back to id for name when name is empty")
+    func simpleEventFallsBackToId() {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-abc",
+            type: "container",
+            status: "start"
+        )
+
+        #expect(event.Actor.Attributes["name"] == "ctr-abc")
+        #expect(event.Actor.Attributes["image"] == "")
+    }
+
+    @Test("simpleEvent with no labels produces only image and name in Attributes")
+    func simpleEventNoLabelsHasOnlyStandardKeys() {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-1",
+            type: "container",
+            status: "stop",
+            image: "postgres:17",
+            name: "db"
+        )
+
+        #expect(event.Actor.Attributes.keys.sorted() == ["image", "name"])
+    }
+
+    @Test("simpleEvent Attributes contain labels plus image and name")
+    func simpleEventAttributeKeySet() {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-1",
+            type: "container",
+            status: "start",
+            image: "alpine",
+            name: "test",
+            labels: ["app": "x", "env": "prod"]
+        )
+
+        #expect(event.Actor.Attributes.keys.sorted() == ["app", "env", "image", "name"])
+    }
+
+    @Test("Attributes encodes as flat JSON dictionary")
+    func attributesEncodesAsFlat() throws {
+        let event = DockerEvent.simpleEvent(
+            id: "ctr-1",
+            type: "container",
+            status: "start",
+            image: "alpine",
+            name: "test",
+            labels: ["app": "myapp"]
+        )
+
+        let json = try JSONEncoder().encode(event)
+        let obj = try JSONDecoder().decode([String: AnyDecodable].self, from: json)
+        let actor = obj["Actor"]?.value as? [String: Any]
+        let attributes = actor?["Attributes"] as? [String: String]
+
+        #expect(attributes?["app"] == "myapp")
+        #expect(attributes?["image"] == "alpine")
+        #expect(attributes?["name"] == "test")
+    }
+}
+
+// Minimal helper for decoding arbitrary JSON values in tests.
+private struct AnyDecodable: Decodable {
+    let value: Any
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self) {
+            value = string
+        } else if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let dict = try? container.decode([String: AnyDecodable].self) {
+            value = dict.mapValues { $0.value }
+        } else if let array = try? container.decode([AnyDecodable].self) {
+            value = array.map { $0.value }
+        } else {
+            value = ()
+        }
+    }
+}


### PR DESCRIPTION
## What

Container labels now appear in `docker events` Actor.Attributes alongside the standard `image` and `name` fields, matching the output of Docker Desktop, Colima, and OrbStack.

**Before:**
```json
{"Actor":{"ID":"abc123","Attributes":{"image":"","name":"abc123"}}}
```

**After:**
```json
{"Actor":{"ID":"abc123","Attributes":{"app":"myapp","image":"alpine","name":"my-container","version":"2.0"}}}
```

Events covered: **start**, **stop**, **restart**, **remove** (including `docker run --rm`).

## Why it matters

Docker Compose watches `docker events` and filters by `com.docker.compose.*` labels to correlate lifecycle events to services. Without labels, Compose cannot track which containers belong to which service. Monitoring tools (Portainer, Watchtower, custom scripts) that route events by label are also unblocked.

## How

`Actor.Attributes` was a fixed struct with three hardcoded fields. It is now a flat `[String: String]` dictionary built from the container snapshot at event time, with `image` and `name` merged in alongside the restored user labels.

For `docker run --rm`, Apple Container auto-removes the container before DELETE arrives, so `ContainerDeleteRoute` is never called. A `ContainerInfoCache` actor caches hex-ID → labels at start time. The remove event is emitted from `attachStoppedOutputOnly` by detecting that the container has disappeared from Apple Container's registry after exit.

## Also fixes

**EventsRoute crash on client disconnect** — The `asyncStream` body used `Task.detached`, letting the closure return while the task still held un-awaited writes. Vapor asserted `Response body stream writer deinitialized before .end or .error was sent` on client disconnect. Fixed by using `for await` directly in the async body.

**ContainerWaitRoute never delivering the response body for pipe-bootstrapped containers** — Same pattern caused Docker CLI to never receive the `/wait` body for containers started via `attachStoppedOutputOnly`, so `--rm` containers never triggered DELETE. Fixed with `asyncStream` and a race between Apple Container's native wait and a lightweight poll of `ContainerExitCodeStore` (in-memory actor reads at 100 ms intervals, 30 s max, no Apple Container API calls).

## Tests

- `DockerEventTests` — 6 unit tests: label forwarding, key merging, name fallback, JSON encoding shape
- `ContainerInfoCacheTests` — 5 unit tests: set/get/remove by both hex and native ID (caught a real bug where remove-by-native-id did not clear the hex entry)
- `ContainerStartEventLabelTests` — route-level: verifies the broadcast start event contains the container's labels
- `ContainerEventLabelTests` — route-level: stop, restart, delete (snapshot exists), delete (container already gone, labels from cache)

Verified against Colima: Attributes key set matches exactly on all event types.