### PR TITLE
fix(events): guard EventBroadcaster lookups and use pre-start snapshot as fallback

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -27,13 +27,13 @@ extension ContainerDeleteRoute {
                 ?? cached?.labels ?? [:]
 
             func broadcastRemove() async {
-                let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+                await ContainerInfoCache.shared.remove(id: id)
+                guard let broadcaster = req.application.storage[EventBroadcasterKey.self] else { return }
                 await broadcaster.broadcast(
                     DockerEvent.simpleEvent(
                         id: id, type: "container", status: "remove",
                         image: eventImage, name: eventName, labels: eventLabels
                     ))
-                await ContainerInfoCache.shared.remove(id: id)
             }
 
             do {

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerResource
 import Vapor
 
 struct ContainerStartRoute: RouteCollection {
@@ -24,8 +25,18 @@ extension ContainerStartRoute {
             let query = try req.query.decode(ContainerStartQuery.self)
             let detachKeys = query.detachKeys
 
+            let preStartSnapshot: ContainerSnapshot?
             do {
-                guard let container = try await client.getContainer(id: id) else {
+                preStartSnapshot = try await client.getContainer(id: id)
+            } catch ClientContainerError.notFound {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                let matchList = matches.joined(separator: ", ")
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
+            }
+
+            do {
+                guard let container = preStartSnapshot else {
                     throw Abort(.notFound, reason: "No such container: \(id)")
                 }
 
@@ -85,7 +96,8 @@ extension ContainerStartRoute {
                 await healthManager.start(containerId: snapshot.id, config: healthcheck)
             }
 
-            if let snap = startedSnapshot {
+            let metadataSnapshot = startedSnapshot ?? preStartSnapshot
+            if let snap = metadataSnapshot {
                 await ContainerInfoCache.shared.set(
                     hexId: id,
                     nativeId: snap.id,
@@ -94,14 +106,16 @@ extension ContainerStartRoute {
                 )
             }
 
-            let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+            guard let broadcaster = req.application.storage[EventBroadcasterKey.self] else {
+                return .noContent
+            }
             let event = DockerEvent.simpleEvent(
                 id: id,
                 type: "container",
                 status: "start",
-                image: startedSnapshot?.configuration.image.reference ?? "",
-                name: startedSnapshot?.id ?? id,
-                labels: LabelNormalization.restore(startedSnapshot?.configuration.labels ?? [:])
+                image: metadataSnapshot?.configuration.image.reference ?? "",
+                name: metadataSnapshot?.id ?? id,
+                labels: LabelNormalization.restore(metadataSnapshot?.configuration.labels ?? [:])
             )
             await broadcaster.broadcast(event)
 

--- a/Sources/socktainer/Routes/Server/EventsRoute.swift
+++ b/Sources/socktainer/Routes/Server/EventsRoute.swift
@@ -14,7 +14,9 @@ extension EventsRoute {
     static func handler(client: ClientHealthCheckProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
 
-            let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+            guard let broadcaster = req.application.storage[EventBroadcasterKey.self] else {
+                throw Abort(.internalServerError, reason: "EventBroadcaster not configured")
+            }
             let stream = await broadcaster.stream()
 
             let response = Response(status: .ok)


### PR DESCRIPTION
## What

Three follow-up fixes from CodeRabbit review of #225.

## Changes

**EventsRoute** — replace force-unwrap of `EventBroadcasterKey` with a `guard` that returns 500 on misconfiguration instead of crashing.

**ContainerDeleteRoute** — same in `broadcastRemove()` — silently skips the broadcast rather than crashing when the broadcaster is absent.

**ContainerStartRoute** — fetch the container snapshot *before* the start attempt so it is available as a metadata fallback even when the post-start lookup returns nil. This fixes a race for fast-exiting auto-removed containers (`docker run --rm`): the container may be gone by the time the post-start fetch runs, leaving `startedSnapshot` nil and the event/cache with empty metadata. Fetching pre-start guarantees the snapshot is available.

## Testing

All 207 existing tests pass. No new tests needed — the pre-start snapshot is already exercised by `ContainerStartEventLabelTests` and `removeEventFromCacheWhenNotFound`.