### PR TITLE
fix(attach): guard channel.close with isActive to prevent EBADF crash

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -751,8 +751,11 @@ extension ContainerAttachRoute {
                     try? stderrPipe?.fileHandleForWriting.close()
                     try? stdinPipe.fileHandleForWriting.close()
 
-                    // Close the channel gracefully
+                    // Close the channel gracefully only if still open.
+                    // Calling close() on an already-closed channel causes
+                    // EBADF which triggers a NIO precondition failure.
                     _ = channel.eventLoop.submit {
+                        guard channel.isActive else { return }
                         channel.close(promise: nil)
                     }
                 }


### PR DESCRIPTION
## What

Guards `channel.close(promise: nil)` with `channel.isActive` in `createContainerForAttachment`.

## Why

When the client disconnects before the process monitor task runs, the NIO layer already closes the channel internally. Calling `close()` again produces **EBADF** (errno 9 — bad file descriptor), which hits a NIO `precondition` and crashes the entire Socktainer daemon:

```
NIOPosix/System.swift:277: Precondition failed:
  unacceptable errno 9 Bad file descriptor in close(descriptor:)
```

This surfaces when Docker Compose starts containers with nginx/services that use the TCP-upgrade attach path — the channel may be closed by the peer before the process monitor's cleanup task fires.

## Fix

```swift
_ = channel.eventLoop.submit {
    guard channel.isActive else { return }  // ← added
    channel.close(promise: nil)
}
```

`channel.isActive` is set to `false` by NIO when the channel is closed, so this check is reliable.