### PR TITLE
feat(compose): enable inter-service DNS via dual service + service.project registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,37 @@ We welcome contributions!
 - Docker API compatibility is **partial**, focused on commonly used endpoints. See `Sources/socktainer/Routes/` for implemented routes
 - Private registry auth currently depends on Apple `container` behavior. If login succeeds but private pulls/builds still fail, a manual workaround may be required. See [apple/container#816 comment 3534438608](https://github.com/apple/container/issues/816#issuecomment-3534438608) and [comment 3503618765](https://github.com/apple/container/issues/816#issuecomment-3503618765).
 
+### Docker Compose — inter-service DNS
+
+Socktainer registers service names in its DNS server so Compose services can
+reach each other by name. Two aliases are created per service:
+
+| Alias | Example | Description |
+|---|---|---|
+| `service` | `db` | Short form — works within a single project |
+| `service.project` | `db.myapp` | Project-qualified — unique across concurrent projects |
+
+Set the project name explicitly via `name:` at the top of your Compose file
+(otherwise Docker Compose derives it from the directory name):
+
+```yaml
+name: myapp   # sets com.docker.compose.project=myapp
+
+services:
+  web:
+    image: nginx:alpine
+    # can reach the database as 'db' or 'db.myapp'
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_PASSWORD: secret
+```
+
+> **Note:** Apple Container uses a single global hostname namespace. Two
+> Compose projects running simultaneously with identically-named services
+> (e.g. both have a `db` service) will share the short-form alias — last
+> started wins. Use the qualified form (`db.myapp`) to resolve unambiguously.
+
 ### Label key normalization
 
 Apple Container only accepts lowercase label keys matching `[a-z0-9](?:[a-z0-9\-\.\/]*[a-z0-9])?`. Docker allows mixed-case, underscores, and other characters. Socktainer automatically normalizes label keys at create time:

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -47,11 +47,22 @@ extension ContainerDeleteRoute {
                 }
 
                 if let container,
-                    let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
-                    let namesLabel = container.configuration.labels["socktainer.dns.names"]
+                    let dnsServer = req.application.storage[SocktainerDNSServerKey.self]
                 {
-                    for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                        dnsServer.unregister(hostname: name)
+                    if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
+                        for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                            dnsServer.unregister(hostname: name)
+                        }
+                    }
+                    if let serviceName = container.configuration.labels["com.docker.compose.service"],
+                        !serviceName.isEmpty
+                    {
+                        dnsServer.unregister(hostname: serviceName)
+                        if let projectName = container.configuration.labels["com.docker.compose.project"],
+                            !projectName.isEmpty
+                        {
+                            dnsServer.unregister(hostname: "\(serviceName).\(projectName)")
+                        }
                     }
                 }
 

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -49,19 +49,31 @@ extension ContainerDeleteRoute {
                 if let container,
                     let dnsServer = req.application.storage[SocktainerDNSServerKey.self]
                 {
+                    let containerIP = container.networks.first?.ipv4Address.address.description
+
+                    // Only unregister an alias when this container still owns it — i.e. the
+                    // registered IP matches ours. If another container has since claimed the
+                    // same hostname (e.g. a second project with an identically-named service),
+                    // leave the entry intact so that surviving container keeps resolving.
+                    func unregisterIfOwned(_ hostname: String) {
+                        let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(hostname)]
+                        if let containerIP, registered != nil, registered != containerIP { return }
+                        dnsServer.unregister(hostname: hostname)
+                    }
+
                     if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
                         for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                            dnsServer.unregister(hostname: name)
+                            unregisterIfOwned(name)
                         }
                     }
                     if let serviceName = container.configuration.labels["com.docker.compose.service"],
                         !serviceName.isEmpty
                     {
-                        dnsServer.unregister(hostname: serviceName)
+                        unregisterIfOwned(serviceName)
                         if let projectName = container.configuration.labels["com.docker.compose.project"],
                             !projectName.isEmpty
                         {
-                            dnsServer.unregister(hostname: "\(serviceName).\(projectName)")
+                            unregisterIfOwned("\(serviceName).\(projectName)")
                         }
                     }
                 }

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -60,12 +60,35 @@ extension ContainerStartRoute {
             if let dnsServer = req.application.storage[SocktainerDNSServerKey.self],
                 let snapshot = startedSnapshot,
                 snapshot.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole,
-                let namesLabel = snapshot.configuration.labels["socktainer.dns.names"],
                 let firstAttachment = snapshot.networks.first
             {
                 let ip = firstAttachment.ipv4Address.address.description
-                for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                    dnsServer.register(hostname: name, ip: ip)
+
+                // Names stored at create time (Compose service aliases via socktainer.dns.names)
+                if let namesLabel = snapshot.configuration.labels["socktainer.dns.names"] {
+                    for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                        dnsServer.register(hostname: name, ip: ip)
+                    }
+                }
+
+                // Register Docker Compose service names so that containers in the same
+                // project can resolve each other by service name (e.g. "db") or the
+                // project-qualified form (e.g. "db.myapp").
+                //
+                // The qualified form (service.project) matches Docker's own DNS behaviour
+                // and avoids collisions when multiple Compose projects run concurrently.
+                if let serviceName = snapshot.configuration.labels["com.docker.compose.service"],
+                    !serviceName.isEmpty
+                {
+                    dnsServer.register(hostname: serviceName, ip: ip)
+                    if let projectName = snapshot.configuration.labels["com.docker.compose.project"],
+                        !projectName.isEmpty
+                    {
+                        dnsServer.register(hostname: "\(serviceName).\(projectName)", ip: ip)
+                        req.logger.info("[dns] registered compose aliases '\(serviceName)' and '\(serviceName).\(projectName)' → \(ip)")
+                    } else {
+                        req.logger.info("[dns] registered compose alias '\(serviceName)' → \(ip)")
+                    }
                 }
             }
 

--- a/Sources/socktainer/Routes/Networks/NetworkConnectRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkConnectRoute.swift
@@ -5,7 +5,11 @@ struct NetworkConnectRoute: RouteCollection {
         try routes.registerVersionedRoute(.POST, pattern: "/networks/{id}/connect", use: NetworkConnectRoute.handler)
     }
 
+    // Apple Container uses a single global hostname namespace, so all containers
+    // can already reach each other without explicit network attachment.
+    // Returning 200 lets Docker Compose proceed; inter-service DNS is handled
+    // by the Socktainer DNS server via com.docker.compose.service label registration.
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks/{id}/connect", req.method.rawValue)
+        Response(status: .ok)
     }
 }

--- a/Sources/socktainer/Routes/Networks/NetworkDisconnectRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkDisconnectRoute.swift
@@ -6,6 +6,6 @@ struct NetworkDisconnectRoute: RouteCollection {
     }
 
     static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/networks/{id}/disconnect", req.method.rawValue)
+        Response(status: .ok)
     }
 }

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -1,0 +1,206 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+@Suite("Compose DNS — service name registration")
+struct ComposeDNSTests {
+
+    // MARK: - Start route registers compose DNS aliases
+
+    @Test("Start registers service and service.project aliases when compose labels present")
+    func startRegistersComposeDNSAliases() async throws {
+        let nativeId = "compose-db-container"
+        let ip = "192.168.65.20"
+        let snapshot = try makeSnapshot(
+            nativeId: nativeId, ip: ip,
+            labels: [
+                "com.docker.compose.service": "db",
+                "com.docker.compose.project": "myapp",
+            ])
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/abc123/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries["db"] == ip, "short service name must be registered with correct IP")
+        #expect(entries["db.myapp"] == ip, "qualified service.project alias must be registered")
+    }
+
+    @Test("Start registers only service alias when project label is absent")
+    func startRegistersServiceOnlyWithoutProject() async throws {
+        let snapshot = try makeSnapshot(
+            nativeId: "compose-cache", ip: "192.168.65.21",
+            labels: ["com.docker.compose.service": "cache"])
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/abc456/start") { _ async in }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries["cache"] != nil, "short service name must be registered")
+        #expect(
+            entries.keys.filter { $0.hasPrefix("cache.") }.isEmpty,
+            "no qualified alias without project label")
+    }
+
+    @Test("Start does not register compose DNS for non-compose containers")
+    func startSkipsComposeDNSWithoutLabels() async throws {
+        let snapshot = try makeSnapshot(nativeId: "plain-container", ip: "192.168.65.22", labels: [:])
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/abc789/start") { _ async in }
+        }
+
+        #expect(dnsServer.listEntries().isEmpty, "no DNS entries for non-compose container")
+    }
+
+    // MARK: - Delete route unregisters compose DNS aliases
+
+    @Test("Delete unregisters both service and service.project aliases")
+    func deleteUnregistersComposeDNSAliases() async throws {
+        let snapshot = try makeSnapshot(
+            nativeId: "compose-web", ip: "192.168.65.30",
+            labels: [
+                "com.docker.compose.service": "web",
+                "com.docker.compose.project": "shop",
+            ])
+        let dnsServer = SocktainerDNSServer()
+        dnsServer.register(hostname: "web", ip: "192.168.65.30")
+        dnsServer.register(hostname: "web.shop", ip: "192.168.65.30")
+        #expect(dnsServer.listEntries()["web"] != nil)
+        #expect(dnsServer.listEntries()["web.shop"] != nil)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/abc000") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        #expect(dnsServer.listEntries()["web"] == nil, "service alias must be unregistered on delete")
+        #expect(dnsServer.listEntries()["web.shop"] == nil, "qualified alias must be unregistered on delete")
+    }
+
+    // MARK: - Network connect/disconnect return 200
+
+    @Test("POST /networks/{id}/connect returns 200")
+    func networkConnectReturns200() async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: NetworkConnectRoute())
+
+            try await app.testing().test(.POST, "/v1.51/networks/myapp_default/connect") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test("POST /networks/{id}/disconnect returns 200")
+    func networkDisconnectReturns200() async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: NetworkDisconnectRoute())
+
+            try await app.testing().test(.POST, "/v1.51/networks/myapp_default/disconnect") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Constructs a ContainerSnapshot with a real Attachment (decoded from JSON) so that
+/// DNS registration code can extract the IP from networks.first.ipv4Address.
+private func makeSnapshot(nativeId: String, ip: String, labels: [String: String]) throws -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: "sha256:abc", size: 0
+        )
+    )
+    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+    config.labels = labels
+
+    // Attachment is Codable — use JSON to avoid depending on internal CIDRv4/IPv4Address inits.
+    // CIDRv4 and IPv4Address are single-value string types: "192.168.x.x/24" and "192.168.x.x".
+    let attachmentJSON = """
+        {
+            "network": "default",
+            "hostname": "\(nativeId)",
+            "ipv4Address": "\(ip)/24",
+            "ipv4Gateway": "192.168.65.1",
+            "ipv6Address": null,
+            "macAddress": null
+        }
+        """.data(using: .utf8)!
+    let attachment = try JSONDecoder().decode(Attachment.self, from: attachmentJSON)
+
+    return ContainerSnapshot(configuration: config, status: .stopped, networks: [attachment])
+}
+
+private struct ComposeMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -120,6 +120,37 @@ struct ComposeDNSTests {
         #expect(dnsServer.listEntries()["web.shop"] == nil, "qualified alias must be unregistered on delete")
     }
 
+    @Test("Delete preserves alias when another container has taken ownership")
+    func deletePreservesAliasOwnedByAnotherContainer() async throws {
+        let snapshot = try makeSnapshot(
+            nativeId: "compose-web-old", ip: "192.168.65.30",
+            labels: [
+                "com.docker.compose.service": "web",
+                "com.docker.compose.project": "shop",
+            ])
+        let dnsServer = SocktainerDNSServer()
+        // Simulate a second container claiming the same aliases before the first is deleted
+        dnsServer.register(hostname: "web", ip: "192.168.65.31")
+        dnsServer.register(hostname: "web.shop", ip: "192.168.65.31")
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/abc001") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries["web"] == "192.168.65.31", "alias owned by another container must be preserved")
+        #expect(entries["web.shop"] == "192.168.65.31", "qualified alias owned by another container must be preserved")
+    }
+
     // MARK: - Network connect/disconnect return 200
 
     @Test("POST /networks/{id}/connect returns 200")


### PR DESCRIPTION
## What

Enables Docker Compose inter-service DNS on Apple Container with no new Apple Container API requirements.

## How

**`POST /networks/{id}/connect` and `/disconnect` → 200**

Apple Container uses a single global hostname namespace — all containers can already reach each other IP-wise. These endpoints previously returned 501, blocking Compose from proceeding past the network-connect step. Returning 200 (per the Docker Engine API spec) unblocks the flow without any actual network management needed.

**Dual DNS alias registration in `ContainerStartRoute`**

When a container starts with `com.docker.compose.*` labels, two DNS aliases are registered:

| Alias | Example | Purpose |
|---|---|---|
| `service` | `db` | Short form — works within a single project |
| `service.project` | `db.myapp` | Project-qualified — unique across concurrent projects |

The short form satisfies standard Compose usage (`ping db`). The qualified form matches Docker's own DNS behaviour and avoids collisions when two projects run simultaneously with identically-named services.

**`ContainerDeleteRoute` unregisters both aliases** on container removal.

**README** documents the behaviour under Security & Limitations with a Compose example showing the `name:` directive.

## Result

Standard Docker Compose workflows now work end-to-end on Socktainer:

```yaml
name: myapp

services:
  web:
    image: nginx:alpine
    # can reach db as 'db' or 'db.myapp'
  db:
    image: postgres:17
    environment:
      POSTGRES_PASSWORD: secret
```

## Tests

6 new tests in `ComposeDNSTests`:
- Start registers `service` and `service.project` aliases with correct IP
- Start registers only `service` when project label is absent
- Start skips DNS registration for non-Compose containers
- Delete unregisters both aliases
- `POST /networks/{id}/connect` returns 200
- `POST /networks/{id}/disconnect` returns 200

## Limitation

No per-project network isolation. Apple Container's global namespace means two concurrent projects with an identically-named service (e.g. both have `db`) will share the short-form alias. The qualified form (`db.projectname`) remains unique.