### PR TITLE
feat(containers): honor --memory flag for VM RAM allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [GitHub Releases](#github-releases)
   - [Usage 🚀](#usage-🚀)
     - [Volume sync mode](#volume-sync-mode)
+    - [VM memory](#vm-memory)
   - [Building from Source 🏗️](#building-from-source-🏗️)
     - [Prerequisites](#prerequisites)
     - [Build & Run](#build-run)
@@ -122,7 +123,7 @@ DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker images
 - Listens on a Unix domain socket `$HOME/.socktainer/container.sock` and auto-registers a `socktainer` Docker context
 - Supports container lifecycle operations: inspect, stop, remove 🛠️
 - Supports image listing, pulling, deletion, logs, health checks, container stats. Exec without interactive mode 📄
-- `docker stats` reports memory against the Apple Container VM limit (default 1 GiB), not the host RAM
+- `docker stats` reports memory against the Apple Container VM limit (configurable via `--memory`, default 1 GiB per container), not the host RAM
 - Broadcasts container events for client liveness monitoring 📡
 
 ---
@@ -213,6 +214,36 @@ volumes:
 ```
 
 Valid modes: `nosync` · `fsync` · `full`
+
+### VM memory
+
+Each container runs in its own Apple Container VM with a fixed memory allocation.
+Socktainer honors Docker's `--memory` flag and `mem_limit:` / `deploy.resources.limits.memory:` in Compose files.
+
+```bash
+docker run --memory 2g postgres          # 2 GiB VM
+docker run --memory 512m redis           # 512 MiB VM
+docker run postgres                      # 1 GiB VM (Apple Container default)
+```
+
+> **Note:** Apple Container allocates VM RAM at creation time — this is not a cgroup
+> soft limit. Setting `--memory` too low will cause the process to OOM inside the VM.
+>
+> There is no "unlimited" mode: Docker's `--memory 0` (no limit) maps to the Apple
+> Container default of **1 GiB**, not host RAM. To give a container more than 1 GiB,
+> always pass an explicit `--memory` value.
+
+In Docker Compose:
+
+```yaml
+services:
+  kafka:
+    image: confluentinc/cp-kafka
+    mem_limit: 2g
+  redis:
+    image: redis:alpine
+    mem_limit: 256m
+```
 
 ---
 

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -456,6 +456,10 @@ extension ContainerCreateRoute {
 
             containerConfiguration.mounts = resolvedMounts
 
+            if let memoryBytes = resolveMemoryInBytes(body.HostConfig?.Memory) {
+                containerConfiguration.resources.memoryInBytes = memoryBytes
+            }
+
             let options = ContainerCreateOptions(autoRemove: body.HostConfig?.AutoRemove ?? false)
             let container: ContainerSnapshot
             do {
@@ -546,4 +550,12 @@ func convertPortBindings(from portBindings: [String: [PortBinding]]) throws -> [
     }
 
     return publishedPorts
+}
+
+// Maps Docker HostConfig.Memory (bytes, 0 = no limit) to Apple Container memoryInBytes.
+// Returns nil when the value is absent, zero, or negative so the Apple Container
+// default (1 GiB) is preserved.
+func resolveMemoryInBytes(_ memory: Int?) -> UInt64? {
+    guard let memory, memory > 0 else { return nil }
+    return UInt64(memory)
 }

--- a/Tests/socktainerTests/Routes/ContainerMemoryTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerMemoryTests.swift
@@ -1,0 +1,54 @@
+import ContainerResource
+import Testing
+
+@testable import socktainer
+
+@Suite("Container memory mapping")
+struct ContainerMemoryTests {
+
+    // MARK: - resolveMemoryInBytes
+
+    @Test("nil memory returns nil (preserve Apple Container default)")
+    func nilMemoryReturnsNil() {
+        #expect(resolveMemoryInBytes(nil) == nil)
+    }
+
+    @Test("zero memory returns nil — Apple Container 1 GiB default is preserved")
+    func zeroMemoryReturnsNil() {
+        // Docker's 'no limit' sentinel (Memory=0) has no equivalent in Apple Container:
+        // VMs require a fixed RAM amount. Returning nil preserves the 1 GiB default.
+        #expect(resolveMemoryInBytes(0) == nil)
+    }
+
+    @Test("negative memory returns nil (invalid, treated as no limit)")
+    func negativeMemoryReturnsNil() {
+        #expect(resolveMemoryInBytes(-1) == nil)
+        #expect(resolveMemoryInBytes(Int.min) == nil)
+    }
+
+    @Test("positive memory maps to UInt64 bytes")
+    func positiveMemoryMapped() {
+        let mib: Int = 512 * 1024 * 1024
+        #expect(resolveMemoryInBytes(mib) == UInt64(mib))
+    }
+
+    @Test("1 byte is the minimum positive value accepted")
+    func oneByteAccepted() {
+        #expect(resolveMemoryInBytes(1) == 1)
+    }
+
+    // MARK: - ContainerConfiguration.Resources default
+
+    @Test("Apple Container default VM memory is 1 GiB")
+    func defaultMemoryIs1GiB() {
+        let resources = ContainerConfiguration.Resources()
+        #expect(resources.memoryInBytes == 1024 * 1024 * 1024)
+    }
+
+    @Test("Setting resources.memoryInBytes overrides the default")
+    func overrideMemory() {
+        var resources = ContainerConfiguration.Resources()
+        resources.memoryInBytes = 512 * 1024 * 1024
+        #expect(resources.memoryInBytes == 512 * 1024 * 1024)
+    }
+}


### PR DESCRIPTION
## Summary

Map Docker's `HostConfig.Memory` to Apple Container's `ContainerConfiguration.resources.memoryInBytes` at container create time. Before this change, the `--memory` flag was decoded but silently discarded — every container VM got the Apple Container default of 1 GiB regardless of what the client requested.

## Related Issue

N/A

## Changes

- `ContainerCreateRoute.swift`: wire `HostConfig.Memory` → `containerConfiguration.resources.memoryInBytes` when the value is positive; preserve the Apple Container 1 GiB default for `Memory=0` (Docker's "no limit" sentinel) and absent values
- `resolveMemoryInBytes(_:)` helper extracted alongside `convertPortBindings` for independent testability
- `ContainerMemoryTests.swift`: 7 unit tests covering nil / zero / negative / positive inputs and the Apple Container default
- `README.md`: new **VM memory** section documenting `--memory` usage, the VM-vs-cgroup distinction, and the semantic gap between Docker's "no limit" (0) and Apple Container's 1 GiB default; updated Key Features bullet

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (221 tests)
- [x] Unit tests added (`Tests/socktainerTests/Routes/ContainerMemoryTests.swift`)
- [x] Manual testing performed — verified end-to-end via `memory_stats.limit` from the stats API against a live socktainer instance:
  - `docker run --memory 512m` → 536,870,912 bytes ✅
  - `docker run --memory 2g` → 2,147,483,648 bytes ✅
  - no `--memory` → 1,073,741,824 bytes (1 GiB default) ✅
  - `mem_limit: 512m` in Docker Compose → 536,870,912 bytes ✅
  - `deploy.resources.limits.memory: 2g` in Docker Compose → 2,147,483,648 bytes ✅

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))