### PR TITLE
fix(attach): fix stdin pipe coordination for docker run -i and exec -i

### DIFF
--- a/Sources/socktainer/Utilities/DockerConnectionUtility.swift
+++ b/Sources/socktainer/Utilities/DockerConnectionUtility.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import NIOCore
 import NIOHTTP1
 import Vapor
@@ -80,59 +81,124 @@ private struct DockerTCPProtocolUpgrader: HTTPServerProtocolUpgrader {
 
         let channel = context.channel
         let eventLoop = context.eventLoop
+        let pipeline = context.pipeline
 
-        return context.pipeline.addHandler(tcpHandler).flatMap { _ in
-            _ = Task.detached { [streamHandler] in
-                do {
-                    try await streamHandler(channel, tcpHandler)
-                } catch {
-                    eventLoop.execute {
-                        channel.close(promise: nil)
+        // Allow the remote peer to half-close its write side (stdin EOF) without
+        // tearing down the whole channel. Without this, Docker CLI piping stdin
+        // (echo "hi" | docker run -i ...) closes the write half after sending data,
+        // which NIO interprets as a full close — the channel goes away before
+        // stdout can be sent back. With this option NIO fires .inputClosed instead.
+        return channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).flatMap {
+            pipeline.addHandler(tcpHandler).flatMap { _ in
+                _ = Task.detached { [streamHandler] in
+                    do {
+                        try await streamHandler(channel, tcpHandler)
+                    } catch {
+                        eventLoop.execute {
+                            channel.close(promise: nil)
+                        }
                     }
                 }
-            }
 
-            return eventLoop.makeSucceededVoidFuture()
+                return eventLoop.makeSucceededVoidFuture()
+            }
         }
     }
 }
 
-/// Channel handler that manages raw TCP communication after HTTP upgrade
+/// Channel handler that manages raw TCP communication after HTTP upgrade.
+///
+/// All writes to the stdin file descriptor are serialized through `writeQueue`,
+/// a private serial DispatchQueue. This guarantees FIFO ordering and prevents
+/// byte-interleaving between concurrent callers (channelRead on the NIO event
+/// loop, setStdinWriter from a detached Swift Task).
+///
+/// The NSLock protects the mutable flags and stdinWriter pointer across threads.
+/// The writeQueue serializes the actual fd writes independently of the lock, so
+/// writes never hold the lock while potentially blocking on a full pipe.
 public final class DockerTCPHandler: ChannelInboundHandler, @unchecked Sendable {
     public typealias InboundIn = ByteBuffer
 
     let execId: String
     let ttyEnabled: Bool
+    private let lock = NSLock()
+    private static let logger = Logger(label: "DockerTCPHandler")
+    // Serial queue — all fd writes and closes go through here.
+    // Guarantees: (1) FIFO across concurrent callers, (2) no byte-interleaving
+    // for writes > PIPE_BUF, (3) close always follows all pending writes.
+    private let writeQueue = DispatchQueue(label: "DockerTCPHandler.stdin", qos: .userInteractive)
     private var stdinWriter: FileHandle?
+    // Buffers stdin bytes arriving before setStdinWriter is called.
+    // Capped at 1 MiB to prevent unbounded growth if setup is delayed.
+    private var pendingData: [Data] = []
+    private var pendingDataSize: Int = 0
+    private static let pendingDataMaxBytes = 1 * 1024 * 1024  // 1 MiB
+    private var didReceiveInputClosed = false
+    private var isChannelInactive = false
 
     init(execId: String, ttyEnabled: Bool) {
         self.execId = execId
         self.ttyEnabled = ttyEnabled
     }
 
-    public func channelActive(context: ChannelHandlerContext) {
+    deinit {
+        // Defensive cleanup for exceptional teardown paths where channelInactive
+        // never fires. deinit only runs when the stream handler Task has released
+        // its reference, so writeQueue is idle — direct close is safe.
+        lock.lock()
+        let writer = stdinWriter
+        stdinWriter = nil
+        lock.unlock()
+        try? writer?.close()
     }
+
+    public func channelActive(context: ChannelHandlerContext) {}
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = unwrapInboundIn(data)
+        guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else { return }
+        writeToStdin(data)
+    }
 
-        // Handle raw TCP input from client (stdin)
-        // This data should be forwarded to the process stdin
-        if let stdinWriter = self.stdinWriter {
-            if let data = buffer.getData(at: 0, length: buffer.readableBytes) {
-                do {
-                    try stdinWriter.write(contentsOf: data)
-
-                    // Force flush the data to ensure it reaches the process
-                    try stdinWriter.synchronize()
-                } catch {
-                    // Failed to write to stdin
-                }
+    /// Core write path — buffers when no writer is set yet; dispatches to
+    /// writeQueue otherwise. Called by channelRead and exposed for unit tests.
+    func writeToStdin(_ data: Data) {
+        lock.lock()
+        let writer = stdinWriter
+        if writer == nil {
+            if pendingDataSize + data.count <= Self.pendingDataMaxBytes {
+                pendingData.append(data)
+                pendingDataSize += data.count
             } else {
-                // No buffer data available
+                Self.logger.warning(
+                    "[\(execId)] stdin buffer full (\(Self.pendingDataMaxBytes) B) — discarding \(data.count) B"
+                )
+            }
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
+        writeQueue.async { [execId] in
+            do { try writer!.write(contentsOf: data) } catch { Self.logger.error("[\(execId)] stdin write failed: \(error)") }
+        }
+    }
+
+    // Fired when Docker CLI half-closes its write side (stdin EOF).
+    // Dispatching the close through writeQueue ensures it runs after all
+    // previously queued writes, so the process sees EOF only after all data.
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if (event as? ChannelEvent) == .inputClosed {
+            lock.lock()
+            didReceiveInputClosed = true
+            let writer = stdinWriter
+            stdinWriter = nil
+            lock.unlock()
+            if let writer {
+                writeQueue.async { try? writer.close() }
             }
         } else {
-            // No stdin writer available
+            context.fireUserInboundEventTriggered(event)
         }
     }
 
@@ -141,12 +207,78 @@ public final class DockerTCPHandler: ChannelInboundHandler, @unchecked Sendable 
     }
 
     public func channelInactive(context: ChannelHandlerContext) {
-        try? stdinWriter?.close()
+        lock.lock()
+        isChannelInactive = true
+        let writer = stdinWriter
+        stdinWriter = nil
+        lock.unlock()
+        if let writer {
+            writeQueue.async { try? writer.close() }
+        }
     }
 
-    // Method to set the stdin writer from the stream handler
+    /// Set the stdin writer. Publishes the writer and enqueues the buffered-data
+    /// flush atomically under the lock, so any concurrent writeToStdin that
+    /// observes the new writer (and enqueues its write after our unlock) is
+    /// guaranteed to be ordered after the flush — true FIFO preserved.
+    /// writeQueue.async is non-blocking so enqueuing under the lock is safe.
     public func setStdinWriter(_ writer: FileHandle?) {
-        self.stdinWriter = writer
+        lock.lock()
+        let buffered = pendingData
+        pendingData = []
+        pendingDataSize = 0
+        let shouldClose = didReceiveInputClosed || isChannelInactive
+        if let writer {
+            if !shouldClose { stdinWriter = writer }
+            writeQueue.async { [execId] in
+                for data in buffered {
+                    do { try writer.write(contentsOf: data) } catch {
+                        Self.logger.error("[\(execId)] stdin flush failed: \(error)")
+                    }
+                }
+                if shouldClose { try? writer.close() }
+            }
+        }
+        lock.unlock()
+    }
+
+    // MARK: - Test helpers
+
+    /// Returns the total bytes currently buffered in pendingData.
+    var pendingDataSizeForTesting: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return pendingDataSize
+    }
+
+    /// Blocks until all pending writeQueue work completes. Call before reading
+    /// pipe state in tests that write asynchronously through writeQueue.
+    func drainForTesting() {
+        writeQueue.sync {}
+    }
+
+    /// Simulates channelInactive without a NIO context (tests only).
+    func simulateChannelInactive() {
+        lock.lock()
+        isChannelInactive = true
+        let writer = stdinWriter
+        stdinWriter = nil
+        lock.unlock()
+        if let writer {
+            writeQueue.async { try? writer.close() }
+        }
+    }
+
+    /// Simulates .inputClosed without a NIO context (tests only).
+    func simulateInputClosed() {
+        lock.lock()
+        didReceiveInputClosed = true
+        let writer = stdinWriter
+        stdinWriter = nil
+        lock.unlock()
+        if let writer {
+            writeQueue.async { try? writer.close() }
+        }
     }
 }
 

--- a/Tests/socktainerTests/Routes/DockerTCPHandlerTests.swift
+++ b/Tests/socktainerTests/Routes/DockerTCPHandlerTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// Unit tests for DockerTCPHandler stdin coordination.
+///
+/// These tests exercise writeToStdin(), simulateInputClosed(), and
+/// simulateChannelInactive() — internal helpers that call the same logic
+/// as channelRead / userInboundEventTriggered — without requiring NIO
+/// EmbeddedChannel (which has significant build overhead; see PR #231).
+///
+/// Async writes go through DockerTCPHandler.writeQueue (a serial
+/// DispatchQueue). Tests that inspect pipe state after async writes call
+/// drainForTesting() to synchronise, or use readDataToEndOfFile() which
+/// naturally blocks until the write end is closed.
+@Suite("DockerTCPHandler — stdin coordination")
+struct DockerTCPHandlerTests {
+
+    // MARK: - writeToStdin before setStdinWriter (pending buffer)
+
+    @Test("data written before setStdinWriter is buffered and flushed on set")
+    func pendingDataFlushedOnSetStdinWriter() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.writeToStdin(Data("hello".utf8))
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+        handler.drainForTesting()
+        try pipe.fileHandleForWriting.close()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(data: data, encoding: .utf8) == "hello")
+    }
+
+    @Test("multiple buffered chunks flushed in order")
+    func multipleChunksFlushedInOrder() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.writeToStdin(Data("foo".utf8))
+        handler.writeToStdin(Data("bar".utf8))
+        handler.writeToStdin(Data("baz".utf8))
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+        handler.drainForTesting()
+        try pipe.fileHandleForWriting.close()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(data: data, encoding: .utf8) == "foobarbaz")
+    }
+
+    // MARK: - writeToStdin after setStdinWriter (direct write)
+
+    @Test("data written after setStdinWriter flows through writeQueue to the pipe")
+    func dataAfterSetWrittenDirectly() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+        handler.writeToStdin(Data("direct".utf8))
+        handler.drainForTesting()
+        try pipe.fileHandleForWriting.close()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(data: data, encoding: .utf8) == "direct")
+    }
+
+    // MARK: - setStdinWriter contract
+
+    @Test("setStdinWriter(nil) does not crash")
+    func setStdinWriterNilIsSafe() {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        handler.setStdinWriter(nil)
+    }
+
+    @Test("second setStdinWriter call replaces the writer — writes go to new pipe only")
+    func setStdinWriterCalledTwiceReplacesWriter() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipeA = Pipe()
+        let pipeB = Pipe()
+
+        handler.setStdinWriter(pipeA.fileHandleForWriting)
+        handler.setStdinWriter(pipeB.fileHandleForWriting)
+        handler.writeToStdin(Data("second".utf8))
+        handler.drainForTesting()
+        try pipeB.fileHandleForWriting.close()
+        try pipeA.fileHandleForWriting.close()
+
+        let dataB = pipeB.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(data: dataB, encoding: .utf8) == "second")
+
+        let dataA = pipeA.fileHandleForReading.readDataToEndOfFile()
+        #expect(dataA.isEmpty)
+    }
+
+    // MARK: - inputClosed race condition
+
+    @Test("inputClosed before setStdinWriter: buffered data flushed then write end closed")
+    func inputClosedBeforeSetStdinWriterFlushesAndCloses() throws {
+        // Without didReceiveInputClosed this test would hang because the
+        // write end would never be closed and readDataToEndOfFile() blocks.
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.writeToStdin(Data("piped".utf8))
+        handler.simulateInputClosed()
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(data: data, encoding: .utf8) == "piped")
+    }
+
+    @Test("inputClosed before setStdinWriter with no pending data closes write end")
+    func inputClosedBeforeSetStdinWriterNoDataClosesWriter() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.simulateInputClosed()
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(data.isEmpty)
+    }
+
+    // MARK: - inputClosed during flush (deferred close via writeQueue ordering)
+
+    @Test("inputClosed during flush: all data flushed before write end closes")
+    func inputClosedDuringFlushDataFlushedBeforeClose() async throws {
+        // Fills the pipe buffer so setStdinWriter's flush blocks mid-write.
+        // simulateInputClosed is injected from a concurrent thread while the
+        // flush is stalled. The reader unblocks the flush. All data must arrive
+        // before EOF — the writeQueue serialisation guarantees this.
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        let abovePipeBuffer = Data(repeating: 0x41, count: 65_537)
+        let sentinel = Data([0xFF])
+        handler.writeToStdin(abovePipeBuffer)
+        handler.writeToStdin(sentinel)
+
+        // Flush in background — will block when the pipe buffer fills
+        let flushTask = Task.detached { handler.setStdinWriter(pipe.fileHandleForWriting) }
+        // Reader runs concurrently, draining the pipe so flush can progress
+        let readTask = Task.detached { pipe.fileHandleForReading.readDataToEndOfFile() }
+
+        // Give the flush time to block
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Inject close while flush is in progress
+        handler.simulateInputClosed()
+
+        await flushTask.value
+        let received = await readTask.value
+
+        #expect(received.count == abovePipeBuffer.count + sentinel.count)
+        #expect(received.last == 0xFF)
+    }
+
+    // MARK: - channelInactive race
+
+    @Test("setStdinWriter called after channelInactive immediately closes the writer")
+    func setStdinWriterAfterChannelInactiveClosesWriter() throws {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let pipe = Pipe()
+
+        handler.simulateChannelInactive()
+        handler.setStdinWriter(pipe.fileHandleForWriting)
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(data.isEmpty)
+    }
+
+    // MARK: - pendingData cap
+
+    @Test("pendingData cap: data beyond 1 MiB is discarded, buffer stays at cap")
+    func pendingDataCapDiscardsOverflow() {
+        let handler = DockerTCPHandler(execId: "test", ttyEnabled: false)
+        let cap = 1 * 1024 * 1024
+
+        let chunk = Data(repeating: 0x41, count: 512 * 1024)
+        handler.writeToStdin(chunk)
+        handler.writeToStdin(chunk)  // exactly at cap
+        handler.writeToStdin(chunk)  // over cap — discarded
+
+        #expect(handler.pendingDataSizeForTesting == cap)
+    }
+}


### PR DESCRIPTION
## Summary

\`docker run -i\` and \`docker exec -i\` silently dropped all stdin input, making piped commands (\`echo "hi" | docker run -i alpine cat\`) return empty and causing \`docker exec -i\` to crash. Three race conditions in \`DockerTCPHandler\` were responsible — all fixed by replacing the lock+flag approach with a serial \`DispatchQueue\` that serializes all writes to the stdin fd, guaranteeing FIFO ordering and preventing byte-interleaving.

Fixes the root cause of VSCode dev containers failing (issue #120): dev container setup relies heavily on \`docker exec -i\` for running setup scripts. Combined with #232 (terminal resize, already merged), full interactive TTY sessions now work correctly.

## Related Issue

Closes #120

## Changes

**\`DockerConnectionUtility.swift\`** — \`DockerTCPHandler\` refactored:
- Added a serial \`writeQueue\` (DispatchQueue) — all writes and closes go through it, guaranteeing FIFO and preventing byte-interleaving for chunks > PIPE_BUF
- Buffered-data flush is enqueued atomically inside the lock before unlock, so any concurrent \`writeToStdin\` that observes the new writer is ordered after the flush
- \`allowRemoteHalfClosure: true\` on the NIO channel so Docker CLI half-closing stdin doesn't tear down the channel before stdout returns
- \`didReceiveInputClosed\` / \`isChannelInactive\` flags handle the race where close events arrive before \`setStdinWriter\` is called
- 1 MiB cap on \`pendingData\` to prevent unbounded growth; overflow logged and discarded

**\`DockerTCPHandlerTests.swift\`** — 10 unit tests covering: pending buffer flush, FIFO ordering, nil safety, writer replacement, inputClosed races, channelInactive race, cap enforcement, and a concurrent flush test (fills pipe buffer so close is deferred until flush completes)

## Local devcontainer simulation

Tested against a real container simulating VSCode dev container operations (all with \`#231\` patch applied):

| Operation | Result |
|---|---|
| Container create + start | ✅ |
| \`exec -i\` setup scripts | ✅ |
| \`exec -i\` stdin forwarding | ✅ |
| \`exec -i\` package install (apk) | ✅ |
| 5 sequential \`exec -i\` | ✅ |
| \`exec -it\` → PTY + \`isatty:yes\` | ✅ |
| Workspace volume read/write | ✅ |
| 20 rapid concurrent \`exec -i\` | ✅ |
| Crashes / continuation errors in logs | None |

## Testing

- [x] \`make fmt\` passes
- [x] \`make test\` passes (244 tests)
- [x] 6/6 integration tests: \`echo "x" | docker run -i alpine cat\`, \`docker exec -i\`, etc.
- [x] Devcontainer simulation (above)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))