### PR TITLE
feat(routes): implement terminal resize for containers and exec instances

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -286,6 +286,8 @@ extension ContainerAttachRoute {
             }
         }
 
+        await ProcessRegistry.shared.set(id: container.id, process: process)
+
         let contentType =
             isTTY
             ? "application/vnd.docker.raw-stream" : "application/vnd.docker.multiplexed-stream"
@@ -306,6 +308,7 @@ extension ContainerAttachRoute {
                     // Close pipes → readers drain → grace period → unblock /wait.
                     group.addTask {
                         let code = (try? await process.wait()) ?? 0
+                        await ProcessRegistry.shared.remove(id: container.id)
                         try? stdoutPipe?.fileHandleForWriting.close()
                         try? stderrPipe?.fileHandleForWriting.close()
                         try? stdinPipe.fileHandleForReading.close()
@@ -471,6 +474,8 @@ extension ContainerAttachRoute {
             throw Abort(.internalServerError, reason: "Failed to start main process: \(error.localizedDescription)")
         }
 
+        await ProcessRegistry.shared.set(id: container.id, process: process)
+
         guard shouldUpgrade else {
 
             return ConnectionHijackingMiddleware.createDockerStreamingResponse(
@@ -500,6 +505,7 @@ extension ContainerAttachRoute {
                             // /containers/{id}/wait can't block forever.
                             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                         }
+                        await ProcessRegistry.shared.remove(id: container.id)
                     }
 
                     if let stdoutHandle = stdoutPipe?.fileHandleForReading {
@@ -742,6 +748,7 @@ extension ContainerAttachRoute {
                         // /containers/{id}/wait can't block forever.
                         await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                     }
+                    await ProcessRegistry.shared.remove(id: container.id)
 
                     // Give a small delay for any final output to be processed
                     try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms

--- a/Sources/socktainer/Routes/Containers/ContainerResizeRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerResizeRoute.swift
@@ -1,3 +1,4 @@
+import ContainerizationOS
 import Vapor
 
 struct ContainerResizeRoute: RouteCollection {
@@ -6,8 +7,6 @@ struct ContainerResizeRoute: RouteCollection {
         try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/resize", use: ContainerResizeRoute.resize(client: client))
     }
 
-    // NOTE: This is stubbed as we are not using this endpoint to resize terminal size
-    //       work needs to be done to inform the client on the new size
     static func resize(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
 
@@ -15,16 +14,21 @@ struct ContainerResizeRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
-            guard let _ = try? req.query.get(Int.self, at: "h") else {
-                throw Abort(.badRequest, reason: "Missing height parameter")
+            guard let h = try? req.query.get(Int.self, at: "h"), h > 0 else {
+                throw Abort(.badRequest, reason: "Missing or invalid height parameter")
             }
 
-            guard let _ = try? req.query.get(Int.self, at: "w") else {
-                throw Abort(.badRequest, reason: "Missing width parameter")
+            guard let w = try? req.query.get(Int.self, at: "w"), w > 0 else {
+                throw Abort(.badRequest, reason: "Missing or invalid width parameter")
             }
 
-            guard let _ = try await client.getContainer(id: containerId) else {
-                throw Abort(.notFound, reason: "Container not found")
+            guard let container = try await client.getContainer(id: containerId) else {
+                throw Abort(.notFound, reason: "No such container: \(containerId)")
+            }
+
+            if let process = await ProcessRegistry.shared.get(id: container.id) {
+                let size = Terminal.Size(width: UInt16(min(w, Int(UInt16.max))), height: UInt16(min(h, Int(UInt16.max))))
+                try? await process.resize(size)
             }
 
             return Response(status: .ok)

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -1,5 +1,6 @@
 import ContainerAPIClient
 import ContainerResource
+import ContainerizationOS
 import Foundation
 import NIOCore
 import Vapor
@@ -100,6 +101,7 @@ struct ExecRoute: RouteCollection {
         try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/exec", use: ExecRoute.createExec(client: client))
         try routes.registerVersionedRoute(.GET, pattern: "/exec/{id}/json", use: ExecRoute.inspectExec(client: client))
         try routes.registerVersionedRoute(.POST, pattern: "/exec/{id}/start", use: ExecRoute.startExec(client: client))
+        try routes.registerVersionedRoute(.POST, pattern: "/exec/{id}/resize", use: ExecRoute.resizeExec)
     }
 
     static func inspectExec(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
@@ -341,6 +343,8 @@ struct ExecRoute: RouteCollection {
                         throw error
                     }
 
+                    await ProcessRegistry.shared.set(id: execId, process: process)
+
                     await withTaskGroup(of: Void.self) { group in
                         // stdout handler
                         if let stdoutHandle = stdoutPipe?.fileHandleForReading {
@@ -439,6 +443,7 @@ struct ExecRoute: RouteCollection {
                                 // code so the exec leaves the Running state.
                                 await ExecManager.shared.setExitCode(id: execId, code: -1)
                             }
+                            await ProcessRegistry.shared.remove(id: execId)
                         }
 
                         for await _ in group {}
@@ -495,6 +500,8 @@ struct ExecRoute: RouteCollection {
                     await ExecManager.shared.setExitCode(id: execId, code: -1)
                     throw error
                 }
+
+                await ProcessRegistry.shared.set(id: execId, process: process)
 
                 // Setup bidirectional communication for interactive sessions
                 await withTaskGroup(of: Void.self) { group in
@@ -652,6 +659,7 @@ struct ExecRoute: RouteCollection {
                             // hanging there forever.
                             await ExecManager.shared.setExitCode(id: execId, code: -1)
                         }
+                        await ProcessRegistry.shared.remove(id: execId)
 
                         // Give a small delay for any final output to be processed
                         try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
@@ -674,5 +682,31 @@ struct ExecRoute: RouteCollection {
                 // `GET /exec/{id}/json` can read the recorded exit code.
             }
         }
+    }
+
+    static let resizeExec: @Sendable (Request) async throws -> Response = { req in
+        guard let execId = req.parameters.get("id") else {
+            throw Abort(.badRequest, reason: "Missing exec ID")
+        }
+
+        guard let h = try? req.query.get(Int.self, at: "h"), h > 0 else {
+            throw Abort(.badRequest, reason: "Missing or invalid height parameter")
+        }
+
+        guard let w = try? req.query.get(Int.self, at: "w"), w > 0 else {
+            throw Abort(.badRequest, reason: "Missing or invalid width parameter")
+        }
+
+        // 404 if exec instance never existed; 200 (no-op) if it ran and already exited.
+        guard await ExecManager.shared.get(id: execId) != nil else {
+            throw Abort(.notFound, reason: "No such exec instance: \(execId)")
+        }
+
+        if let process = await ProcessRegistry.shared.get(id: execId) {
+            let size = Terminal.Size(width: UInt16(min(w, Int(UInt16.max))), height: UInt16(min(h, Int(UInt16.max))))
+            try? await process.resize(size)
+        }
+
+        return Response(status: .ok)
     }
 }

--- a/Sources/socktainer/Utilities/ProcessRegistry.swift
+++ b/Sources/socktainer/Utilities/ProcessRegistry.swift
@@ -1,0 +1,22 @@
+import ContainerAPIClient
+
+/// Shared registry of running ClientProcess instances keyed by container or exec ID.
+/// Allows the resize routes to forward terminal size changes to the active process
+/// without threading the process reference through the HTTP layer.
+actor ProcessRegistry {
+    static let shared = ProcessRegistry()
+
+    private var processes: [String: any ClientProcess] = [:]
+
+    func set(id: String, process: any ClientProcess) {
+        processes[id] = process
+    }
+
+    func get(id: String) -> (any ClientProcess)? {
+        processes[id]
+    }
+
+    func remove(id: String) {
+        processes.removeValue(forKey: id)
+    }
+}

--- a/Tests/socktainerTests/Routes/ExecResizeRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ExecResizeRouteTests.swift
@@ -1,0 +1,113 @@
+import ContainerAPIClient
+import ContainerResource
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Unit tests for POST /exec/{id}/resize.
+///
+/// The process.resize() call requires a live Apple Container process and is
+/// validated via integration testing (POST .../resize?h=50&w=120 → 200 against
+/// a running container). These tests cover the parameter validation and exec-ID
+/// lookup that are unit-testable without infrastructure.
+@Suite("ExecResizeRoute")
+struct ExecResizeRouteTests {
+
+    @Test("unknown exec ID returns 404")
+    func unknownExecIdReturns404() async throws {
+        try await withExecRouteApp { app in
+            try await app.testing().test(
+                .POST,
+                "/v1.51/exec/nonexistent-id/resize?h=40&w=120"
+            ) { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("missing height parameter returns 400")
+    func missingHeightReturns400() async throws {
+        try await withExecRouteApp { app in
+            try await app.testing().test(
+                .POST,
+                "/v1.51/exec/any-id/resize?w=120"
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("missing width parameter returns 400")
+    func missingWidthReturns400() async throws {
+        try await withExecRouteApp { app in
+            try await app.testing().test(
+                .POST,
+                "/v1.51/exec/any-id/resize?h=40"
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("known exec ID with no running process returns 200")
+    func knownExecIdNoProcessReturns200() async throws {
+        // Register an exec so ExecManager.shared.get() returns non-nil,
+        // but leave ProcessRegistry empty (simulates: exec ran and exited).
+        let config = ExecManager.ExecConfig(
+            containerId: "test-ctr",
+            cmd: ["sh"],
+            attachStdin: false,
+            attachStdout: true,
+            attachStderr: true,
+            tty: true,
+            detach: false,
+            env: [],
+            user: nil,
+            workingDir: nil
+        )
+        let execId = await ExecManager.shared.create(config: config)
+        defer { Task { await ExecManager.shared.remove(id: execId) } }
+
+        try await withExecRouteApp { app in
+            try await app.testing().test(
+                .POST,
+                "/v1.51/exec/\(execId)/resize?h=40&w=120"
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func withExecRouteApp(
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        try app.register(collection: ExecRoute(client: NullContainerMock()))
+        try await test(app)
+    }
+}
+
+private struct NullContainerMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (
+        deletedContainers: [String], spaceReclaimed: Int64
+    ) { ([], 0) }
+}


### PR DESCRIPTION
## Summary

\`POST /containers/{id}/resize\` was stubbed — it returned 200 without forwarding the new dimensions to the running process. \`POST /exec/{id}/resize\` was not registered at all.

## Related Issue

Partial progress toward #120 (devcontainer / interactive TTY support).

> **Note on TTY scope:** resize is wired and functional. Full interactive PTY sessions (e.g. \`vim\`, readline-based shells) still require a deeper rework: when \`Tty: true\`, bootstrapping with pipe fds gives the container a pipe on stdin rather than a real pseudo-terminal. \`docker exec -it sh -c 'echo hi'\` works; an interactive \`sh\` waiting for typed input does not. That is a separate effort.

## Changes

- **\`ProcessRegistry.swift\`** — new shared actor that stores \`any ClientProcess\` references keyed by container or exec ID, allowing resize routes to reach the active process without threading it through the HTTP layer
- **\`ContainerResizeRoute.swift\`** — implements actual \`process.resize(Terminal.Size(width:height:))\` call; silently no-ops when no process is registered (not yet started / already exited), matching Docker's behaviour
- **\`ContainerAttachRoute.swift\`** — register process after \`process.start()\`, deregister in both HTTP streaming and TCP upgrade process monitor tasks
- **\`ExecRoutes.swift\`** — register/deregister process in both HTTP and TCP paths; add \`POST /exec/{id}/resize\` route

## Testing

- [x] \`make fmt\` passes
- [x] \`make test\` passes (214 tests)
- [x] End-to-end: \`POST /containers/.../resize?h=50&w=120\` → 200 ✅
- [x] End-to-end: \`POST /exec/.../resize?h=50&w=120\` → 200 ✅
- [x] \`docker run -it alpine sh -c 'echo TTY_WORKS'\` → output received ✅
- [x] \`docker exec -it <ctr> sh -c 'echo EXEC_TTY_WORKS'\` → output received ✅

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))