### PR TITLE
fix(events,volumes): populate image delete event 'from' field; support negative volume prune filter

### DIFF
--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -31,7 +31,9 @@ struct ClientVolumeService: ClientVolumeProtocol {
         let volumes = results.map { Self.convert($0) }
         var parsedFilters: [String: [String]] = [:]
         var labelDictFilter: [String: Any]? = nil
-        if let filters = filters, !filters.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, filters.trimmingCharacters(in: .whitespacesAndNewlines) != "{}" {
+        if let filters = filters, !filters.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            filters.trimmingCharacters(in: .whitespacesAndNewlines) != "{}"
+        {
             guard let data = filters.data(using: .utf8),
                 let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
             else {
@@ -52,11 +54,19 @@ struct ClientVolumeService: ClientVolumeProtocol {
                 }
             }
         }
-        if parsedFilters.isEmpty {
+        return Self.applyFilters(volumes, parsedFilters: parsedFilters, labelDictFilter: labelDictFilter)
+    }
+
+    /// Applies parsed volume filters to a list of volumes.
+    static func applyFilters(
+        _ volumes: [Volume],
+        parsedFilters: [String: [String]],
+        labelDictFilter: [String: Any]? = nil
+    ) -> [Volume] {
+        if parsedFilters.isEmpty && labelDictFilter == nil {
             return volumes
         }
-        // Filtering logic
-        let filteredVolumes = volumes.filter { volume in
+        return volumes.filter { volume in
             var matches = true
             if let names = parsedFilters["name"], !names.isEmpty {
                 matches = matches && names.contains(where: { volume.Name.contains($0) })
@@ -75,24 +85,33 @@ struct ClientVolumeService: ClientVolumeProtocol {
                 }
                 matches = matches && labelMatches
             }
+            // label! key = negative label filter (docker volume prune --filter label!=key)
+            if let negLabels = parsedFilters["label!"], !negLabels.isEmpty {
+                let volumeLabels = volume.Labels ?? [:]
+                let negMatches = negLabels.allSatisfy { labelFilter in
+                    guard let eqIdx = labelFilter.firstIndex(of: "=") else {
+                        return !LabelNormalization.filterContainsKey(labelFilter, in: volumeLabels)
+                    }
+                    let key = String(labelFilter[..<eqIdx])
+                    let value = String(labelFilter[labelFilter.index(after: eqIdx)...])
+                    return LabelNormalization.filterValue(in: volumeLabels, forKey: key) != value
+                }
+                matches = matches && negMatches
+            }
             if let labelDict = labelDictFilter, let volumeLabels = volume.Labels {
                 let labelMatches = labelDict.allSatisfy { (key, value) in
                     if let volumeValue = volumeLabels[key] {
-                        // Compare as string
                         return String(describing: volumeValue) == String(describing: value)
                     }
                     return false
                 }
                 matches = matches && labelMatches
             }
-            // NOTE: we currently have no mechanism to correlate volumes
-            //       to containers.
+            // NOTE: we currently have no mechanism to correlate volumes to containers.
             // Filter by dangling (not referenced by any container)
-            // if let dangling = parsedFilters["dangling"], !dangling.isEmpty {
-            // }
+            // if let dangling = parsedFilters["dangling"], !dangling.isEmpty { }
             return matches
         }
-        return filteredVolumes
     }
 
     func inspect(name: String) async throws -> Volume {

--- a/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
@@ -32,7 +32,7 @@ extension ImageDeleteRoute {
 
             // Optional: broadcast event
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-            let event = DockerEvent.simpleEvent(id: imageRef, type: "image", status: "remove")
+            let event = DockerEvent.simpleEvent(id: imageRef, type: "image", status: "remove", image: imageRef)
             await broadcaster.broadcast(event)
 
             let deleteResponse = [

--- a/Sources/socktainer/Utilities/DockerFilterUtility.swift
+++ b/Sources/socktainer/Utilities/DockerFilterUtility.swift
@@ -138,7 +138,8 @@ struct DockerContainerFilterUtility {
 // utility for parsing volume filters from query string
 struct DockerVolumeFilterUtility {
     static func parsePruneFilters(filtersParam: String?, logger: Logger) throws -> [String: [String]] {
-        let allowedKeys: Set<String> = ["label", "all"]
+        // "label!" is the key Docker CLI sends for --filter label!=key (negative match).
+        let allowedKeys: Set<String> = ["label", "label!", "all"]
         var filters: [String: Any] = [:]
         var parsedFilters: [String: [String]] = [:]
         if let filtersParam = filtersParam, let data = filtersParam.data(using: .utf8) {

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -1,0 +1,81 @@
+import ContainerAPIClient
+import ContainerizationOCI
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+@Suite("ImageDeleteRoute — event 'from' field")
+struct ImageDeleteEventTests {
+
+    @Test("image delete event carries image reference in 'from' field")
+    func imageDeleteEventPopulatesFromField() async throws {
+        let imageRef = "alpine:latest"
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "remove" && event.Type == "image" {
+                return event
+            }
+            return nil
+        }
+
+        try await withImageRouteApp(broadcaster: broadcaster) { app in
+            try await app.testing().test(
+                .DELETE,
+                "/v1.51/images/\(imageRef)"
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        captureTask.cancel()  // unblock the for-await if the event was never emitted
+        let event = await captureTask.value
+        #expect(event?.from == imageRef)
+        #expect(event?.Actor.Attributes["image"] == imageRef)
+    }
+}
+
+// MARK: - Helpers
+
+private func withImageRouteApp(
+    broadcaster: EventBroadcaster,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = broadcaster
+        try app.register(collection: ImageDeleteRoute(client: ImageDeleteMock()))
+        try await test(app)
+    }
+}
+
+private struct ImageDeleteMock: ClientImageProtocol {
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws {}
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
+        -> AsyncThrowingStream<String, Error>
+    {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws
+        -> AsyncThrowingStream<String, Error>
+    {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (
+        deletedImages: [String], spaceReclaimed: Int64
+    ) { ([], 0) }
+    func load(
+        tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> [String] { [] }
+    func save(
+        references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> URL { URL(fileURLWithPath: "/tmp") }
+}

--- a/Tests/socktainerTests/Routes/ExecResizeRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ExecResizeRouteTests.swift
@@ -8,10 +8,9 @@ import VaporTesting
 
 /// Unit tests for POST /exec/{id}/resize.
 ///
-/// The process.resize() call requires a live Apple Container process and is
-/// validated via integration testing (POST .../resize?h=50&w=120 → 200 against
-/// a running container). These tests cover the parameter validation and exec-ID
-/// lookup that are unit-testable without infrastructure.
+/// The process.resize() call requires a live Apple Container process.
+/// These tests cover the parameter validation and exec-ID lookup that
+/// are unit-testable without infrastructure.
 @Suite("ExecResizeRoute")
 struct ExecResizeRouteTests {
 

--- a/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
@@ -1,0 +1,95 @@
+import Logging
+import Testing
+
+@testable import socktainer
+
+@Suite("Volume prune — negative label filter")
+struct VolumePruneFilterTests {
+
+    private let logger = Logger(label: "test")
+
+    // MARK: - parsePruneFilters: label! accepted
+
+    @Test("label! key is accepted and preserved in parsed filters")
+    func labelBangKeyAccepted() throws {
+        let json = #"{"label!": ["env=prod"]}"#
+        let filters = try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: json, logger: logger)
+        #expect(filters["label!"] == ["env=prod"])
+    }
+
+    @Test("label! and label keys can coexist")
+    func labelBangAndLabelCoexist() throws {
+        let json = #"{"label": ["tier=web"], "label!": ["env=dev"]}"#
+        let filters = try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: json, logger: logger)
+        #expect(filters["label"] == ["tier=web"])
+        #expect(filters["label!"] == ["env=dev"])
+    }
+
+    @Test("unknown filter key still rejected")
+    func unknownKeyRejected() throws {
+        let json = #"{"unknown": ["value"]}"#
+        #expect(throws: (any Error).self) {
+            try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: json, logger: logger)
+        }
+    }
+
+    // MARK: - Negative label matching via ClientVolumeService.applyFilters
+
+    @Test("label!=key=value: volume matching the negated label is excluded")
+    func volumeMatchingNegLabelExcluded() {
+        let volumes = [
+            makeVolume(name: "vol-prod", labels: ["env": "prod"]),
+            makeVolume(name: "vol-dev", labels: ["env": "dev"]),
+            makeVolume(name: "vol-unlabeled"),
+        ]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env=prod"]])
+        let names = result.map(\.Name).sorted()
+        #expect(names == ["vol-dev", "vol-unlabeled"])
+        #expect(!names.contains("vol-prod"))
+    }
+
+    @Test("label!=key=value: volume not matching the negated label is included")
+    func volumeNotMatchingNegLabelIncluded() {
+        let volumes = [makeVolume(name: "vol-dev", labels: ["env": "dev"])]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env=prod"]])
+        #expect(result.map(\.Name) == ["vol-dev"])
+    }
+
+    @Test("label!=key=value: unlabeled volume is included")
+    func unlabeledVolumeIncluded() {
+        let volumes = [makeVolume(name: "vol-none")]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env=prod"]])
+        #expect(result.map(\.Name) == ["vol-none"])
+    }
+
+    @Test("label!=key (key-only): volume without key is included")
+    func volumeWithoutKeyIncluded() {
+        let volumes = [makeVolume(name: "vol-other", labels: ["tier": "web"])]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env"]])
+        #expect(result.map(\.Name) == ["vol-other"])
+    }
+
+    @Test("label!=key (key-only): volume with key is excluded")
+    func volumeWithKeyExcluded() {
+        let volumes = [makeVolume(name: "vol-env", labels: ["env": "anything"])]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env"]])
+        #expect(result.isEmpty)
+    }
+}
+
+// MARK: - Helpers
+
+private func makeVolume(name: String, labels: [String: String]? = nil) -> Volume {
+    Volume(
+        Name: name,
+        Driver: "local",
+        Mountpoint: "/var/lib/docker/volumes/\(name)/_data",
+        CreatedAt: nil,
+        Status: nil,
+        Labels: labels,
+        Scope: "local",
+        ClusterVolume: nil,
+        Options: [:],
+        UsageData: nil
+    )
+}


### PR DESCRIPTION
## Summary

Two small independent fixes.

**1. Image delete event \`from\` field was empty**
\`ImageDeleteRoute\` was not passing \`image:\` to \`simpleEvent()\`, so \`DockerEvent.from\` was always \`""\` for image remove events. Fixed by passing \`image: imageRef\`.

**2. \`docker volume prune --filter label!=key\` returned 400** — closes #59

Docker CLI sends negative label filters using \`"label!"\` as the JSON key (not \`"label"\` with a \`!=\` value). \`parsePruneFilters\` rejected it as an unknown key. Fixed in two places:
- \`DockerFilterUtility\`: allow \`"label!"\` in \`allowedKeys\`
- \`ClientVolumeService.list()\`: apply negative label matching for \`"label!"\` entries — mirrors the \`!=\` logic already present in container list filtering

## Changes

- \`ImageDeleteRoute.swift\` — pass \`image: imageRef\` to \`simpleEvent\`
- \`DockerFilterUtility.swift\` — add \`"label!"\` to \`parsePruneFilters\` allowedKeys
- \`ClientVolumeService.swift\` — handle \`"label!"\` negative filter in list()
- \`ImageDeleteEventTests.swift\` — verifies \`from\` field equals image reference
- \`VolumePruneFilterTests.swift\` — 7 tests: parser acceptance, regression guard for unknown keys, 5 predicate cases (key-only and key=value negation)

## Testing

- [x] \`make fmt\` passes
- [x] \`make test\` passes (223 tests)
- [x] End-to-end: \`docker volume prune --force --filter "label!=env=prod"\`
  - Before: vol-dev, vol-prod, vol-unlabeled
  - After:  vol-prod ✅ (only the matching volume survived)
- [x] Key-only negation: \`--filter "label!=env"\` → both labeled volumes survive, unlabeled volume is pruned ✅

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))