### PR TITLE
feat(info): expose Apple container system properties in GET /info Labels

### DIFF
--- a/Sources/socktainer/Routes/Server/InfoRoute.swift
+++ b/Sources/socktainer/Routes/Server/InfoRoute.swift
@@ -1,55 +1,137 @@
 import ContainerAPIClient
+import ContainerPersistence
 import ContainerResource
 import Vapor
 
 struct InfoRoute: RouteCollection {
+    let containerClient: ClientContainerProtocol
     let imageClient: ClientImageProtocol
+    let configLoader: @Sendable () async throws -> ContainerSystemConfig
+    let systemHealthProvider: @Sendable () async throws -> (dockerRootDir: String, serverVersion: String)
+    let kernelNameProvider: @Sendable () async throws -> String
 
-    func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/info", use: InfoRoute.handler(imageClient: imageClient))
+    init(
+        containerClient: ClientContainerProtocol,
+        imageClient: ClientImageProtocol,
+        configLoader: @Sendable @escaping () async throws -> ContainerSystemConfig = {
+            try await ConfigurationLoader.load()
+        },
+        systemHealthProvider: @Sendable @escaping () async throws -> (dockerRootDir: String, serverVersion: String) = {
+            let health = try await ClientHealthCheck.ping()
+            return (health.appRoot.path, health.apiServerVersion)
+        },
+        kernelNameProvider: @Sendable @escaping () async throws -> String = {
+            try await getLinuxDefaultKernelName()
+        }
+    ) {
+        self.containerClient = containerClient
+        self.imageClient = imageClient
+        self.configLoader = configLoader
+        self.systemHealthProvider = systemHealthProvider
+        self.kernelNameProvider = kernelNameProvider
     }
 
-    static func handler(imageClient: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
-        { req in
-            do {
-                let containerClient = ClientContainerService()
-                let allContainers = try await containerClient.list(showAll: true, filters: [:])
-
-                let info = SystemInfo(
-                    Containers: allContainers.count,
-                    ContainersRunning: allContainers.filter { $0.status == RuntimeStatus.running }.count,
-                    // Apple container doesn't support pausing containers
-                    ContainersPaused: 0,
-                    ContainersStopped: allContainers.filter { $0.status == RuntimeStatus.stopped }.count,
-                    Images: try await imageClient.list().count,
-                    DockerRootDir: try await ClientHealthCheck.ping().appRoot.path,
-                    Debug: isDebug(),
-                    KernelVersion: try await getLinuxDefaultKernelName(),
-                    OSVersion: currentPlatform().osVersion ?? nil,
-                    OSType: currentPlatform().os,
-                    Architecture: currentPlatform().architecture,
-                    NCPU: hostCPUCoreCount(),
-                    MemTotal: Int64(hostPhysicalMemory()),
-                    HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,
-                    HttpsProxy: ProcessInfo.processInfo.environment["HTTPS_PROXY"] ?? nil,
-                    NoProxy: ProcessInfo.processInfo.environment["NO_PROXY"] ?? nil,
-                    Name: hostName(),
-                    ExperimentalBuild: true,
-                    ServerVersion: try await ClientHealthCheck.ping().apiServerVersion,
-                    ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
-                    SystemTime: currentTime(),
-                    Warnings: [
-                        "WARNING: Apple container system info may differ",
-                        "NOTE: socktainer is still under active development and considered experimental!",
-                    ],
-                )
-                return try await info.encodeResponse(for: req)
-            } catch {
-                let response = Response(status: .internalServerError)
-                response.headers.add(name: .contentType, value: "application/json")
-                response.body = .init(string: "{\"message\": \"Failed to generate system information\"}\n")
-                return response
-            }
+    func boot(routes: RoutesBuilder) throws {
+        let containerClient = self.containerClient
+        let imageClient = self.imageClient
+        let configLoader = self.configLoader
+        let systemHealthProvider = self.systemHealthProvider
+        let kernelNameProvider = self.kernelNameProvider
+        try routes.registerVersionedRoute(.GET, pattern: "/info") { req in
+            try await InfoRoute.handle(
+                req,
+                containerClient: containerClient,
+                imageClient: imageClient,
+                configLoader: configLoader,
+                systemHealthProvider: systemHealthProvider,
+                kernelNameProvider: kernelNameProvider
+            )
         }
+    }
+
+    private static func handle(
+        _ req: Request,
+        containerClient: ClientContainerProtocol,
+        imageClient: ClientImageProtocol,
+        configLoader: @Sendable () async throws -> ContainerSystemConfig,
+        systemHealthProvider: @Sendable () async throws -> (dockerRootDir: String, serverVersion: String),
+        kernelNameProvider: @Sendable () async throws -> String
+    ) async throws -> Response {
+        do {
+            let allContainers = try await containerClient.list(showAll: true, filters: [:])
+
+            // Falls back to defaults if config.toml is missing or malformed — non-fatal for /info
+            let systemConfig = try await loadSystemConfig(using: configLoader, logger: req.logger)
+
+            let health = try await systemHealthProvider()
+
+            let info = SystemInfo(
+                Containers: allContainers.count,
+                ContainersRunning: allContainers.filter { $0.status == RuntimeStatus.running }.count,
+                // Apple container doesn't support pausing containers
+                ContainersPaused: 0,
+                ContainersStopped: allContainers.filter { $0.status == RuntimeStatus.stopped }.count,
+                Images: try await imageClient.list().count,
+                DockerRootDir: health.dockerRootDir,
+                Debug: isDebug(),
+                KernelVersion: try await kernelNameProvider(),
+                OSVersion: currentPlatform().osVersion ?? nil,
+                OSType: currentPlatform().os,
+                Architecture: currentPlatform().architecture,
+                NCPU: hostCPUCoreCount(),
+                MemTotal: Int64(hostPhysicalMemory()),
+                HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,
+                HttpsProxy: ProcessInfo.processInfo.environment["HTTPS_PROXY"] ?? nil,
+                NoProxy: ProcessInfo.processInfo.environment["NO_PROXY"] ?? nil,
+                Name: hostName(),
+                Labels: systemPropertyLabels(config: systemConfig),
+                ExperimentalBuild: true,
+                ServerVersion: health.serverVersion,
+                ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
+                SystemTime: currentTime(),
+                Warnings: [
+                    "WARNING: Apple container system info may differ",
+                    "NOTE: socktainer is still under active development and considered experimental!",
+                ],
+            )
+            return try await info.encodeResponse(for: req)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            req.logger.error("InfoRoute handler failed: \(error)")
+            let response = Response(status: .internalServerError)
+            response.headers.add(name: .contentType, value: "application/json")
+            response.body = .init(string: "{\"message\": \"Failed to generate system information\"}\n")
+            return response
+        }
+    }
+
+    /// Loads the system config, falling back to defaults when `config.toml` is missing or malformed.
+    /// Cancellation is rethrown so request cancellation is not masked by the fallback.
+    static func loadSystemConfig(
+        using configLoader: @Sendable () async throws -> ContainerSystemConfig,
+        logger: Logger
+    ) async throws -> ContainerSystemConfig {
+        do {
+            return try await configLoader()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.warning("Failed to load system config, using defaults: \(error)")
+            return ContainerSystemConfig()
+        }
+    }
+
+    static func systemPropertyLabels(config: ContainerSystemConfig) -> [String] {
+        [
+            "build.rosetta=\(config.build.rosetta)",
+            "dns.domain=\(config.dns.domain ?? "*undefined*")",
+            "image.builder=\(config.build.image)",
+            "image.init=\(config.vminit.image)",
+            "kernel.binaryPath=\(config.kernel.binaryPath)",
+            "kernel.url=\(config.kernel.url.absoluteString)",
+            "network.subnet=\(config.network.subnet?.description ?? "*undefined*")",
+            "registry.domain=\(config.registry.domain)",
+        ]
     }
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -42,7 +42,7 @@ func configure(_ app: Application) async throws {
     try app.register(collection: HealthCheckPingRoute(client: healthCheckClient))
 
     // /info
-    try app.register(collection: InfoRoute(imageClient: imageClient))
+    try app.register(collection: InfoRoute(containerClient: containerClient, imageClient: imageClient))
 
     // /events
     try app.register(collection: EventsRoute(client: healthCheckClient))

--- a/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
@@ -1,0 +1,187 @@
+import ContainerAPIClient
+import ContainerPersistence
+import ContainerResource
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+// MARK: - Mocks
+
+private struct DummyError: Error {}
+
+private struct ThrowingContainerClient: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] {
+        throw DummyError()
+    }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+private struct EmptyContainerClient: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+private struct StubImageClient: ClientImageProtocol {
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws {}
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (deletedImages: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        URL(fileURLWithPath: "/dev/null")
+    }
+}
+
+// MARK: - loadSystemConfig
+
+@Suite("InfoRoute.loadSystemConfig")
+struct InfoRouteLoadSystemConfigTests {
+    private let logger = Logger(label: "test")
+
+    @Test("Returns the loaded config on success")
+    func returnsLoadedConfig() async throws {
+        let loaded = ContainerSystemConfig(registry: .init(domain: "ghcr.io"))
+        let config = try await InfoRoute.loadSystemConfig(using: { loaded }, logger: logger)
+        #expect(config.registry.domain == "ghcr.io")
+    }
+
+    @Test("Falls back to defaults when loading fails")
+    func fallsBackOnError() async throws {
+        let config = try await InfoRoute.loadSystemConfig(using: { throw DummyError() }, logger: logger)
+        #expect(config.registry.domain == ContainerSystemConfig().registry.domain)
+    }
+
+    @Test("Rethrows CancellationError instead of swallowing it")
+    func rethrowsCancellation() async throws {
+        await #expect(throws: CancellationError.self) {
+            try await InfoRoute.loadSystemConfig(using: { throw CancellationError() }, logger: logger)
+        }
+    }
+}
+
+// MARK: - Route error path
+
+@Suite("InfoRoute GET /info error handling")
+struct InfoRouteErrorPathTests {
+
+    private func withRoute(_ test: @escaping (Application) async throws -> Void) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(
+                collection: InfoRoute(
+                    containerClient: ThrowingContainerClient(),
+                    imageClient: StubImageClient(),
+                    configLoader: { ContainerSystemConfig() }
+                ))
+            try await test(app)
+        }
+    }
+
+    @Test("Returns 500 with the documented JSON body when a dependency throws")
+    func returns500OnFailure() async throws {
+        try await withRoute { app in
+            try await app.testing().test(.GET, "/info") { res async in
+                #expect(res.status == .internalServerError)
+                #expect(res.headers.first(name: .contentType) == "application/json")
+                #expect(res.body.string == "{\"message\": \"Failed to generate system information\"}\n")
+            }
+        }
+    }
+}
+
+// MARK: - Route label wiring
+
+private struct InfoResponseBody: Decodable {
+    let Labels: [String]
+}
+
+@Suite("InfoRoute GET /info label wiring")
+struct InfoRouteLabelWiringTests {
+
+    private func withRoute(
+        configLoader: @escaping @Sendable () async throws -> ContainerSystemConfig,
+        test: @escaping (Application) async throws -> Void
+    ) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(
+                collection: InfoRoute(
+                    containerClient: EmptyContainerClient(),
+                    imageClient: StubImageClient(),
+                    configLoader: configLoader,
+                    systemHealthProvider: { (dockerRootDir: "/tmp/app-root", serverVersion: "9.9.9") },
+                    kernelNameProvider: { "vmlinux-test" }
+                ))
+            try await test(app)
+        }
+    }
+
+    @Test("Response body includes all 8 system property labels with configured values")
+    func bodyIncludesConfiguredLabels() async throws {
+        let config = ContainerSystemConfig(dns: .init(domain: "test.local"), registry: .init(domain: "ghcr.io"))
+        try await withRoute(configLoader: { config }) { app in
+            try await app.testing().test(.GET, "/info") { res async in
+                #expect(res.status == .ok)
+                let labels = (try? JSONDecoder().decode(InfoResponseBody.self, from: res.body))?.Labels ?? []
+                let keys = Set(labels.map { $0.components(separatedBy: "=").first ?? "" })
+                #expect(
+                    keys == [
+                        "build.rosetta", "dns.domain", "image.builder", "image.init",
+                        "kernel.binaryPath", "kernel.url", "network.subnet", "registry.domain",
+                    ])
+                #expect(labels.contains("dns.domain=test.local"))
+                #expect(labels.contains("registry.domain=ghcr.io"))
+            }
+        }
+    }
+
+    @Test("Labels fall back to defaults when config loading fails")
+    func bodyFallsBackWhenConfigFails() async throws {
+        try await withRoute(configLoader: { throw DummyError() }) { app in
+            try await app.testing().test(.GET, "/info") { res async in
+                #expect(res.status == .ok)
+                let labels = (try? JSONDecoder().decode(InfoResponseBody.self, from: res.body))?.Labels ?? []
+                #expect(labels == InfoRoute.systemPropertyLabels(config: ContainerSystemConfig()))
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/Server/SystemPropertyLabelsTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemPropertyLabelsTests.swift
@@ -1,0 +1,88 @@
+import ContainerPersistence
+import ContainerizationExtras
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("InfoRoute.systemPropertyLabels")
+struct SystemPropertyLabelsTests {
+
+    @Test("Produces all 8 expected label keys with default config")
+    func defaultConfigHasAllKeys() {
+        let labels = InfoRoute.systemPropertyLabels(config: ContainerSystemConfig())
+        let keySet = Set(labels.map { $0.components(separatedBy: "=").first ?? "" })
+        #expect(
+            keySet == [
+                "build.rosetta", "dns.domain", "image.builder", "image.init",
+                "kernel.binaryPath", "kernel.url", "network.subnet", "registry.domain",
+            ])
+    }
+
+    @Test("build.rosetta reflects the Bool value", arguments: [true, false])
+    func buildRosettaValue(rosetta: Bool) {
+        let config = ContainerSystemConfig(build: .init(rosetta: rosetta))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("build.rosetta=\(rosetta)"))
+    }
+
+    @Test("dns.domain shows *undefined* when nil")
+    func dnsDomainNil() {
+        let config = ContainerSystemConfig(dns: .init(domain: nil))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("dns.domain=*undefined*"))
+    }
+
+    @Test("dns.domain shows the value when set")
+    func dnsDomainSet() {
+        let config = ContainerSystemConfig(dns: .init(domain: "containers.local"))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("dns.domain=containers.local"))
+    }
+
+    @Test("network.subnet shows *undefined* when nil")
+    func networkSubnetNil() {
+        let config = ContainerSystemConfig(network: .init(subnet: nil))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("network.subnet=*undefined*"))
+    }
+
+    @Test("network.subnet shows CIDR notation when set")
+    func networkSubnetSet() throws {
+        let subnet = try CIDRv4("192.168.100.0/24")
+        let config = ContainerSystemConfig(network: .init(subnet: subnet))
+        #expect(
+            InfoRoute.systemPropertyLabels(config: config).contains("network.subnet=192.168.100.0/24"))
+    }
+
+    @Test("registry.domain reflects a configured value")
+    func registryDomain() {
+        let config = ContainerSystemConfig(registry: .init(domain: "ghcr.io"))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("registry.domain=ghcr.io"))
+    }
+
+    @Test("image.builder reflects a custom value")
+    func imageBuilderCustom() {
+        let config = ContainerSystemConfig(build: .init(image: "my-builder:v1"))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("image.builder=my-builder:v1"))
+    }
+
+    @Test("image.init reflects a custom value")
+    func imageInitCustom() {
+        let config = ContainerSystemConfig(vminit: .init(image: "my-vminit:v1"))
+        #expect(InfoRoute.systemPropertyLabels(config: config).contains("image.init=my-vminit:v1"))
+    }
+
+    @Test("kernel.binaryPath reflects a custom value")
+    func kernelBinaryPathCustom() {
+        let config = ContainerSystemConfig(kernel: .init(binaryPath: "opt/my/kernel/vmlinux"))
+        #expect(
+            InfoRoute.systemPropertyLabels(config: config).contains(
+                "kernel.binaryPath=opt/my/kernel/vmlinux"))
+    }
+
+    @Test("kernel.url uses absoluteString serialisation")
+    func kernelURLAbsoluteString() {
+        let url = URL(string: "https://example.com/kernel.tar.zst")!
+        let config = ContainerSystemConfig(kernel: .init(url: url))
+        #expect(
+            InfoRoute.systemPropertyLabels(config: config).contains(
+                "kernel.url=https://example.com/kernel.tar.zst"))
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces all 8 Apple container system properties (`build.rosetta`, `dns.domain`, `image.builder`, `image.init`, `kernel.binaryPath`, `kernel.url`, `network.subnet`, `registry.domain`) in the `GET /info` response `Labels` field, reading from the user's actual `config.toml` rather than hardcoded defaults. Keys match the names shown by `container system property list`; undefined optional values render as `*undefined*`.

## Related Issue

Closes #144

## Changes

- `InfoRoute`: reads live config via `ConfigurationLoader.load()` with warning-logged fallback to defaults if `config.toml` is missing or malformed
- `InfoRoute`: `containerClient` and `imageClient` are now injected (matching `SystemDFRoute`'s pattern); `configLoader` is an injectable `@Sendable` closure for testability
- `InfoRoute`: adds error logging to the outer `catch` block
- `configure.swift`: wires `containerClient` and `imageClient` explicitly into `InfoRoute`
- New `systemPropertyLabels(config:)` pure static helper (testable without network/filesystem)
- 11 unit tests covering all 8 label keys, nil/set optionals, serialisation format, and custom values

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (277 tests)
- [x] Unit tests added (`Tests/socktainerTests/Routes/Server/SystemPropertyLabelsTests.swift`)
- [x] Manual: ran daemon with `registry.domain = "ghcr.io"` and `dns.domain = "test.local"` in `config.toml` — both reflected correctly in `docker info`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))