### PR TITLE
feat(config): propagate ContainerSystemConfig loaded from config.toml at startup

### DIFF
--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -52,19 +52,22 @@ struct ClientBuilderService: ClientBuilderProtocol {
     private let builderCPUs: Int64
     private let builderMemory: String
     private let appSupportURL: URL
+    private let containerSystemConfig: ContainerSystemConfig
 
     init(
         builderContainerId: String = "buildkit",
         builderPort: UInt32 = 8088,
         builderCPUs: Int64 = 2,
         builderMemory: String = "2048MB",
-        appSupportURL: URL
+        appSupportURL: URL,
+        containerSystemConfig: ContainerSystemConfig
     ) {
         self.builderContainerId = builderContainerId
         self.builderPort = builderPort
         self.builderCPUs = builderCPUs
         self.builderMemory = builderMemory
         self.appSupportURL = appSupportURL
+        self.containerSystemConfig = containerSystemConfig
     }
 
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {
@@ -205,11 +208,11 @@ struct ClientBuilderService: ClientBuilderProtocol {
             try FileManager.default.createDirectory(at: exportsMount, withIntermediateDirectories: true)
         }
 
-        let builderImage = BuildConfig.defaultImage
+        let builderImage = containerSystemConfig.build.image
         let builderPlatform = Platform(arch: "arm64", os: "linux", variant: "v8")
-        let useRosetta = BuildConfig.defaultRosetta
+        let useRosetta = containerSystemConfig.build.rosetta
 
-        let image = try await ClientImage.fetch(reference: builderImage, platform: builderPlatform, containerSystemConfig: ContainerSystemConfig())
+        let image = try await ClientImage.fetch(reference: builderImage, platform: builderPlatform, containerSystemConfig: containerSystemConfig)
         _ = try await image.getCreateSnapshot(platform: builderPlatform)
         let imageDesc = ImageDescription(reference: builderImage, descriptor: image.descriptor)
 

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -31,7 +31,11 @@ enum ClientImageError: Error {
 }
 
 struct ClientImageService: ClientImageProtocol {
-    private let containerSystemConfig = ContainerSystemConfig()
+    private let containerSystemConfig: ContainerSystemConfig
+
+    init(containerSystemConfig: ContainerSystemConfig) {
+        self.containerSystemConfig = containerSystemConfig
+    }
 
     // Workaround for narrowing an unspecified push from all platforms to a single platform available.
     // This avoids container push failures caused by missing blobs for non local platforms.
@@ -79,7 +83,7 @@ struct ClientImageService: ClientImageProtocol {
         let filteredImages = allImages.filter { img in
             let ref = img.reference.trimmingCharacters(in: .whitespacesAndNewlines)
             let isDigest = ref.contains("@sha256:")
-            let isInfra = Utility.isInfraImage(name: ref, builderImage: BuildConfig.defaultImage, initImage: VminitConfig.defaultImage)
+            let isInfra = Utility.isInfraImage(name: ref, builderImage: containerSystemConfig.build.image, initImage: containerSystemConfig.vminit.image)
             return isDigest || !isInfra
         }
         return filteredImages

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -30,13 +30,15 @@ actor NetworkDNSManager {
 
     private let appSupportURL: URL
     private let dnsPort: Int
+    private let containerSystemConfig: ContainerSystemConfig
     private var containerIPs: [String: String] = [:]  // networkId → CoreDNS container IP
     private var pendingCreation: [String: Task<String, Error>] = [:]
     private var log = Logger(label: "socktainer.dns.manager")
 
-    init(appSupportURL: URL, dnsPort: Int = 2054) {
+    init(appSupportURL: URL, dnsPort: Int = 2054, containerSystemConfig: ContainerSystemConfig) {
         self.appSupportURL = appSupportURL
         self.dnsPort = dnsPort
+        self.containerSystemConfig = containerSystemConfig
     }
 
     // MARK: - Public API
@@ -57,8 +59,9 @@ actor NetworkDNSManager {
         log.info("[dns-manager] creating CoreDNS container for network \(networkId)")
         let appSupportURL = self.appSupportURL
         let dnsPort = self.dnsPort
+        let containerSystemConfig = self.containerSystemConfig
         let task = Task<String, Error> {
-            try await Self.createDNSContainerWork(networkId: networkId, appSupportURL: appSupportURL, dnsPort: dnsPort)
+            try await Self.createDNSContainerWork(networkId: networkId, appSupportURL: appSupportURL, dnsPort: dnsPort, containerSystemConfig: containerSystemConfig)
         }
         pendingCreation[networkId] = task
 
@@ -126,7 +129,7 @@ actor NetworkDNSManager {
     // MARK: - Private implementation
 
     /// Runs outside the actor's executor to avoid deadlock with the Task created in ensureDNSContainer.
-    private static func createDNSContainerWork(networkId: String, appSupportURL: URL, dnsPort: Int) async throws -> String {
+    private static func createDNSContainerWork(networkId: String, appSupportURL: URL, dnsPort: Int, containerSystemConfig: ContainerSystemConfig) async throws -> String {
         let containerClient = ContainerClient()
         // Sanitize to respect Apple Container's 64-char container ID limit
         let containerId = ContainerNameUtility.sanitize(containerPrefix + networkId)
@@ -157,7 +160,6 @@ actor NetworkDNSManager {
         try corefile.write(to: corefileURL, atomically: true, encoding: .utf8)
 
         // Pull CoreDNS image — arm64 native, no Rosetta needed
-        let containerSystemConfig = ContainerSystemConfig()
         let imageRef = try ClientImage.normalizeReference("docker.io/coredns/coredns:latest", containerSystemConfig: containerSystemConfig)
         let platform = Platform.current
         let image = try await ClientImage.fetch(reference: imageRef, platform: platform, containerSystemConfig: containerSystemConfig)

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -10,8 +10,10 @@ import Vapor
 
 struct ContainerCreateRoute: RouteCollection {
     let client: ClientContainerProtocol
+    let systemConfig: ContainerSystemConfig
+
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/containers/create", use: ContainerCreateRoute.handler(client: client))
+        try routes.registerVersionedRoute(.POST, pattern: "/containers/create", use: ContainerCreateRoute.handler(client: client, systemConfig: systemConfig))
     }
 
 }
@@ -52,7 +54,7 @@ struct CreateContainerRequest: Content {
 }
 
 extension ContainerCreateRoute {
-    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerCreate {
+    static func handler(client: ClientContainerProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> RESTContainerCreate {
         { req in
             let query = try req.query.decode(ContainerCreateQuery.self)
 
@@ -75,7 +77,7 @@ extension ContainerCreateRoute {
 
             // Check if image exists locally
             do {
-                _ = try await ClientImage.get(reference: body.Image, containerSystemConfig: ContainerSystemConfig())
+                _ = try await ClientImage.get(reference: body.Image, containerSystemConfig: systemConfig)
             } catch {
                 throw Abort(.notFound, reason: "No such image: \(body.Image)")
             }
@@ -90,7 +92,7 @@ extension ContainerCreateRoute {
                 img = try await ClientImage.fetch(
                     reference: body.Image,
                     platform: requestedPlatform,
-                    containerSystemConfig: ContainerSystemConfig()
+                    containerSystemConfig: systemConfig
                 )
                 // Case 2: image exists locally but may have been pulled as amd64
                 if requestedPlatform.architecture == "arm64",
@@ -110,7 +112,7 @@ extension ContainerCreateRoute {
                 img = try await ClientImage.fetch(
                     reference: body.Image,
                     platform: amd64,
-                    containerSystemConfig: ContainerSystemConfig()
+                    containerSystemConfig: systemConfig
                 )
                 requestedPlatform = amd64
             }
@@ -123,8 +125,8 @@ extension ContainerCreateRoute {
             let kernel = try await ClientKernel.getDefaultKernel(for: .current)
 
             let initImage = try await ClientImage.fetch(
-                reference: ContainerSystemConfig().vminit.image, platform: .current,
-                containerSystemConfig: ContainerSystemConfig()
+                reference: systemConfig.vminit.image, platform: .current,
+                containerSystemConfig: systemConfig
             )
 
             _ = try await initImage.getCreateSnapshot(

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -16,14 +16,16 @@ struct BuildRoute: RouteCollection {
 
     let client: ClientContainerProtocol
     let builderClient: ClientBuilderProtocol
+    let systemConfig: ContainerSystemConfig
 
-    init(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol) {
+    init(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig) {
         self.client = client
         self.builderClient = builderClient
+        self.systemConfig = systemConfig
     }
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/build", use: BuildRoute.handler(client: client, builderClient: builderClient))
+        try routes.registerVersionedRoute(.POST, pattern: "/build", use: BuildRoute.handler(client: client, builderClient: builderClient, systemConfig: systemConfig))
 
     }
 
@@ -104,7 +106,8 @@ extension BuildRoute {
         try writeHandle.write(contentsOf: terminator)
     }
 
-    static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol) -> @Sendable (Request) async throws -> Response {
+    static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> Response
+    {
         { req in
             var query = try req.query.decode(RESTBuildQuery.self)
 
@@ -262,6 +265,7 @@ extension BuildRoute {
                             memory: memory,
                             quiet: quiet,
                             builderClient: builderClient,
+                            systemConfig: systemConfig,
                             writer: writer,
                             logger: req.logger
                         )
@@ -337,6 +341,7 @@ extension BuildRoute {
         memory: Int,
         quiet: Bool,
         builderClient: ClientBuilderProtocol,
+        systemConfig: ContainerSystemConfig,
         writer: BodyStreamWriter,
         logger: Logger
     ) async throws {
@@ -453,7 +458,7 @@ extension BuildRoute {
             cacheIn: [],
             cacheOut: [],
             pull: pull,
-            containerSystemConfig: ContainerSystemConfig()
+            containerSystemConfig: systemConfig
         )
 
         sendStreamMessage(" ---> Starting build process")

--- a/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageHistoryRoute.swift
@@ -9,10 +9,10 @@ struct RESTImageHistoryQuery: Vapor.Content {
 }
 
 struct ImageHistoryRoute: RouteCollection {
-    let client: ClientImageProtocol
+    let systemConfig: ContainerSystemConfig
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/history", use: ImageHistoryRoute.handler(client: client))
+        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/history", use: ImageHistoryRoute.handler(systemConfig: systemConfig))
     }
 }
 
@@ -119,7 +119,7 @@ extension ImageHistoryRoute {
         throw Abort(.notFound, reason: "Image '\(requestedName)' not found")
     }
 
-    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> [RESTImageHistoryResponseItem] {
+    static func handler(systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> [RESTImageHistoryResponseItem] {
         { req in
             guard let refOrId = req.parameters.get("name") else {
                 throw Abort(.badRequest, reason: "Missing image name parameter")
@@ -133,11 +133,9 @@ extension ImageHistoryRoute {
                 preferredPlatform = nil
             }
 
-            _ = client
-
             let image: ClientImage
             do {
-                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: ContainerSystemConfig())
+                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: systemConfig)
             } catch {
                 throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
             }

--- a/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
@@ -10,10 +10,10 @@ struct RESTImageInspectQuery: Vapor.Content {
 }
 
 struct ImageInspectRoute: RouteCollection {
-    let client: ClientImageProtocol
+    let systemConfig: ContainerSystemConfig
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/json", use: ImageInspectRoute.handler(client: client))
+        try routes.registerVersionedRoute(.GET, pattern: "/images/{name:.*}/json", use: ImageInspectRoute.handler(systemConfig: systemConfig))
     }
 }
 
@@ -124,7 +124,7 @@ extension ImageInspectRoute {
         return try platformOrThrow(platformString)
     }
 
-    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> RESTImageInspect {
+    static func handler(systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> RESTImageInspect {
         { req in
             guard let refOrId = req.parameters.get("name") else {
                 throw Abort(.badRequest, reason: "Missing image name parameter")
@@ -136,11 +136,9 @@ extension ImageInspectRoute {
                 throw Abort(.internalServerError, reason: "Apple Container application support URL is not configured")
             }
 
-            _ = client
-
             let image: ClientImage
             do {
-                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: ContainerSystemConfig())
+                image = try await ClientImage.get(reference: refOrId, containerSystemConfig: systemConfig)
             } catch {
                 throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
             }

--- a/Sources/socktainer/Routes/Images/ImageTagRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageTagRoute.swift
@@ -3,8 +3,12 @@ import ContainerPersistence
 import Vapor
 
 struct ImageTagRoute: RouteCollection {
+    let systemConfig: ContainerSystemConfig
+
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/images/{name:.*}/tag", use: ImageTagRoute.handler)
+        try routes.registerVersionedRoute(.POST, pattern: "/images/{name:.*}/tag") { [systemConfig] req in
+            try await ImageTagRoute.handler(req, systemConfig: systemConfig)
+        }
     }
 }
 
@@ -14,7 +18,7 @@ struct RESTImageTagQuery: Vapor.Content {
 }
 
 extension ImageTagRoute {
-    static func handler(_ req: Request) async throws -> Response {
+    static func handler(_ req: Request, systemConfig: ContainerSystemConfig) async throws -> Response {
         guard let sourceImageName = req.parameters.get("name") else {
             throw Abort(.badRequest, reason: "Missing image name parameter")
         }
@@ -25,17 +29,16 @@ extension ImageTagRoute {
             throw Abort(.badRequest, reason: "repo parameter is required")
         }
 
-        let containerSystemConfig = ContainerSystemConfig()
         let targetReference = try {
             if let tag = query.tag, !tag.isEmpty {
-                return try ClientImage.normalizeReference("\(repo):\(tag)", containerSystemConfig: containerSystemConfig)
+                return try ClientImage.normalizeReference("\(repo):\(tag)", containerSystemConfig: systemConfig)
             }
-            return try ClientImage.normalizeReference(repo, containerSystemConfig: containerSystemConfig)
+            return try ClientImage.normalizeReference(repo, containerSystemConfig: systemConfig)
         }()
 
         let sourceImage: ClientImage
         do {
-            sourceImage = try await ClientImage.get(reference: sourceImageName, containerSystemConfig: containerSystemConfig)
+            sourceImage = try await ClientImage.get(reference: sourceImageName, containerSystemConfig: systemConfig)
         } catch {
             throw Abort(.notFound, reason: "No such image: \(sourceImageName)")
         }

--- a/Sources/socktainer/Routes/Server/InfoRoute.swift
+++ b/Sources/socktainer/Routes/Server/InfoRoute.swift
@@ -3,49 +3,53 @@ import ContainerResource
 import Vapor
 
 struct InfoRoute: RouteCollection {
+    let imageClient: ClientImageProtocol
+
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/info", use: InfoRoute.handler)
+        try routes.registerVersionedRoute(.GET, pattern: "/info", use: InfoRoute.handler(imageClient: imageClient))
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        do {
-            let containerClient = ClientContainerService()
-            let allContainers = try await containerClient.list(showAll: true, filters: [:])
+    static func handler(imageClient: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            do {
+                let containerClient = ClientContainerService()
+                let allContainers = try await containerClient.list(showAll: true, filters: [:])
 
-            let info = SystemInfo(
-                Containers: allContainers.count,
-                ContainersRunning: allContainers.filter { $0.status == RuntimeStatus.running }.count,
-                // Apple container doesn't support pausing containers
-                ContainersPaused: 0,
-                ContainersStopped: allContainers.filter { $0.status == RuntimeStatus.stopped }.count,
-                Images: try await ClientImageService().list().count,
-                DockerRootDir: try await ClientHealthCheck.ping().appRoot.path,
-                Debug: isDebug(),
-                KernelVersion: try await getLinuxDefaultKernelName(),
-                OSVersion: currentPlatform().osVersion ?? nil,
-                OSType: currentPlatform().os,
-                Architecture: currentPlatform().architecture,
-                NCPU: hostCPUCoreCount(),
-                MemTotal: Int64(hostPhysicalMemory()),
-                HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,
-                HttpsProxy: ProcessInfo.processInfo.environment["HTTPS_PROXY"] ?? nil,
-                NoProxy: ProcessInfo.processInfo.environment["NO_PROXY"] ?? nil,
-                Name: hostName(),
-                ExperimentalBuild: true,
-                ServerVersion: try await ClientHealthCheck.ping().apiServerVersion,
-                ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
-                SystemTime: currentTime(),
-                Warnings: [
-                    "WARNING: Apple container system info may differ",
-                    "NOTE: socktainer is still under active development and considered experimental!",
-                ],
-            )
-            return try await info.encodeResponse(for: req)
-        } catch {
-            let response = Response(status: .internalServerError)
-            response.headers.add(name: .contentType, value: "application/json")
-            response.body = .init(string: "{\"message\": \"Failed to generate system information\"}\n")
-            return response
+                let info = SystemInfo(
+                    Containers: allContainers.count,
+                    ContainersRunning: allContainers.filter { $0.status == RuntimeStatus.running }.count,
+                    // Apple container doesn't support pausing containers
+                    ContainersPaused: 0,
+                    ContainersStopped: allContainers.filter { $0.status == RuntimeStatus.stopped }.count,
+                    Images: try await imageClient.list().count,
+                    DockerRootDir: try await ClientHealthCheck.ping().appRoot.path,
+                    Debug: isDebug(),
+                    KernelVersion: try await getLinuxDefaultKernelName(),
+                    OSVersion: currentPlatform().osVersion ?? nil,
+                    OSType: currentPlatform().os,
+                    Architecture: currentPlatform().architecture,
+                    NCPU: hostCPUCoreCount(),
+                    MemTotal: Int64(hostPhysicalMemory()),
+                    HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,
+                    HttpsProxy: ProcessInfo.processInfo.environment["HTTPS_PROXY"] ?? nil,
+                    NoProxy: ProcessInfo.processInfo.environment["NO_PROXY"] ?? nil,
+                    Name: hostName(),
+                    ExperimentalBuild: true,
+                    ServerVersion: try await ClientHealthCheck.ping().apiServerVersion,
+                    ProductLicense: "socktainer [Apache License 2.0], Apple container [Apache License 2.0]",
+                    SystemTime: currentTime(),
+                    Warnings: [
+                        "WARNING: Apple container system info may differ",
+                        "NOTE: socktainer is still under active development and considered experimental!",
+                    ],
+                )
+                return try await info.encodeResponse(for: req)
+            } catch {
+                let response = Response(status: .internalServerError)
+                response.headers.add(name: .contentType, value: "application/json")
+                response.body = .init(string: "{\"message\": \"Failed to generate system information\"}\n")
+                return response
+            }
         }
     }
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -1,4 +1,6 @@
 import ContainerAPIClient
+import ContainerPersistence
+import ContainerizationError
 import Vapor
 
 struct AppleContainerAppSupportUrlKey: StorageKey {
@@ -11,14 +13,25 @@ func configure(_ app: Application) async throws {
     let folderPath = ("\(NSHomeDirectory())/Library/Application Support/com.apple.container")
     let appleContainerAppSupportUrl = URL(fileURLWithPath: folderPath)
 
+    let systemConfig: ContainerSystemConfig
+    do {
+        systemConfig = try await ConfigurationLoader.load()
+    } catch let err as ContainerizationError {
+        app.logger.error("System config is malformed — falling back to defaults. Fix your config.toml: \(err)")
+        systemConfig = ContainerSystemConfig()
+    } catch {
+        app.logger.warning("Failed to load system config at startup, using defaults: \(error)")
+        systemConfig = ContainerSystemConfig()
+    }
+
     let containerClient = ClientContainerService()
-    let imageClient = ClientImageService()
+    let imageClient = ClientImageService(containerSystemConfig: systemConfig)
     let healthCheckClient = ClientHealthCheckService()
     let networkClient = ClientNetworkService()
-    let volumeClinet = ClientVolumeService()
+    let volumeClient = ClientVolumeService()
     let registryClient = ClientRegistryService()
     let archiveClient = ClientArchiveService(appSupportPath: appleContainerAppSupportUrl)
-    let builderClient = ClientBuilderService(appSupportURL: appleContainerAppSupportUrl)
+    let builderClient = ClientBuilderService(appSupportURL: appleContainerAppSupportUrl, containerSystemConfig: systemConfig)
 
     // Create and install regex routing middleware with logging
     let regexRouter = app.regexRouter(with: app.logger)
@@ -29,7 +42,7 @@ func configure(_ app: Application) async throws {
     try app.register(collection: HealthCheckPingRoute(client: healthCheckClient))
 
     // /info
-    try app.register(collection: InfoRoute())
+    try app.register(collection: InfoRoute(imageClient: imageClient))
 
     // /events
     try app.register(collection: EventsRoute(client: healthCheckClient))
@@ -42,7 +55,7 @@ func configure(_ app: Application) async throws {
     try app.register(collection: ContainerAttachRoute(client: containerClient))
     try app.register(collection: ContainerAttachWSRoute())
     try app.register(collection: ContainerChangesRoute())
-    try app.register(collection: ContainerCreateRoute(client: containerClient))
+    try app.register(collection: ContainerCreateRoute(client: containerClient, systemConfig: systemConfig))
     try app.register(collection: ContainerDeleteRoute(client: containerClient))
     try app.register(collection: ContainerExportRoute())
     try app.register(collection: ContainerInspectRoute(client: containerClient))
@@ -64,23 +77,23 @@ func configure(_ app: Application) async throws {
 
     // /images
     try app.register(collection: ImageDeleteRoute(client: imageClient))
-    try app.register(collection: ImageHistoryRoute(client: imageClient))
+    try app.register(collection: ImageHistoryRoute(systemConfig: systemConfig))
     try app.register(collection: ImageListRoute(client: imageClient))
     try app.register(collection: ImagePruneRoute(client: imageClient))
     try app.register(collection: ImageCreateRoute(client: imageClient))
     try app.register(collection: ImagePushRoute(client: imageClient))
     try app.register(collection: ImageSearchRoute())
-    try app.register(collection: ImageInspectRoute(client: imageClient))
-    try app.register(collection: ImageTagRoute())
+    try app.register(collection: ImageInspectRoute(systemConfig: systemConfig))
+    try app.register(collection: ImageTagRoute(systemConfig: systemConfig))
     try app.register(collection: ImagesGetRoute(client: imageClient))
     try app.register(collection: ImagesLoadRoute(client: imageClient))
 
     // /volumes
-    try app.register(collection: VolumeCreateRoute(client: volumeClinet))
-    try app.register(collection: VolumeDeleteRoute(client: volumeClinet))
-    try app.register(collection: VolumeInspectRoute(client: volumeClinet))
-    try app.register(collection: VolumeListRoute(client: volumeClinet))
-    try app.register(collection: VolumePruneRoute(client: volumeClinet))
+    try app.register(collection: VolumeCreateRoute(client: volumeClient))
+    try app.register(collection: VolumeDeleteRoute(client: volumeClient))
+    try app.register(collection: VolumeInspectRoute(client: volumeClient))
+    try app.register(collection: VolumeListRoute(client: volumeClient))
+    try app.register(collection: VolumePruneRoute(client: volumeClient))
 
     // /swarm
     try app.register(collection: SwarmInitRoute())
@@ -102,7 +115,7 @@ func configure(_ app: Application) async throws {
 
     // --- build/distribution routes ---
     try app.register(collection: BuildPruneRoute(builderClient: builderClient))
-    try app.register(collection: BuildRoute(client: containerClient, builderClient: builderClient))
+    try app.register(collection: BuildRoute(client: containerClient, builderClient: builderClient, systemConfig: systemConfig))
     try app.register(collection: DistributionJsonRoute())
 
     // --- plugin routes ---
@@ -153,7 +166,7 @@ func configure(_ app: Application) async throws {
     // --- miscellaneous ---
     try app.register(collection: AuthRoute(client: registryClient))
     try app.register(collection: CommitRoute())
-    try app.register(collection: SystemDFRoute(imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClinet, builderClient: builderClient))
+    try app.register(collection: SystemDFRoute(imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient))
     try app.register(collection: VersionRoute())
 
     // Initialize broadcaster
@@ -181,7 +194,7 @@ func configure(_ app: Application) async throws {
     app.logger.notice("DNS server listening on port \(resolvedDNSPort)")
     app.storage[SocktainerDNSServerKey.self] = dnsServer
 
-    let dnsManager = NetworkDNSManager(appSupportURL: appleContainerAppSupportUrl, dnsPort: resolvedDNSPort)
+    let dnsManager = NetworkDNSManager(appSupportURL: appleContainerAppSupportUrl, dnsPort: resolvedDNSPort, containerSystemConfig: systemConfig)
     app.storage[NetworkDNSManagerKey.self] = dnsManager
 
     // Healthcheck executor: runs `HEALTHCHECK` probes inside containers and

--- a/Tests/socktainerTests/Utilitites/SystemConfigPropagationTests.swift
+++ b/Tests/socktainerTests/Utilitites/SystemConfigPropagationTests.swift
@@ -1,0 +1,57 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Testing
+
+@testable import socktainer
+
+/// Verifies that ContainerSystemConfig overrides are honoured by the apple/container
+/// normalizeReference logic that all image operations ultimately go through.
+@Suite("SystemConfig propagation")
+struct SystemConfigPropagationTests {
+
+    @Test("default registry.domain resolves unqualified references via docker.io")
+    func defaultRegistryResolvesToDockerIO() throws {
+        let config = ContainerSystemConfig()
+
+        let normalized = try ClientImage.normalizeReference("ubuntu", containerSystemConfig: config)
+
+        #expect(normalized.hasPrefix("docker.io/") || normalized.hasPrefix("registry-1.docker.io/"))
+    }
+
+    @Test("custom registry.domain is prepended to unqualified image references")
+    func customRegistryDomainPropagated() throws {
+        let config = ContainerSystemConfig(registry: .init(domain: "ghcr.io"))
+
+        let normalized = try ClientImage.normalizeReference("ubuntu", containerSystemConfig: config)
+
+        #expect(normalized.hasPrefix("ghcr.io/"))
+        #expect(!normalized.contains("docker.io"))
+    }
+
+    @Test("fully-qualified references are not modified by registry.domain override")
+    func fullyQualifiedReferenceUnchanged() throws {
+        let config = ContainerSystemConfig(registry: .init(domain: "ghcr.io"))
+
+        let normalized = try ClientImage.normalizeReference(
+            "docker.io/library/ubuntu:latest", containerSystemConfig: config)
+
+        #expect(normalized.hasPrefix("docker.io/"))
+    }
+
+    @Test("tag is preserved when custom registry.domain is applied")
+    func tagPreservedWithCustomRegistry() throws {
+        let config = ContainerSystemConfig(registry: .init(domain: "ghcr.io"))
+
+        let normalized = try ClientImage.normalizeReference("ubuntu:22.04", containerSystemConfig: config)
+
+        #expect(normalized.hasPrefix("ghcr.io/"))
+        #expect(normalized.contains("22.04"))
+    }
+
+    @Test("malformed reference throws an error")
+    func malformedReferenceThrows() {
+        #expect(throws: (any Error).self) {
+            try ClientImage.normalizeReference("://invalid", containerSystemConfig: ContainerSystemConfig())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces all inline `ContainerSystemConfig()` constructions with a single instance loaded from the user's `config.toml` at startup and injected throughout. User overrides for `registry.domain`, `vminit.image`, `build.image`, and `build.rosetta` now take effect across all image operations, container creation, DNS resolution, and the builder — instead of being silently ignored.

## Related Issue

Related to #144 (follow-up — makes the config actually drive runtime behaviour, not just display it)

## Changes

- **`configure.swift`**: loads `ContainerSystemConfig` at startup via `ConfigurationLoader.load()`; splits catch so malformed TOML emits `.error` (user edited their config) vs `.warning` (missing file); fixes pre-existing `volumeClient` typo
- **`ClientImageService`**: required `containerSystemConfig` init; infra-image filter now uses instance values (`build.image`, `vminit.image`) instead of static class defaults
- **`ClientBuilderService`**: required init; uses `containerSystemConfig.build.image` and `build.rosetta` instead of static class defaults
- **`NetworkDNSManager`**: required init; local-captures config before `Task` to avoid actor re-entrancy
- **`ContainerCreateRoute`, `BuildRoute`, `ImageTagRoute`**: `systemConfig` property injected and threaded through static handler factories
- **`ImageHistoryRoute`, `ImageInspectRoute`**: removed vestigial `client: ClientImageProtocol` parameter (was silently discarded with `_ = client`); `systemConfig` added
- **`InfoRoute`**: `imageClient` now injected via factory pattern (required by removal of `ClientImageService` default init)

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (271 tests)
- [x] Unit tests added (`SystemConfigPropagationTests.swift`) — verifies `registry.domain` override, tag preservation, fully-qualified reference passthrough, error path for malformed references
- [x] Integration tests: 22/24 pass (2 pre-existing failures in Docker Compose memory propagation, unrelated to this change; direct `--memory` tests all pass)
- [x] Confirmed `ClientImage.normalizeReference` uses `registry.domain` from injected config (verified against apple/container 1.0.0 source)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (DCO)