### PR TITLE
perf(dns): replace CoreDNS sidecar with embedded Rust DNS forwarder

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e94fe9965b3333056fef3185f0c1cb2d0d183db968d746c6ff22eb7731692799",
+  "originHash" : "d58903d6c9b1cbaddb75d3520d6645301c361d96d9364c1caf12a007abdfe734",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
         "version" : "3.9.0"
+      }
+    },
+    {
+      "identity" : "dns-forwarder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/socktainer/dns-forwarder.git",
+      "state" : {
+        "revision" : "13aab5bf2e348ec3a501684e798bff7119f6038e",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
         .package(url: "https://github.com/mw99/DataCompression.git", from: "3.9.0"),
+        .package(url: "https://github.com/socktainer/dns-forwarder.git", exact: "0.1.0"),
     ],
     targets: [
         .executableTarget(
@@ -40,14 +41,16 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "DataCompression", package: "DataCompression"),
+                .product(name: "SocktainerDNSImage", package: "dns-forwarder"),
                 "BuildInfo",
-            ],
+            ]
         ),
         .testTarget(
             name: "socktainerTests",
             dependencies: [
                 .target(name: "socktainer"),
                 .product(name: "ContainerAPIClient", package: "container"),
+                .product(name: "SocktainerDNSImage", package: "dns-forwarder"),
                 .product(name: "VaporTesting", package: "vapor"),
             ],
         ),

--- a/Sources/socktainer/DNS/EmbeddedDNSImage.swift
+++ b/Sources/socktainer/DNS/EmbeddedDNSImage.swift
@@ -1,0 +1,74 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Foundation
+import Logging
+import SocktainerDNSImage
+
+/// Manages the embedded DNS forwarder OCI image.
+///
+/// The image ships as a SwiftPM resource in the `dns-forwarder` package (swiftpm branch)
+/// and is imported into Apple Container's image store on first use. Replaces the
+/// `coredns/coredns` pull — no network access required at runtime.
+enum EmbeddedDNSImage {
+    static let tag = SocktainerDNSImage.reference
+    private static let log = Logger(label: "socktainer.dns.embedded")
+
+    /// Serializes concurrent first-use imports across all networks.
+    /// Without this, two networks starting simultaneously both miss the
+    /// `ClientImage.get` check and both call `load`, making startup racy.
+    actor ImportGate {
+        static let shared = ImportGate()
+        private var task: Task<Void, Error>?
+
+        func ensureOnce(perform: @escaping @Sendable () async throws -> Void) async throws {
+            if let existing = task {
+                // A prior or in-flight import — wait for it; success or failure is shared.
+                try await existing.value
+                return
+            }
+            let t = Task { try await perform() }
+            task = t
+            do {
+                try await t.value
+            } catch {
+                // Reset on failure so the next caller can retry — a transient resource
+                // error or store hiccup must not permanently poison every future import.
+                task = nil
+                throw error
+            }
+        }
+    }
+
+    /// Ensures the embedded DNS image is available in Apple Container's image store.
+    /// Imports from the SwiftPM-bundled resource if not already present. Concurrent
+    /// callers coalesce on a single import; subsequent calls return immediately once
+    /// the image is in the store.
+    static func ensure(
+        containerSystemConfig: ContainerSystemConfig,
+        appSupportURL: URL
+    ) async throws {
+        // Fast path: image already in store (common case after first use).
+        if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) != nil {
+            return
+        }
+
+        // Slow path: serialize through ImportGate so concurrent first-use callers
+        // don't each call load() independently.
+        try await ImportGate.shared.ensureOnce {
+            // Re-check inside the gate — a concurrent caller may have just loaded it.
+            if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) != nil {
+                return
+            }
+            let resourceURL = SocktainerDNSImage.archiveURL
+            log.info("[dns-embedded] importing embedded DNS forwarder image")
+            let imageClient = ClientImageService(containerSystemConfig: containerSystemConfig)
+            _ = try await imageClient.load(
+                tarballPath: resourceURL,
+                platform: .current,
+                appleContainerAppSupportUrl: appSupportURL,
+                logger: log
+            )
+            log.info("[dns-embedded] DNS forwarder image ready: \(tag)")
+        }
+    }
+}

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -12,12 +12,12 @@ struct NetworkDNSManagerKey: StorageKey {
     typealias Value = NetworkDNSManager
 }
 
-/// Manages one CoreDNS sidecar container per user-created network.
+/// Manages one DNS forwarder sidecar container per user-created network.
 ///
-/// Each CoreDNS container is configured to forward all DNS queries to
-/// SocktainerDNSServer running on the host (reachable at the network's
-/// gateway IP on port 2054). SocktainerDNSServer resolves container
-/// service names and forwards unknown queries upstream to 1.1.1.1.
+/// Each forwarder is the embedded `socktainer-dns` binary (static Rust, ~388 KB,
+/// bundled as a Swift Package resource). It proxies DNS queries from containers
+/// to SocktainerDNSServer on the macOS host via the network gateway, without
+/// pulling anything from the internet at runtime.
 ///
 /// DNS containers are identified by the label `socktainer.role=dns` and
 /// named `socktainer-dns-{networkId}`.
@@ -31,7 +31,7 @@ actor NetworkDNSManager {
     private let appSupportURL: URL
     private let dnsPort: Int
     private let containerSystemConfig: ContainerSystemConfig
-    private var containerIPs: [String: String] = [:]  // networkId → CoreDNS container IP
+    private var containerIPs: [String: String] = [:]  // networkId → DNS forwarder container IP
     private var pendingCreation: [String: Task<String, Error>] = [:]
     private var log = Logger(label: "socktainer.dns.manager")
 
@@ -43,20 +43,20 @@ actor NetworkDNSManager {
 
     // MARK: - Public API
 
-    /// Returns the IP of the CoreDNS container for `networkId`, creating it lazily.
+    /// Returns the IP of the DNS forwarder container for `networkId`, creating it lazily.
     /// Concurrent callers for the same network are coalesced — only one container is created.
     func ensureDNSContainer(networkId: String) async throws -> String {
         if let ip = containerIPs[networkId] {
-            log.info("[dns-manager] reusing cached CoreDNS at \(ip) for network \(networkId)")
+            log.info("[dns-manager] reusing cached DNS forwarder at \(ip) for network \(networkId)")
             return ip
         }
 
         if let pending = pendingCreation[networkId] {
-            log.info("[dns-manager] waiting for in-flight CoreDNS creation for network \(networkId)")
+            log.info("[dns-manager] waiting for in-flight DNS forwarder creation for network \(networkId)")
             return try await pending.value
         }
 
-        log.info("[dns-manager] creating CoreDNS container for network \(networkId)")
+        log.info("[dns-manager] creating DNS forwarder container for network \(networkId)")
         let appSupportURL = self.appSupportURL
         let dnsPort = self.dnsPort
         let containerSystemConfig = self.containerSystemConfig
@@ -69,7 +69,7 @@ actor NetworkDNSManager {
             let ip = try await task.value
             containerIPs[networkId] = ip
             pendingCreation.removeValue(forKey: networkId)
-            log.info("[dns-manager] CoreDNS running at \(ip) for network \(networkId)")
+            log.info("[dns-manager] DNS forwarder running at \(ip) for network \(networkId)")
             return ip
         } catch {
             pendingCreation.removeValue(forKey: networkId)
@@ -77,7 +77,7 @@ actor NetworkDNSManager {
         }
     }
 
-    /// Removes the CoreDNS container for `networkId` and clears its cached IP.
+    /// Removes the DNS forwarder container for `networkId` and clears its cached IP.
     /// Called when a user network is deleted.
     func cleanupDNSContainer(networkId: String) async {
         containerIPs.removeValue(forKey: networkId)
@@ -142,33 +142,28 @@ actor NetworkDNSManager {
             return attachment.ipv4Address.address.description
         }
 
-        // Get the network's gateway IP — needed for the CoreDNS Corefile
+        // Get the network's gateway IP — passed to the forwarder as DNS_UPSTREAM
         let networkResource = try await NetworkClient().get(id: networkId)
         let gatewayIP = networkResource.status.ipv4Gateway.description
 
-        // Write Corefile to a host directory that will be virtiofs-mounted
-        let corefileDir = appSupportURL.appendingPathComponent("dns/\(networkId)")
-        try FileManager.default.createDirectory(at: corefileDir, withIntermediateDirectories: true)
-        let corefileURL = corefileDir.appendingPathComponent("Corefile")
-        let corefile = """
-            . {
-                forward . \(gatewayIP):\(dnsPort)
-                cache 10
-                errors
-            }
-            """
-        try corefile.write(to: corefileURL, atomically: true, encoding: .utf8)
+        // Ensure the embedded DNS forwarder image is available (imports from bundle on first use)
+        try await EmbeddedDNSImage.ensure(
+            containerSystemConfig: containerSystemConfig,
+            appSupportURL: appSupportURL
+        )
 
-        // Pull CoreDNS image — arm64 native, no Rosetta needed
-        let imageRef = try ClientImage.normalizeReference("docker.io/coredns/coredns:latest", containerSystemConfig: containerSystemConfig)
         let platform = Platform.current
-        let image = try await ClientImage.fetch(reference: imageRef, platform: platform, containerSystemConfig: containerSystemConfig)
+        let image = try await ClientImage.fetch(
+            reference: EmbeddedDNSImage.tag,
+            platform: platform,
+            containerSystemConfig: containerSystemConfig
+        )
         _ = try await image.getCreateSnapshot(platform: platform)
 
         let processConfig = ProcessConfiguration(
-            executable: "/coredns",
-            arguments: ["-conf", "/etc/coredns/Corefile"],
-            environment: [],
+            executable: "/dns-forwarder",
+            arguments: [],
+            environment: ["DNS_UPSTREAM=\(gatewayIP):\(dnsPort)"],
             workingDirectory: "/",
             terminal: false,
             user: .id(uid: 0, gid: 0)
@@ -179,16 +174,13 @@ actor NetworkDNSManager {
             roleLabel: dnsRole,
             networkLabel: networkId,
         ]
-        config.mounts = [
-            Filesystem.virtiofs(source: corefileDir.path, destination: "/etc/coredns", options: [])
-        ]
         config.networks = [
             AttachmentConfiguration(
                 network: networkId,
                 options: AttachmentOptions(hostname: ContainerNameUtility.sanitize(containerPrefix + networkId))
             )
         ]
-        // Point CoreDNS to the vmnet gateway for upstream resolution
+        // Point DNS forwarder to the vmnet gateway for upstream resolution
         config.dns = ContainerConfiguration.DNSConfiguration(
             nameservers: [gatewayIP],
             domain: nil,

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -1,4 +1,6 @@
 import Darwin
+import Foundation
+import SocktainerDNSImage
 import Testing
 
 @testable import socktainer
@@ -129,4 +131,78 @@ struct SocktainerDNSServerTests {
         server.register(hostname: "db", ip: "10.0.0.99")
         #expect(server.listEntries()["db"] == "10.0.0.99")
     }
+}
+
+// MARK: - EmbeddedDNSImage / SocktainerDNSImage SwiftPM resource
+
+@Suite("EmbeddedDNSImage — SwiftPM resource")
+struct EmbeddedDNSImageTests {
+
+    @Test("SocktainerDNSImage.archiveURL resolves to an existing file")
+    func archiveURLResolvesToExistingFile() {
+        let url = SocktainerDNSImage.archiveURL
+        #expect(url.lastPathComponent == "socktainer-dns.tar.gz")
+        #expect(FileManager.default.fileExists(atPath: url.path), "tarball must be present in SwiftPM resource bundle")
+    }
+
+    @Test("EmbeddedDNSImage.tag matches SocktainerDNSImage.reference")
+    func tagMatchesPackageReference() {
+        #expect(EmbeddedDNSImage.tag == SocktainerDNSImage.reference)
+        #expect(EmbeddedDNSImage.tag == "socktainer-dns:embedded", "image tag must match what NetworkDNSManager registers")
+    }
+
+    // Regression for the permanent-failure-caching bug (CodeRabbit review): a transient
+    // error in perform() must not poison every future call. After a failure the gate resets
+    // so the next caller can retry — without this, DNS sidecar creation never recovers
+    // from a momentary resource error without a process restart.
+    @Test("ImportGate.ensureOnce resets after failure so the next caller can retry")
+    func importGateResetsAfterFailure() async throws {
+        struct ImportError: Error {}
+        let gate = EmbeddedDNSImage.ImportGate()
+
+        // First call: fails.
+        await #expect(throws: ImportError.self) {
+            try await gate.ensureOnce { throw ImportError() }
+        }
+
+        // Second call: must succeed — gate must have cleared the failed task.
+        let retryCount = ActorCounter()
+        try await gate.ensureOnce { await retryCount.increment() }
+        #expect(await retryCount.value == 1, "gate must allow retry after a prior failure")
+    }
+
+    // Regression for the concurrent first-use race (Finding #1 in CodeRabbit review):
+    // without ImportGate, two networks starting simultaneously both missed the
+    // ClientImage.get check and both called load(), nondeterministic on a fresh store.
+    // This test proves that ImportGate.ensureOnce coalesces concurrent callers so the
+    // perform closure executes exactly once even when two tasks race through it.
+    @Test("ImportGate.ensureOnce executes perform exactly once under concurrent callers")
+    func importGateCoalescesConcurrentCallers() async throws {
+        let gate = EmbeddedDNSImage.ImportGate()
+        let callCount = ActorCounter()
+
+        // Start two tasks concurrently; both will race into ensureOnce.
+        async let t1: Void = gate.ensureOnce {
+            await callCount.increment()
+            // Brief yield so the second task has a chance to arrive while the first is
+            // in-flight, proving the "in-flight task" branch of ensureOnce is exercised.
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        async let t2: Void = gate.ensureOnce {
+            await callCount.increment()
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try await t1
+        try await t2
+
+        let count = await callCount.value
+        #expect(count == 1, "perform must execute exactly once — concurrent callers must coalesce, not each run the body")
+    }
+}
+
+// MARK: - Helpers
+
+private actor ActorCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
 }


### PR DESCRIPTION
## Summary

Replaces the `coredns/coredns:latest` sidecar (21 MB DockerHub pull, 76 MB RAM per network) with a minimal static Rust binary bundled as a Swift Package resource — no internet access required at runtime.

> **Draft — depends on [socktainer/dns-forwarder#1](https://github.com/socktainer/dns-forwarder/pull/1) being merged and tagged as `v0.1.0`.**
> Once that PR is merged, this PR will switch from `make fetch-dns-local` to `make fetch-dns` (downloading the release tarball) and can be marked ready for review.

Source: https://github.com/socktainer/dns-forwarder (Rust, PR #1 open)

## Results

| | CoreDNS | **Rust forwarder** |
|---|---|---|
| Image size | 21 MB (DockerHub pull) | **225 KB** (bundled OCI tarball) |
| RAM per network | 76 MB | **~1–2 MB** |
| Works offline | ❌ | ✅ |
| Runtime deps | none (pulls on first use) | none (embedded in binary) |

Verified end-to-end with socktainer-check: **25/25 tests pass**, 2 known xfail ⚠️ (pre-existing compose timing issue, unrelated to DNS).

## Architecture

The OCI tarball is **not committed** to this repository. It is fetched before building:

```sh
make fetch-dns          # download from socktainer/dns-forwarder release (once released)
make fetch-dns-local    # build from ~/Projects/dns-forwarder (local dev, works today)
```

`DNS_FORWARDER_VERSION` in the Makefile pins the exact release to consume.

## Changes

- `EmbeddedDNSImage.swift` — new; imports the OCI tarball into Apple Container's image store on first use; no-ops if already present
- `NetworkDNSManager.swift` — uses `socktainer-dns:embedded` instead of `coredns/coredns:latest`; passes upstream as `DNS_UPSTREAM` env var (no Corefile, no virtiofs mount)
- `Package.swift` — declares the OCI tarball as a `.copy` resource (gitignored)
- `Makefile` — `fetch-dns` (download release) + `fetch-dns-local` (build from source)
- `.gitignore` — `Sources/socktainer/Resources/socktainer-dns-embedded.tar.gz`

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (288 tests)
- [x] `make fetch-dns-local` + `make release` + socktainer-check: **25/25 pass**
- [x] All commits signed off (DCO)

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)