### PR TITLE
docs(readme): update installation via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,27 +139,24 @@ DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker images
 
 ### Homebrew
 
-`socktainer` is shipped via a homebrew tap:
-
-```shell
-brew tap socktainer/tap
-```
-
-#### Stable Release
-
-Install the official release:
+`socktainer` is included in [Homebrew Formulae](https://formulae.brew.sh/formula/socktainer#default):
 
 ```shell
 brew install socktainer
 ```
 
-#### Pre Release
-
-Install development release:
+If you want to install the latest head version of socktainer:
 
 ```shell
-brew install socktainer-next
+brew install socktainer --HEAD
 ```
+
+> [!NOTE]
+> Formerly we have provided our own Homebrew tap. You may want to integrate it with the Homebrew official, and you can run the following command:
+> 
+> ```shell
+> brew untap socktainer/tap
+> ```
 
 ### GitHub Releases
 


### PR DESCRIPTION
# Pull Request

## Summary

Socktainer is now included in Homebrew Core Formulae: https://github.com/Homebrew/homebrew-core/pull/288658
The current README.md describes how users can install socktainer from Tap.
This should be a new description with Homebrew Core Formulae for users to install easily.

## Related Issue

None

## Changes

- Remove `brew tap` command.
- Suggest to run `brew untap socktainer/tap`. Recent Homebrew update requires some trust settings for each custom tap, and we should remove our custom tap from user environment to reduce troubles.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [ ] ~Unit tests added or updated (required for features and bug fixes)~
- [ ] ~Manual testing performed (if applicable)~

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
