### PR TITLE
fix(volumes): remove lost+found before Postgres initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Usage 🚀](#usage-🚀)
     - [Volume sync mode](#volume-sync-mode)
     - [VM memory](#vm-memory)
+    - [Volume compatibility — Postgres](#volume-compatibility--postgres)
   - [Building from Source 🏗️](#building-from-source-🏗️)
     - [Prerequisites](#prerequisites)
     - [Build & Run](#build-run)
@@ -244,6 +245,16 @@ services:
     image: redis:alpine
     mem_limit: 256m
 ```
+
+### Volume compatibility — Postgres
+
+Apple Container's EXT4 volumes always contain `/lost+found`, which causes
+`initdb` to fail with "directory exists but is not empty". Socktainer
+automatically removes it when a Postgres container is created, before
+`initdb` runs.
+
+**Opt out** — set `SOCKTAINER_CLEAN_VOLUMES=false` globally, or label a
+specific volume with `socktainer.clean-volumes=false`.
 
 ---
 

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -424,7 +424,6 @@ extension ContainerCreateRoute {
 
                     let volume: ContainerResource.VolumeConfiguration
                     if let existing = existingVolume {
-                        // Volume exists, use it
                         volume = existing
                     } else {
                         // Volume doesn't exist, create it automatically (Docker behavior)
@@ -436,6 +435,20 @@ extension ContainerCreateRoute {
                             driverOpts: [:],
                             labels: [:]
                         )
+                    }
+
+                    // Strip /lost+found when PGDATA matches this volume's destination.
+                    // Every official Postgres image sets PGDATA as a Docker ENV, so
+                    // this reliably targets the exact volume that initdb will reject.
+                    let pgdata =
+                        mergedEnv
+                        .first(where: { $0.hasPrefix("PGDATA=") })
+                        .map { String($0.dropFirst("PGDATA=".count)) }
+                    if let pgdata, parsed.destination == pgdata,
+                        volume.format == "ext4",
+                        VolumeImageCleaner.isEnabled(labels: volume.labels)
+                    {
+                        VolumeImageCleaner.removeLostFound(imagePath: volume.source, logger: req.logger)
                     }
 
                     // Per-volume sync label wins; fall back to global --volume-sync (default: nosync).

--- a/Sources/socktainer/Utilities/VolumeImageCleaner.swift
+++ b/Sources/socktainer/Utilities/VolumeImageCleaner.swift
@@ -1,0 +1,84 @@
+import ContainerizationEXT4
+import Foundation
+import Logging
+import SystemPackage
+
+/// Removes `/lost+found` from the EXT4 image backing a named volume.
+///
+/// Apple Container always creates `/lost+found` at the volume root; Postgres's
+/// `initdb` rejects a non-empty data directory. Triggered only when `PGDATA`
+/// matches the volume's mount destination — that is the reliable signal that
+/// `initdb` will run here. Idempotent: no-op when `/lost+found` is absent.
+/// Best-effort: failures are logged and never propagate to the caller.
+enum VolumeImageCleaner {
+    static let optOutLabel = "socktainer.clean-volumes"
+    static let optOutEnvVar = "SOCKTAINER_CLEAN_VOLUMES"
+
+    /// Returns false when opted out via `SOCKTAINER_CLEAN_VOLUMES=false` or
+    /// the `socktainer.clean-volumes=false` volume label.
+    static func isEnabled(
+        labels: [String: String],
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if environment[optOutEnvVar]?.lowercased() == "false" { return false }
+        if labels[optOutLabel]?.lowercased() == "false" { return false }
+        return true
+    }
+
+    /// Reformats the EXT4 block image at `imagePath`, removing `/lost+found`.
+    /// Skips non-regular-files, non-EXT4 images, and images already without it.
+    static func removeLostFound(imagePath: String, logger: Logger) {
+        let fm = FileManager.default
+
+        // Guard against a directory-backed mount point (never a block image).
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: imagePath, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            logger.warning("[volume-clean] skip: \(imagePath) is not a regular file")
+            return
+        }
+
+        // Use the real file size, not the optional volume metadata.
+        guard let attributes = try? fm.attributesOfItem(atPath: imagePath),
+            let size = (attributes[.size] as? NSNumber)?.uint64Value, size >= 256 * 1024
+        else {
+            logger.warning("[volume-clean] skip: cannot determine a valid size for \(imagePath)")
+            return
+        }
+
+        let path = FilePath(imagePath)
+
+        // Idempotency + safety: skip if not EXT4 or already clean.
+        do {
+            let probe = try EXT4Editor(devicePath: path)
+            guard probe.exists(path: "/lost+found") else {
+                logger.info("[volume-clean] \(imagePath) has no /lost+found; nothing to do")
+                return
+            }
+        } catch {
+            logger.warning("[volume-clean] skip: \(imagePath) is not a readable EXT4 image: \(error)")
+            return
+        }
+
+        do {
+            // blockSize 4096, no journal — mirrors Apple's own ContainerManager.
+            let formatter = try EXT4.Formatter(path, blockSize: 4096, minDiskSize: size)
+            try formatter.unlink(path: FilePath("/lost+found"))
+            try formatter.close()
+        } catch {
+            logger.warning("[volume-clean] reformat failed for \(imagePath): \(error)")
+            return
+        }
+
+        // Verify.
+        do {
+            let editor = try EXT4Editor(devicePath: path)
+            if editor.exists(path: "/lost+found") {
+                logger.warning("[volume-clean] /lost+found still present after reformat: \(imagePath)")
+            } else {
+                logger.info("[volume-clean] removed /lost+found from \(imagePath)")
+            }
+        } catch {
+            logger.warning("[volume-clean] post-reformat verification failed for \(imagePath): \(error)")
+        }
+    }
+}

--- a/Tests/socktainerTests/Utilitites/VolumeImageCleanerTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumeImageCleanerTests.swift
@@ -1,0 +1,86 @@
+import ContainerizationEXT4
+import Foundation
+import Logging
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+/// Tests for VolumeImageCleaner — removing `/lost+found` from fresh EXT4 volumes.
+struct VolumeImageCleanerTests {
+    let tempDir: URL
+    let logger = Logger(label: "test.volume-clean")
+
+    init() {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("vol-clean-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    /// Formats a fresh EXT4 image the way Apple Container does — which always
+    /// creates `/lost+found` at the root.
+    private func freshExt4Image(name: String = "vol.img") throws -> URL {
+        let path = tempDir.appendingPathComponent(name)
+        let formatter = try EXT4.Formatter(FilePath(path.path), blockSize: 4096, minDiskSize: 16 * 1024 * 1024)
+        try formatter.close()
+        return path
+    }
+
+    @Test("A freshly-formatted EXT4 image contains /lost+found (baseline)")
+    func freshImageHasLostFound() throws {
+        let img = try freshExt4Image()
+        let editor = try EXT4Editor(devicePath: FilePath(img.path))
+        #expect(editor.exists(path: "/lost+found") == true)
+    }
+
+    @Test("removeLostFound deletes /lost+found and leaves a readable filesystem")
+    func removesLostFound() throws {
+        let img = try freshExt4Image()
+        VolumeImageCleaner.removeLostFound(imagePath: img.path, logger: logger)
+
+        let editor = try EXT4Editor(devicePath: FilePath(img.path))
+        #expect(editor.exists(path: "/lost+found") == false)
+        // Root remains a valid, readable ext4 filesystem.
+        #expect(editor.exists(path: "/") == true)
+    }
+
+    @Test("Skips a path that is not a regular file (never wipes a directory)")
+    func skipsNonRegularFile() {
+        // Must not throw or touch anything when handed a directory.
+        VolumeImageCleaner.removeLostFound(imagePath: tempDir.path, logger: logger)
+        #expect(FileManager.default.fileExists(atPath: tempDir.path))
+    }
+
+    @Test("Skips a missing path")
+    func skipsMissingPath() {
+        VolumeImageCleaner.removeLostFound(imagePath: tempDir.appendingPathComponent("nope.img").path, logger: logger)
+    }
+
+    @Test("Skips a regular file that is not an EXT4 image (never reformats it)")
+    func skipsNonExt4File() throws {
+        let junk = tempDir.appendingPathComponent("junk.img")
+        try Data(repeating: 0, count: 1024 * 1024).write(to: junk)  // 1 MB of zeros — not ext4
+        VolumeImageCleaner.removeLostFound(imagePath: junk.path, logger: logger)
+        // The file must be left untouched — not reformatted into a valid ext4 fs.
+        #expect((try? EXT4Editor(devicePath: FilePath(junk.path))) == nil)
+    }
+
+    @Test("Is idempotent — safe to call on a volume already without /lost+found")
+    func idempotentOnCleanVolume() throws {
+        let img = try freshExt4Image()
+        VolumeImageCleaner.removeLostFound(imagePath: img.path, logger: logger)
+        // Second call must not wipe the volume — /lost+found is already gone.
+        VolumeImageCleaner.removeLostFound(imagePath: img.path, logger: logger)
+        let editor = try EXT4Editor(devicePath: FilePath(img.path))
+        #expect(editor.exists(path: "/") == true)
+        #expect(editor.exists(path: "/lost+found") == false)
+    }
+
+    @Test("Opt-out via env var and per-volume label")
+    func optOut() {
+        #expect(VolumeImageCleaner.isEnabled(labels: [:], environment: ["SOCKTAINER_CLEAN_VOLUMES": "false"]) == false)
+        #expect(VolumeImageCleaner.isEnabled(labels: [:], environment: ["SOCKTAINER_CLEAN_VOLUMES": "FALSE"]) == false)
+        #expect(VolumeImageCleaner.isEnabled(labels: ["socktainer.clean-volumes": "false"], environment: [:]) == false)
+        #expect(VolumeImageCleaner.isEnabled(labels: [:], environment: [:]) == true)
+        #expect(VolumeImageCleaner.isEnabled(labels: ["socktainer.clean-volumes": "true"], environment: [:]) == true)
+    }
+}


### PR DESCRIPTION
## Summary

Apple Container's EXT4 volumes always contain `/lost+found`, which causes Postgres's `initdb` to fail with "directory exists but is not empty". Socktainer now removes it before the container starts, transparently restoring Docker/Colima parity.

## Related Issue

Closes #222

## Changes

- `VolumeImageCleaner` — reformats the volume's EXT4 block image using `EXT4.Formatter.unlink("/lost+found")`; idempotent (no-op when already absent), best-effort (never blocks volume creation)
- `ContainerCreateRoute` — triggers the cleaner when `PGDATA` (set as a Docker `ENV` in every official Postgres image, including `supabase/postgres`) matches a volume's mount destination; targets exactly the volumes `initdb` will reject
- `VolumeImageCleanerTests` — 7 unit tests covering the reformat, idempotency, non-file skip, non-EXT4 skip, and opt-out
- `README` — new "Volume compatibility — Postgres" section

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (273 tests)
- [x] Unit tests added (`VolumeImageCleanerTests`, 7 cases)
- [x] Manual: `docker run -v pgvol:/var/lib/postgresql/data postgres:16-alpine` — initdb succeeds, no `lost+found`
- [x] Verified against postgres:13/14/16/17/latest and `supabase/postgres:17.6.1.134` — all pass with fix, all fail without it

**Opt out:** `SOCKTAINER_CLEAN_VOLUMES=false` globally, or `--label socktainer.clean-volumes=false` per volume.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))