### PR TITLE
refactor(volumes): detect Postgres by PGDATA presence, not path value

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -437,14 +437,10 @@ extension ContainerCreateRoute {
                         )
                     }
 
-                    // Strip /lost+found when PGDATA matches this volume's destination.
-                    // Every official Postgres image sets PGDATA as a Docker ENV, so
-                    // this reliably targets the exact volume that initdb will reject.
-                    let pgdata =
-                        mergedEnv
-                        .first(where: { $0.hasPrefix("PGDATA=") })
-                        .map { String($0.dropFirst("PGDATA=".count)) }
-                    if let pgdata, parsed.destination == pgdata,
+                    // Strip /lost+found when PGDATA is set (any value) — that
+                    // reliably signals a Postgres container, and named volumes are
+                    // always mounted at their root so /lost+found is always reachable.
+                    if VolumeImageCleaner.isPostgresDataVolume(mergedEnv: mergedEnv),
                         volume.format == "ext4",
                         VolumeImageCleaner.isEnabled(labels: volume.labels)
                     {

--- a/Sources/socktainer/Utilities/VolumeImageCleaner.swift
+++ b/Sources/socktainer/Utilities/VolumeImageCleaner.swift
@@ -5,14 +5,23 @@ import SystemPackage
 
 /// Removes `/lost+found` from the EXT4 image backing a named volume.
 ///
-/// Apple Container always creates `/lost+found` at the volume root; Postgres's
-/// `initdb` rejects a non-empty data directory. Triggered only when `PGDATA`
-/// matches the volume's mount destination — that is the reliable signal that
-/// `initdb` will run here. Idempotent: no-op when `/lost+found` is absent.
+/// Apple Container always creates `/lost+found` at the volume root, which
+/// causes Postgres's `initdb` to reject the directory as non-empty. Named
+/// volumes are always mounted at their root, so `/lost+found` is always at
+/// the top of every mount — the EXT4 reformat is idempotent (no-op when
+/// already absent) and safe for all images.
 /// Best-effort: failures are logged and never propagate to the caller.
 enum VolumeImageCleaner {
     static let optOutLabel = "socktainer.clean-volumes"
     static let optOutEnvVar = "SOCKTAINER_CLEAN_VOLUMES"
+
+    /// Returns true when `PGDATA` is set in `mergedEnv` (any value), which
+    /// reliably identifies a Postgres container regardless of the actual path.
+    /// Named volumes are always mounted at their root, so any EXT4 named volume
+    /// used by a Postgres container may contain `/lost+found` at the mount root.
+    static func isPostgresDataVolume(mergedEnv: [String]) -> Bool {
+        mergedEnv.contains(where: { $0.hasPrefix("PGDATA=") })
+    }
 
     /// Returns false when opted out via `SOCKTAINER_CLEAN_VOLUMES=false` or
     /// the `socktainer.clean-volumes=false` volume label.
@@ -39,9 +48,9 @@ enum VolumeImageCleaner {
 
         // Use the real file size, not the optional volume metadata.
         guard let attributes = try? fm.attributesOfItem(atPath: imagePath),
-            let size = (attributes[.size] as? NSNumber)?.uint64Value, size >= 256 * 1024
+            let size = (attributes[.size] as? NSNumber)?.uint64Value, size >= 4 * 1024 * 1024
         else {
-            logger.warning("[volume-clean] skip: cannot determine a valid size for \(imagePath)")
+            logger.warning("[volume-clean] skip: image too small to be a valid EXT4 filesystem: \(imagePath)")
             return
         }
 

--- a/Tests/socktainerTests/Utilitites/VolumeImageCleanerTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumeImageCleanerTests.swift
@@ -7,13 +7,17 @@ import Testing
 @testable import socktainer
 
 /// Tests for VolumeImageCleaner — removing `/lost+found` from fresh EXT4 volumes.
-struct VolumeImageCleanerTests {
+final class VolumeImageCleanerTests {
     let tempDir: URL
     let logger = Logger(label: "test.volume-clean")
 
     init() {
         tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("vol-clean-tests-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempDir)
     }
 
     /// Formats a fresh EXT4 image the way Apple Container does — which always
@@ -73,6 +77,35 @@ struct VolumeImageCleanerTests {
         let editor = try EXT4Editor(devicePath: FilePath(img.path))
         #expect(editor.exists(path: "/") == true)
         #expect(editor.exists(path: "/lost+found") == false)
+    }
+
+    @Test("User files written after the initial clean are preserved on subsequent calls")
+    func userFilesPreservedOnSubsequentCalls() throws {
+        // Safety guarantee: once /lost+found is gone the cleaner is a no-op,
+        // so data written after the first clean (e.g. by initdb) is never wiped.
+        let img = try freshExt4Image()
+        VolumeImageCleaner.removeLostFound(imagePath: img.path, logger: logger)
+
+        let editor = try EXT4Editor(devicePath: FilePath(img.path))
+        try editor.createDirectory(path: "/userdata", uid: 0, gid: 0)
+        try editor.sync()
+
+        VolumeImageCleaner.removeLostFound(imagePath: img.path, logger: logger)  // must be no-op
+
+        let verifier = try EXT4Editor(devicePath: FilePath(img.path))
+        #expect(verifier.exists(path: "/userdata") == true)
+        #expect(verifier.exists(path: "/lost+found") == false)
+    }
+
+    @Test("isPostgresDataVolume detects PGDATA regardless of its value")
+    func isPostgresDataVolume() {
+        // Any PGDATA value (postgres:16 path, postgres:18 path, custom) signals Postgres.
+        #expect(VolumeImageCleaner.isPostgresDataVolume(mergedEnv: ["PGDATA=/var/lib/postgresql/data", "PATH=/usr/bin"]) == true)
+        #expect(VolumeImageCleaner.isPostgresDataVolume(mergedEnv: ["PGDATA=/var/lib/postgresql/18/docker"]) == true)
+        #expect(VolumeImageCleaner.isPostgresDataVolume(mergedEnv: ["PGDATA=/custom/path"]) == true)
+        // No PGDATA → not a Postgres container (MySQL, MongoDB, alpine, …)
+        #expect(VolumeImageCleaner.isPostgresDataVolume(mergedEnv: ["PATH=/usr/bin", "MYSQL_ROOT_PASSWORD=x"]) == false)
+        #expect(VolumeImageCleaner.isPostgresDataVolume(mergedEnv: []) == false)
     }
 
     @Test("Opt-out via env var and per-volume label")


### PR DESCRIPTION
## Summary

Follow-up to #240. Simplifies the Postgres detection logic and addresses CodeRabbit's review.

Instead of comparing the PGDATA value to the volume's mount destination, check only that PGDATA is set in the container's environment. Any value means the container is Postgres; named volumes are always mounted at their root so `/lost+found` is always reachable. This handles postgres:18 (`PGDATA=/var/lib/postgresql/18/docker`) and future versions without any path hardcoding.

## Changes

- `isPostgresDataVolume(mergedEnv:)` — replaces the previous `isPGDATAVolume` destination-match; checks PGDATA presence only
- Minimum file size guard raised 256 KiB → 4 MiB (EXT4 journal requires ~4 MiB at blockSize 4096)
- `VolumeImageCleanerTests` converted from `struct` to `final class` for `deinit`-based temp-dir cleanup
- New test: user data written after the first clean is preserved on subsequent calls (verifies idempotency as the safety guarantee)
- New tests: `isPostgresDataVolume` — presence-only detection, all postgres versions, non-postgres images

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (297 tests)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))