### PR TITLE
fix(exec): apply initial TTY ConsoleSize for interactive exec

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -267,7 +267,11 @@ struct ExecRoute: RouteCollection {
 
             let detach = startRequest.Detach ?? false
             let tty = startRequest.Tty ?? config.tty
-            let _ = startRequest.ConsoleSize
+            // Docker sends ConsoleSize as [height, width] for interactive (-it) exec.
+            // Apply it as the initial PTY winsize right after start so `stty size` and TUIs
+            // (vim/htop/less) work, rather than relying solely on the async /exec/{id}/resize
+            // call, which can race the process registration and be dropped.
+            let initialTerminalSize = ExecRoute.initialTerminalSize(tty: tty, consoleSize: startRequest.ConsoleSize)
 
             // Detached mode
             if detach {
@@ -344,6 +348,7 @@ struct ExecRoute: RouteCollection {
                     }
 
                     await ProcessRegistry.shared.set(id: execId, process: process)
+                    if let initialTerminalSize { try? await process.resize(initialTerminalSize) }
 
                     await withTaskGroup(of: Void.self) { group in
                         // stdout handler
@@ -502,6 +507,7 @@ struct ExecRoute: RouteCollection {
                 }
 
                 await ProcessRegistry.shared.set(id: execId, process: process)
+                if let initialTerminalSize { try? await process.resize(initialTerminalSize) }
 
                 // Setup bidirectional communication for interactive sessions
                 await withTaskGroup(of: Void.self) { group in
@@ -682,6 +688,19 @@ struct ExecRoute: RouteCollection {
                 // `GET /exec/{id}/json` can read the recorded exit code.
             }
         }
+    }
+
+    /// Maps Docker's exec-start `ConsoleSize` to an initial terminal size.
+    ///
+    /// Docker encodes `ConsoleSize` as `[height, width]` and only sends it for
+    /// interactive (`-it`) exec. Returns `nil` when there is no TTY or the value
+    /// is absent/malformed, so callers skip the initial resize.
+    static func initialTerminalSize(tty: Bool, consoleSize: [Int]?) -> ContainerizationOS.Terminal.Size? {
+        guard tty, let cs = consoleSize, cs.count == 2, cs[0] > 0, cs[1] > 0 else { return nil }
+        return ContainerizationOS.Terminal.Size(
+            width: UInt16(min(cs[1], Int(UInt16.max))),
+            height: UInt16(min(cs[0], Int(UInt16.max)))
+        )
     }
 
     static let resizeExec: @Sendable (Request) async throws -> Response = { req in

--- a/Tests/socktainerTests/Routes/ExecInitialTerminalSizeTests.swift
+++ b/Tests/socktainerTests/Routes/ExecInitialTerminalSizeTests.swift
@@ -1,0 +1,51 @@
+import ContainerizationOS
+import Testing
+
+@testable import socktainer
+
+/// Unit tests for `ExecRoute.initialTerminalSize`, which maps Docker's
+/// exec-start `ConsoleSize` ([height, width]) to the initial PTY winsize.
+///
+/// Without applying this, an interactive `docker exec -it` opens a PTY whose
+/// window size is never set, so `stty size` fails and full-screen TUIs
+/// (vim/htop/less) render at size 0.
+@Suite("ExecRoute.initialTerminalSize")
+struct ExecInitialTerminalSizeTests {
+
+    @Test("ConsoleSize [height, width] maps to Terminal.Size(width, height)")
+    func mapsConsoleSize() throws {
+        let size = try #require(ExecRoute.initialTerminalSize(tty: true, consoleSize: [40, 120]))
+        #expect(size.width == 120)  // columns
+        #expect(size.height == 40)  // rows
+    }
+
+    @Test("no TTY returns nil")
+    func noTtyReturnsNil() {
+        #expect(ExecRoute.initialTerminalSize(tty: false, consoleSize: [40, 120]) == nil)
+    }
+
+    @Test("absent ConsoleSize returns nil")
+    func absentConsoleSizeReturnsNil() {
+        #expect(ExecRoute.initialTerminalSize(tty: true, consoleSize: nil) == nil)
+    }
+
+    @Test("zero dimensions return nil")
+    func zeroDimensionsReturnNil() {
+        #expect(ExecRoute.initialTerminalSize(tty: true, consoleSize: [0, 0]) == nil)
+    }
+
+    @Test("wrong element count returns nil")
+    func wrongCountReturnsNil() {
+        #expect(ExecRoute.initialTerminalSize(tty: true, consoleSize: [40]) == nil)
+        #expect(ExecRoute.initialTerminalSize(tty: true, consoleSize: [40, 120, 1]) == nil)
+    }
+
+    @Test("dimensions above UInt16.max are clamped")
+    func clampsLargeDimensions() throws {
+        let size = try #require(
+            ExecRoute.initialTerminalSize(tty: true, consoleSize: [100_000, 100_000])
+        )
+        #expect(size.width == UInt16.max)
+        #expect(size.height == UInt16.max)
+    }
+}


### PR DESCRIPTION
## Summary

`docker exec -it` opens a PTY, but the `ConsoleSize` sent in the exec-start request body was discarded (`let _ = startRequest.ConsoleSize`), so the PTY window size was never initialized. Inside the container `stty size` errors and `$COLUMNS`/`$LINES` are empty, so full-screen TUIs (vim, htop, less) render at size 0.

## Fix

Parse `ConsoleSize` (Docker encodes it as `[height, width]`, sent only for `-it`) and apply it via `process.resize()` right after the process is registered, on both the HTTP-streaming and TCP-upgrade exec paths.

This also closes a small race: the client's async `POST /exec/{id}/resize` can arrive before the process is registered in `ProcessRegistry` and be silently dropped. Applying the initial size at start time makes the first paint correct; subsequent resizes keep flowing through the existing resize handler.

## Testing

- New unit tests for `ExecRoute.initialTerminalSize` (mapping, no-TTY, absent/zero/malformed input, clamping).
- `make fmt` clean; full unit suite passes (303 tests).
- Manual check on macOS 26 / Apple Silicon with `docker exec -it`:
  - before: `stty size` → error
  - after: `stty size` → `40 120` (initial), and follows live window resizes (e.g. → `50 200`).

## Related

Follows up #232 (resize wiring): the resize endpoints were in place, but the initial size from exec-start was dropped. Helps interactive / devcontainer use (#192, #120).
