### PR TITLE
fix(exec): prevent stdio fd double-close crash under concurrent exec load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,42 @@ Tests are in `Tests/socktainerTests/`. The PR CI (`pr-check.yaml`) runs: format 
 - PRs must follow the conventional commit format for titles, include a summary and testing info. See `.github/PULL_REQUEST_TEMPLATE.md`.
 - Skills that create issues or PRs (`create-github-issue`, `create-github-pr`) produce output conforming to these templates.
 
+## Apple Container stdio fd Ownership
+
+**Never use Foundation's `Pipe()` when passing fds to `ContainerClient.createProcess(stdio:)` or `ContainerClient.bootstrap(id:stdio:)`.**
+
+These APIs dup the passed fds into the container and then **immediately close the parent copies**. `Pipe()` does not know about this external close — its `deinit` later calls `close()` again on the same fd, which may now be a recycled NIO socket. The double-close corrupts NIO's fd table, causing `writev`/`kevent` EBADF crashes under concurrent load (issue #107).
+
+**Use `StdioPipes`** (centralized allocation and cleanup, `Sources/socktainer/Utilities/DockerConnectionUtility.swift`):
+
+```swift
+guard let pipes = StdioPipes.make([.stdin, .stdout, .stderr]) else {  // or make(.all)
+    throw Abort(.internalServerError, reason: "Failed to create I/O pipes")
+}
+let process: ClientProcess
+do {
+    process = try await ContainerClient().createProcess(..., stdio: pipes.stdioArray)
+} catch {
+    pipes.closeAll()           // Apple never took ownership — close all 6 fds
+    throw error
+}
+do {
+    try await process.start()
+} catch {
+    pipes.closeAfterHandoff()  // Apple owns stdin.read, stdout.write, stderr.write
+    throw error
+}
+// Success — use pipes.stdout?.read, pipes.stderr?.read, pipes.stdin?.write in tasks
+```
+
+`StdioPipes.make()` handles EMFILE internally (closes any partially-allocated pipes and returns `nil`). `closeAll()` is for createProcess-failure; `closeAfterHandoff()` is for start-failure. `ProcessPipe` (the single-pipe primitive) exists for unusual cases requiring finer control.
+
+Ownership contract:
+- **stdout/stderr**: pass `.write` via `StdioPipes.stdioArray` — Apple closes it. Caller closes `.read`.
+- **stdin**: pass `.read` via `StdioPipes.stdioArray` — Apple closes it. Caller closes `.write`.
+- Always use `StdioPipes.make()` with `guard let` — pipe exhaustion returns nil and yields a clean HTTP error.
+- `make test` runs `make lint-pipes` which rejects `= Pipe()` in non-registry source files.
+
 ## Security
 
 - Never commit secrets, API keys, or credentials. Do not stage files that look like they contain secrets (`.env`, `credentials.json`, etc.).

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,16 @@ help:
 	@echo "  help             - Show this help message"
 
 .PHONY: test
-test:
+test: lint-pipes
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION)
+
+# Prevent Foundation's Pipe() from being used when passing fds to Apple Container
+# APIs (createProcess/bootstrap). Apple closes those fds immediately after duping
+# them into the container, causing Pipe.deinit to double-close a reused fd and
+# corrupt NIO's fd table (writev/kevent EBADF crash). Use StdioPipes instead.
+.PHONY: lint-pipes
+lint-pipes:
+	@bash scripts/lint-pipes.sh
 
 .PHONY: fmt
 fmt:	swift-fmt

--- a/README.md
+++ b/README.md
@@ -319,6 +319,41 @@ We welcome contributions!
   - `Utilities/` — Helper utilities 🧰
 - Document any public API or CLI changes in this README 📝
 
+#### Piping I/O to container processes
+
+When passing I/O to `ContainerClient.createProcess(stdio:)` or `ContainerClient.bootstrap(id:stdio:)`, **do not use Foundation's `Pipe()`**. Use `StdioPipes` from `Sources/socktainer/Utilities/DockerConnectionUtility.swift` instead.
+
+**Background**: on Unix, every open file/socket/pipe is identified by a small integer called a *file descriptor* (fd). Apple's APIs dup the fds you pass into the container and then **immediately close your originals**. Foundation's `Pipe` doesn't know this happened — when it's eventually garbage-collected, it tries to `close()` the same fd number again. By then, that number may have been recycled for a NIO HTTP socket, so the double-close silently kills an active connection, corrupting the event loop and causing hard-to-reproduce crashes under concurrent load (issue [#107](https://github.com/socktainer/socktainer/issues/107)).
+
+`StdioPipes` centralises allocation, EMFILE validation, and cleanup:
+
+```swift
+guard let pipes = StdioPipes.make([.stdin, .stdout, .stderr]) else { // or make(.all)
+    throw Abort(.internalServerError, reason: "Failed to create I/O pipes")
+}
+let process: ClientProcess
+do {
+    process = try await ContainerClient().createProcess(..., stdio: pipes.stdioArray)
+} catch {
+    pipes.closeAll()          // Apple never received the fds — close all 6
+    throw error
+}
+do {
+    try await process.start()
+} catch {
+    pipes.closeAfterHandoff() // Apple owns stdin.read, stdout.write, stderr.write
+    throw error
+}
+// Use pipes.stdout?.read, pipes.stderr?.read, pipes.stdin?.write in tasks
+```
+
+Ownership rules:
+- **stdout/stderr**: Apple closes `.write`. You close `.read` when the reader task ends.
+- **stdin**: Apple closes `.read`. You close `.write` when done sending input.
+- `StdioPipes.make()` closes any partial pipes on EMFILE and returns `nil` — always `guard let`.
+
+`make test` includes a `lint-pipes` check that fails if `= Pipe()` appears in any source file other than the one legitimate exception (`ClientRegistryService.swift`, which uses Foundation's own `Process`, not Apple Container APIs).
+
 ---
 
 ## Security & Limitations ⚠️

--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -347,7 +347,9 @@ struct ClientArchiveService: ClientArchiveProtocol {
         // cannot mask the existence checks.
         processConfig.user = .id(uid: 0, gid: 0)
 
-        let stderrPipe = Pipe()
+        guard let pipes = StdioPipes.make([.stderr]) else {
+            throw ClientArchiveError.operationFailed(message: "Failed to create stderr pipe")
+        }
 
         let process: ClientProcess
         do {
@@ -355,20 +357,23 @@ struct ClientArchiveService: ClientArchiveProtocol {
                 containerId: container.id,
                 processId: UUID().uuidString.lowercased(),
                 configuration: processConfig,
-                stdio: [nil, nil, stderrPipe.fileHandleForWriting]
+                stdio: pipes.stdioArray
             )
+        } catch {
+            pipes.closeAll()
+            throw ClientArchiveError.operationFailed(message: "Failed to exec into running container: \(error.localizedDescription)")
+        }
+        do {
             try await process.start()
         } catch {
-            try? stderrPipe.fileHandleForReading.close()
-            try? stderrPipe.fileHandleForWriting.close()
+            pipes.closeAfterHandoff()
             throw ClientArchiveError.operationFailed(message: "Failed to exec into running container: \(error.localizedDescription)")
         }
 
-        // Close our copy of the remote end so EOF propagates once the guest
-        // process exits (the daemon holds its own duplicate).
-        try? stderrPipe.fileHandleForWriting.close()
-
-        let stderrReader = stderrPipe.fileHandleForReading
+        // Drain stderr concurrently (capped at 16 KiB) while waiting.
+        // collectOutput() is not used here because it reads unboundedly via
+        // readDataToEndOfFile(); this capped reader prevents runaway memory growth.
+        let stderrReader = pipes.stderr!.read
         let stderrTask = Task.detached { () -> Data in
             defer { try? stderrReader.close() }
             var collected = Data()
@@ -384,6 +389,9 @@ struct ClientArchiveService: ClientArchiveProtocol {
         do {
             exitCode = try await process.wait()
         } catch {
+            // Concurrent close(2) + read(2) on the same fd is unsafe (NSException risk).
+            // Rethrow immediately; stderrTask exits naturally when the process terminates
+            // and Apple closes the write end.
             throw ClientArchiveError.operationFailed(message: "Failed waiting for validation in running container: \(error.localizedDescription)")
         }
 

--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -276,23 +276,30 @@ struct ClientBuilderService: ClientBuilderProtocol {
         processConfig.arguments = command.arguments
         processConfig.terminal = false
 
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        let process = try await containerClient.createProcess(
-            containerId: container.id,
-            processId: UUID().uuidString.lowercased(),
-            configuration: processConfig,
-            stdio: [nil, stdoutPipe.fileHandleForWriting, stderrPipe.fileHandleForWriting]
-        )
-
-        try await process.start()
-        let exitCode = try await process.wait()
-
-        try? stdoutPipe.fileHandleForWriting.close()
-        try? stderrPipe.fileHandleForWriting.close()
-
-        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let pipes = StdioPipes.make([.stdout, .stderr]) else {
+            throw ContainerizationError(.internalError, message: "Failed to create I/O pipes")
+        }
+        let process: ClientProcess
+        do {
+            process = try await containerClient.createProcess(
+                containerId: container.id,
+                processId: UUID().uuidString.lowercased(),
+                configuration: processConfig,
+                stdio: pipes.stdioArray
+            )
+        } catch {
+            pipes.closeAll()
+            throw error
+        }
+        do {
+            try await process.start()
+        } catch {
+            pipes.closeAfterHandoff()
+            throw error
+        }
+        let (exitCode, stdoutData, stderrData) = try await pipes.collectOutput {
+            try await process.wait()
+        }
         let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
         let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
 

--- a/Sources/socktainer/Clients/ClientRegistryService.swift
+++ b/Sources/socktainer/Clients/ClientRegistryService.swift
@@ -164,13 +164,32 @@ struct ClientRegistryService: ClientRegistryProtocol {
         }
         try stdinPipe.fileHandleForWriting.close()
 
+        // Drain stdout and stderr concurrently while the process runs.
+        // Calling waitUntilExit() before draining would deadlock if the process
+        // writes more than the pipe buffer holds (it blocks on write).
+        // group.wait() is the happens-before barrier; nonisolated(unsafe) tells
+        // the compiler we own the synchronisation.
+        nonisolated(unsafe) var stdoutData = Data()
+        nonisolated(unsafe) var stderrData = Data()
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
         process.waitUntilExit()
+        group.wait()
 
         let stdout =
-            String(data: try stdoutPipe.fileHandleForReading.readToEnd() ?? Data(), encoding: .utf8)?
+            String(data: stdoutData, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let stderr =
-            String(data: try stderrPipe.fileHandleForReading.readToEnd() ?? Data(), encoding: .utf8)?
+            String(data: stderrData, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
         guard process.terminationStatus == 0 else {

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -253,26 +253,27 @@ extension ContainerAttachRoute {
         // Apple Container requires all three stdio handles to be non-nil to use
         // pipe mode; passing nil for stdin causes it to fall back to log-file mode
         // which has the race condition we are trying to fix.
-        let stdinPipe = Pipe()
-        let stdoutPipe = attachStdout ? Pipe() : nil
-        let stderrPipe = (!isTTY && (query.stderr ?? false)) ? Pipe() : nil
-
-        let stdio: [FileHandle?] = [
-            stdinPipe.fileHandleForReading,
-            stdoutPipe?.fileHandleForWriting,
-            stderrPipe?.fileHandleForWriting,
-        ]
+        guard
+            let pipes = StdioPipes.make(
+                stdin: true,
+                stdout: attachStdout,
+                stderr: !isTTY && (query.stderr ?? false)
+            )
+        else {
+            throw Abort(.internalServerError, reason: "Failed to create stdio pipes")
+        }
 
         // No data will be written to stdin for non-interactive containers — close
-        // the write end immediately so the container's stdin sees EOF.
-        try? stdinPipe.fileHandleForWriting.close()
+        // our write end immediately so the container's stdin sees EOF.
+        try? pipes.stdin?.write.close()
 
         await ContainerExitCodeStore.shared.remove(id: container.id)
 
         let process: ClientProcess
         do {
-            process = try await ContainerClient().bootstrap(id: container.id, stdio: stdio)
+            process = try await ContainerClient().bootstrap(id: container.id, stdio: pipes.stdioArray)
         } catch {
+            pipes.closeAll()
             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             throw Abort(.internalServerError, reason: "Failed to bootstrap container: \(error.localizedDescription)")
         }
@@ -281,6 +282,7 @@ extension ContainerAttachRoute {
             try await process.start()
         } catch {
             if !isBenignStartRace(error) {
+                pipes.closeAfterHandoff()
                 await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                 throw Abort(.internalServerError, reason: "Failed to start container: \(error.localizedDescription)")
             }
@@ -305,13 +307,10 @@ extension ContainerAttachRoute {
                 _ = writer.write(.buffer(sharedAllocator.buffer(capacity: 0)))
 
                 await withTaskGroup(of: Void.self) { group in
-                    // Close pipes → readers drain → grace period → unblock /wait.
+                    // Process monitor — stdout/stderr write ends and stdin read are Apple-owned.
                     group.addTask {
                         let code = (try? await process.wait()) ?? 0
                         await ProcessRegistry.shared.remove(id: container.id)
-                        try? stdoutPipe?.fileHandleForWriting.close()
-                        try? stderrPipe?.fileHandleForWriting.close()
-                        try? stdinPipe.fileHandleForReading.close()
                         try? await Task.sleep(nanoseconds: Self.outputFlushGraceNs)
                         await ContainerExitCodeStore.shared.set(id: container.id, code: code)
                         await ContainerExitCodeStore.shared.set(id: hexId, code: code)
@@ -347,7 +346,7 @@ extension ContainerAttachRoute {
                     }
 
                     // Stdout reader
-                    if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+                    if let stdoutHandle = pipes.stdout?.read {
                         let frameType: DockerStreamFrame.StreamType = stderrOnly ? .stderr : .stdout
                         group.addTask {
                             defer { try? stdoutHandle.close() }
@@ -360,7 +359,7 @@ extension ContainerAttachRoute {
                     }
 
                     // Stderr reader (separate stream when both stdout and stderr requested)
-                    if let stderrHandle = stderrPipe?.fileHandleForReading {
+                    if let stderrHandle = pipes.stderr?.read {
                         group.addTask {
                             defer { try? stderrHandle.close() }
                             while let data = try? stderrHandle.read(upToCount: 8192), !data.isEmpty {
@@ -427,15 +426,15 @@ extension ContainerAttachRoute {
         let attachStderr = query.stderr ?? !isTTY
 
         // Create pipes for bidirectional communication with the main process
-        let stdinPipe: Pipe = Pipe()
-        let stdoutPipe: Pipe? = attachStdout ? Pipe() : nil
-        let stderrPipe: Pipe? = (attachStderr && !isTTY) ? Pipe() : nil
-
-        let stdio = [
-            stdinPipe.fileHandleForReading,
-            stdoutPipe?.fileHandleForWriting,
-            stderrPipe?.fileHandleForWriting,
-        ]
+        guard
+            let pipes = StdioPipes.make(
+                stdin: true,
+                stdout: attachStdout,
+                stderr: attachStderr && !isTTY
+            )
+        else {
+            throw Abort(.internalServerError, reason: "Failed to create stdio pipes")
+        }
 
         // Mirror ClientContainerService.start()'s exit-code contract: /wait returns
         // as soon as ContainerExitCodeStore is non-nil, so clear any stale code
@@ -445,8 +444,9 @@ extension ContainerAttachRoute {
 
         let process: ClientProcess
         do {
-            process = try await ContainerClient().bootstrap(id: container.id, stdio: stdio)
+            process = try await ContainerClient().bootstrap(id: container.id, stdio: pipes.stdioArray)
         } catch {
+            pipes.closeAll()
             if isBenignStartRace(error) {
                 throw Abort(.conflict, reason: "Container is already starting")
             }
@@ -457,6 +457,7 @@ extension ContainerAttachRoute {
         do {
             try await process.start()
         } catch {
+            pipes.closeAfterHandoff()
             if isBenignStartRace(error) {
                 throw Abort(.conflict, reason: "Container is already starting")
             }
@@ -477,12 +478,9 @@ extension ContainerAttachRoute {
                     // Process monitor - when process exits, close pipes and finish stream
                     group.addTask {
                         defer {
-                            // Close pipes to break the reader loops
-                            try? stdoutPipe?.fileHandleForWriting.close()
-                            try? stderrPipe?.fileHandleForWriting.close()
-                            try? stdinPipe.fileHandleForWriting.close()
-
-                            // Close stream
+                            // stdout/stderr write ends are Apple-owned — do not close them.
+                            // stdin write end is owned by the stdin-writer task below; closing
+                            // it here too would be a double-close on the same fd.
                             streamContinuation.finish()
                         }
 
@@ -498,7 +496,7 @@ extension ContainerAttachRoute {
                         await ProcessRegistry.shared.remove(id: container.id)
                     }
 
-                    if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+                    if let stdoutHandle = pipes.stdout?.read {
                         group.addTask {
                             defer {
                                 try? stdoutHandle.close()
@@ -525,7 +523,7 @@ extension ContainerAttachRoute {
                         }
                     }
 
-                    if let stderrHandle = stderrPipe?.fileHandleForReading {
+                    if let stderrHandle = pipes.stderr?.read {
                         group.addTask {
                             defer {
                                 try? stderrHandle.close()
@@ -552,7 +550,7 @@ extension ContainerAttachRoute {
                         }
                     }
 
-                    let stdinWriter = stdinPipe.fileHandleForWriting
+                    let stdinWriter = pipes.stdin!.write
                     group.addTask {
                         defer {
                             try? stdinWriter.close()
@@ -579,17 +577,21 @@ extension ContainerAttachRoute {
             ttyEnabled: isTTY
         ) { channel, tcpHandler in
 
-            tcpHandler.setStdinWriter(stdinPipe.fileHandleForWriting)
+            tcpHandler.setStdinWriter(pipes.stdin!.write)
 
             await withTaskGroup(of: Void.self) { group in
-                if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+                if let stdoutHandle = pipes.stdout?.read {
                     group.addTask {
                         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                             let dispatchIO = DispatchIO(
                                 type: .stream,
                                 fileDescriptor: stdoutHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
-                            ) { error in
+                            ) { _ in
+                                // Close in the cleanup handler — DispatchIO relinquishes
+                                // the fd here, so it's safe to close without risk of
+                                // closing a recycled descriptor.
+                                try? stdoutHandle.close()
                                 continuation.resume()
                             }
 
@@ -646,19 +648,18 @@ extension ContainerAttachRoute {
 
                             readNextChunk()
                         }
-
-                        try? stdoutHandle.close()
                     }
                 }
 
-                if let stderrHandle = stderrPipe?.fileHandleForReading {
+                if let stderrHandle = pipes.stderr?.read {
                     group.addTask {
                         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                             let dispatchIO = DispatchIO(
                                 type: .stream,
                                 fileDescriptor: stderrHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
-                            ) { error in
+                            ) { _ in
+                                try? stderrHandle.close()
                                 continuation.resume()
                             }
 
@@ -715,8 +716,6 @@ extension ContainerAttachRoute {
 
                             readNextChunk()
                         }
-
-                        try? stderrHandle.close()
                     }
                 }
 
@@ -743,10 +742,10 @@ extension ContainerAttachRoute {
                     // Give a small delay for any final output to be processed
                     try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms
 
-                    // Close all pipes to signal EOF to readers
-                    try? stdoutPipe?.fileHandleForWriting.close()
-                    try? stderrPipe?.fileHandleForWriting.close()
-                    try? stdinPipe.fileHandleForWriting.close()
+                    // DockerTCPHandler owns pipes.stdin!.write after setStdinWriter(); it closes
+                    // it via writeQueue on channelInactive / inputClosed. Closing it here too
+                    // would be a double-close that can kill a reused fd.
+                    // stdout/stderr write ends are Apple-owned — also do not close them.
 
                     // Close the channel gracefully only if still open.
                     // Calling close() on an already-closed channel causes

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -64,40 +64,32 @@ extension ContainerAttachWSRoute {
         let stderr = query.stderr ?? true
         let isTTY = container.configuration.initProcess.terminal
 
-        let stdinPipe = Pipe()
-        let stdoutPipe: Pipe? = stdout ? Pipe() : nil
-        let stderrPipe: Pipe? = (stderr && !isTTY) ? Pipe() : nil
-
-        let stdio: [FileHandle?] = [
-            stdinPipe.fileHandleForReading,
-            stdoutPipe?.fileHandleForWriting,
-            stderrPipe?.fileHandleForWriting,
-        ]
-
-        // Close the write end immediately when not interactive so the container
-        // sees EOF on its stdin without waiting for a client signal.
-        if !stdin {
-            try? stdinPipe.fileHandleForWriting.close()
+        guard let pipes = StdioPipes.make(stdin: true, stdout: stdout, stderr: stderr && !isTTY) else {
+            try? await ws.close(code: .unexpectedServerError)
+            return
         }
 
-        // Wire client disconnect → stdin EOF before bootstrap, so an early
-        // disconnect still signals the container cleanly.
-        // ws.onClose is the ONLY cleanup path for the stdin write end;
-        // the process monitor task owns all other teardown to avoid double-close.
+        // For non-interactive containers, pre-close the write end so the container
+        // sees immediate stdin EOF. ws.onClose (registered below) calls close() on
+        // the same FileHandle object — Foundation makes that second call a no-op.
+        if !stdin {
+            try? pipes.stdin?.write.close()
+        }
+
+        // ws.onClose is the sole owner for the interactive stdin write end.
+        // For non-interactive, the pre-close above already happened — this is a
+        // safe no-op second call on the same FileHandle object.
         ws.onClose.whenComplete { _ in
-            try? stdinPipe.fileHandleForWriting.close()
+            try? pipes.stdin?.write.close()
         }
 
         await ContainerExitCodeStore.shared.remove(id: container.id)
 
         let process: ClientProcess
         do {
-            process = try await ContainerClient().bootstrap(id: container.id, stdio: stdio)
+            process = try await ContainerClient().bootstrap(id: container.id, stdio: pipes.stdioArray)
         } catch {
-            // Fix: close all pipe handles before returning to avoid fd leaks.
-            try? stdinPipe.fileHandleForReading.close()
-            try? stdoutPipe?.fileHandleForWriting.close()
-            try? stderrPipe?.fileHandleForWriting.close()
+            pipes.closeAll()
             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
             await ContainerExitCodeStore.shared.set(id: hexId, code: -1)
             try? await ws.close(code: .unexpectedServerError)
@@ -108,9 +100,7 @@ extension ContainerAttachWSRoute {
             try await process.start()
         } catch {
             if !isBenignStartRace(error) {
-                try? stdinPipe.fileHandleForReading.close()
-                try? stdoutPipe?.fileHandleForWriting.close()
-                try? stderrPipe?.fileHandleForWriting.close()
+                pipes.closeAfterHandoff()
                 await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
                 await ContainerExitCodeStore.shared.set(id: hexId, code: -1)
                 try? await ws.close(code: .unexpectedServerError)
@@ -123,7 +113,7 @@ extension ContainerAttachWSRoute {
         // Wire WS → stdin. Guard ws.isClosed so a late-arriving frame after
         // teardown doesn't write to a closed fd.
         if stdin {
-            let stdinWriter = stdinPipe.fileHandleForWriting
+            let stdinWriter = pipes.stdin!.write
             ws.onBinary { ws, buf in
                 guard !ws.isClosed else { return }
                 var b = buf
@@ -143,10 +133,9 @@ extension ContainerAttachWSRoute {
 
                 await ProcessRegistry.shared.remove(id: container.id)
 
-                // Close pipe write ends → readers drain → break their loops.
-                try? stdoutPipe?.fileHandleForWriting.close()
-                try? stderrPipe?.fileHandleForWriting.close()
-                try? stdinPipe.fileHandleForReading.close()
+                // stdout/stderr write ends and stdin read end are Apple-owned —
+                // do not close them here (double-close causes fd-reuse crashes).
+                // ws.onClose owns the stdin write end; readers own their read ends.
 
                 try? await Task.sleep(nanoseconds: ContainerAttachRoute.outputFlushGraceNs)
                 // Extra probe delay matching HTTP attach — lets Apple Container finish
@@ -180,7 +169,7 @@ extension ContainerAttachWSRoute {
             }
 
             // Stdout → WS binary frames. Break on send error (client disconnected).
-            if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+            if let stdoutHandle = pipes.stdout?.read {
                 group.addTask {
                     defer { try? stdoutHandle.close() }
                     while let data = try? stdoutHandle.read(upToCount: 8192), !data.isEmpty {
@@ -194,7 +183,7 @@ extension ContainerAttachWSRoute {
             }
 
             // Stderr → WS binary frames (non-TTY + both streams requested).
-            if let stderrHandle = stderrPipe?.fileHandleForReading {
+            if let stderrHandle = pipes.stderr?.read {
                 group.addTask {
                     defer { try? stderrHandle.close() }
                     while let data = try? stderrHandle.read(upToCount: 8192), !data.isEmpty {

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -83,17 +83,6 @@ struct CreateExecResponse: Content {
     let Id: String
 }
 
-// Helper to convert pipes to stdio array
-struct Stdio {
-    let stdin: FileHandle?
-    let stdout: FileHandle?
-    let stderr: FileHandle?
-
-    var asArray: [FileHandle?] {
-        [stdin, stdout, stderr]
-    }
-}
-
 struct ExecRoute: RouteCollection {
     let client: ClientContainerProtocol
 
@@ -313,16 +302,16 @@ struct ExecRoute: RouteCollection {
                     ttyEnabled: tty
                 ) { streamContinuation in
 
-                    // Setup pipes
-                    let stdinPipe: Pipe? = config.attachStdin ? Pipe() : nil
-                    let stdoutPipe: Pipe? = config.attachStdout ? Pipe() : nil
-                    let stderrPipe: Pipe? = (config.attachStderr && !tty) ? Pipe() : nil
-
-                    let stdio = Stdio(
-                        stdin: stdinPipe?.fileHandleForReading,
-                        stdout: stdoutPipe?.fileHandleForWriting,
-                        stderr: stderrPipe?.fileHandleForWriting
-                    )
+                    guard
+                        let pipes = StdioPipes.make(
+                            stdin: config.attachStdin,
+                            stdout: config.attachStdout,
+                            stderr: config.attachStderr && !tty
+                        )
+                    else {
+                        await ExecManager.shared.setExitCode(id: execId, code: -1)
+                        throw Abort(.internalServerError, reason: "Failed to create I/O pipes")
+                    }
 
                     let executable = config.cmd.first!
                     let arguments = Array(config.cmd.dropFirst())
@@ -331,18 +320,24 @@ struct ExecRoute: RouteCollection {
                     processConfig.arguments = arguments
                     processConfig.terminal = tty
 
-                    let process = try await ContainerClient().createProcess(
-                        containerId: container.id,
-                        processId: UUID().uuidString.lowercased(),
-                        configuration: processConfig,
-                        stdio: stdio.asArray
-                    )
+                    let process: ClientProcess
+                    do {
+                        process = try await ContainerClient().createProcess(
+                            containerId: container.id,
+                            processId: UUID().uuidString.lowercased(),
+                            configuration: processConfig,
+                            stdio: pipes.stdioArray
+                        )
+                    } catch {
+                        pipes.closeAll()
+                        await ExecManager.shared.setExitCode(id: execId, code: -1)
+                        throw error
+                    }
 
                     do {
                         try await process.start()
                     } catch {
-                        // Record an exit code so a failed start doesn't leave
-                        // the exec stuck reporting Running forever.
+                        pipes.closeAfterHandoff()
                         await ExecManager.shared.setExitCode(id: execId, code: -1)
                         throw error
                     }
@@ -352,100 +347,65 @@ struct ExecRoute: RouteCollection {
 
                     await withTaskGroup(of: Void.self) { group in
                         // stdout handler
-                        if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+                        if let stdoutRead = pipes.stdout?.read {
                             group.addTask {
-                                defer {
-                                    try? stdoutHandle.close()
-                                }
-
-                                let state = DockerConnectionState()
-
-                                while !state.shouldStop() {
+                                defer { try? stdoutRead.close() }
+                                while true {
                                     do {
                                         // A blocking pipe read returns empty Data only at EOF —
                                         // the process exited and its stdout writer was closed.
-                                        // Break so the task group can finish and the response
-                                        // stream is closed; sleeping/continuing here spins forever
-                                        // and the Docker client hangs waiting for the stream to end.
-                                        guard let data = try stdoutHandle.read(upToCount: 8192), !data.isEmpty else {
+                                        guard let data = try stdoutRead.read(upToCount: 8192), !data.isEmpty else {
                                             break
                                         }
-
                                         let bufferSize = min(data.count + (tty ? 0 : 8), 65536)
                                         var buffer = sharedAllocator.buffer(capacity: bufferSize)
                                         buffer.writeDockerFrame(streamType: .stdout, data: data, ttyMode: tty)
                                         streamContinuation.yield(buffer)
-                                    } catch {
-                                        break
-                                    }
+                                    } catch { break }
                                 }
                             }
                         }
 
                         // stderr handler
-                        if let stderrHandle = stderrPipe?.fileHandleForReading {
+                        if let stderrRead = pipes.stderr?.read {
                             group.addTask {
-                                defer {
-                                    try? stderrHandle.close()
-                                }
-
-                                let state = DockerConnectionState()
-
-                                while !state.shouldStop() {
+                                defer { try? stderrRead.close() }
+                                while true {
                                     do {
                                         // A blocking pipe read returns empty Data only at EOF —
                                         // the process exited and its stderr writer was closed.
-                                        // Break so the task group can finish and the response
-                                        // stream is closed; sleeping/continuing here spins forever
-                                        // and the Docker client hangs waiting for the stream to end.
-                                        guard let data = try stderrHandle.read(upToCount: 8192), !data.isEmpty else {
+                                        guard let data = try stderrRead.read(upToCount: 8192), !data.isEmpty else {
                                             break
                                         }
-
                                         let bufferSize = min(data.count + 8, 65536)
                                         var buffer = sharedAllocator.buffer(capacity: bufferSize)
                                         buffer.writeDockerFrame(streamType: .stderr, data: data, ttyMode: tty)
                                         streamContinuation.yield(buffer)
-                                    } catch {
-                                        break
-                                    }
+                                    } catch { break }
                                 }
                             }
                         }
 
                         // stdin handler for HTTP mode
-                        if let stdinWriter = stdinPipe?.fileHandleForWriting {
+                        if let stdinWrite = pipes.stdin?.write {
                             group.addTask {
-                                defer {
-                                    try? stdinWriter.close()
-                                }
-
+                                defer { try? stdinWrite.close() }
                                 do {
                                     for try await var buf in req.body {
                                         if let data = buf.readData(length: buf.readableBytes) {
-                                            try stdinWriter.write(contentsOf: data)
+                                            try stdinWrite.write(contentsOf: data)
                                         }
                                     }
-                                } catch {
-                                }
+                                } catch {}
                             }
                         }
 
                         // Process monitor
                         group.addTask {
-                            defer {
-                                // Close all write ends to signal EOF
-                                try? stdoutPipe?.fileHandleForWriting.close()
-                                try? stderrPipe?.fileHandleForWriting.close()
-                                try? stdinPipe?.fileHandleForWriting.close()
-                            }
-
                             do {
                                 let exitCode = try await process.wait()
                                 await ExecManager.shared.setExitCode(id: execId, code: exitCode)
                             } catch {
-                                // process.wait() failed — record a synthetic exit
-                                // code so the exec leaves the Running state.
                                 await ExecManager.shared.setExitCode(id: execId, code: -1)
                             }
                             await ProcessRegistry.shared.remove(id: execId)
@@ -466,20 +426,15 @@ struct ExecRoute: RouteCollection {
                 ttyEnabled: tty
             ) { channel, tcpHandler in
 
-                // Setup pipes with detailed logging
-                let stdinPipe: Pipe? = config.attachStdin ? Pipe() : nil
-                let stdoutPipe: Pipe? = config.attachStdout ? Pipe() : nil
-                let stderrPipe: Pipe? = (config.attachStderr && !tty) ? Pipe() : nil
-
-                let stdio = Stdio(
-                    stdin: stdinPipe?.fileHandleForReading,
-                    stdout: stdoutPipe?.fileHandleForWriting,
-                    stderr: stderrPipe?.fileHandleForWriting
-                )
-
-                // Connect TCP handler to stdin writer for bidirectional communication
-                if let stdinWriter = stdinPipe?.fileHandleForWriting {
-                    tcpHandler.setStdinWriter(stdinWriter)
+                guard
+                    let pipes = StdioPipes.make(
+                        stdin: config.attachStdin,
+                        stdout: config.attachStdout,
+                        stderr: config.attachStderr && !tty
+                    )
+                else {
+                    await ExecManager.shared.setExitCode(id: execId, code: -1)
+                    throw Abort(.internalServerError, reason: "Failed to create I/O pipes")
                 }
 
                 let executable = config.cmd.first!
@@ -490,20 +445,30 @@ struct ExecRoute: RouteCollection {
                 processConfig.arguments = arguments
                 processConfig.terminal = tty
 
-                let process = try await ContainerClient().createProcess(
-                    containerId: container.id,
-                    processId: UUID().uuidString.lowercased(),
-                    configuration: processConfig,
-                    stdio: stdio.asArray
-                )
-
+                let process: ClientProcess
+                do {
+                    process = try await ContainerClient().createProcess(
+                        containerId: container.id,
+                        processId: UUID().uuidString.lowercased(),
+                        configuration: processConfig,
+                        stdio: pipes.stdioArray
+                    )
+                } catch {
+                    pipes.closeAll()
+                    await ExecManager.shared.setExitCode(id: execId, code: -1)
+                    throw error
+                }
                 do {
                     try await process.start()
                 } catch {
-                    // Record an exit code so a failed start doesn't leave the
-                    // exec stuck reporting Running forever.
+                    pipes.closeAfterHandoff()
                     await ExecManager.shared.setExitCode(id: execId, code: -1)
                     throw error
+                }
+                // Wire stdin only after start() succeeds so closeAfterHandoff()
+                // remains the sole owner on any failure path before this point.
+                if let stdinWrite = pipes.stdin?.write {
+                    tcpHandler.setStdinWriter(stdinWrite)
                 }
 
                 await ProcessRegistry.shared.set(id: execId, process: process)
@@ -512,17 +477,16 @@ struct ExecRoute: RouteCollection {
                 // Setup bidirectional communication for interactive sessions
                 await withTaskGroup(of: Void.self) { group in
                     // stdout/stderr -> channel (container output to client)
-                    if let stdoutHandle = stdoutPipe?.fileHandleForReading {
+                    if let stdoutHandle = pipes.stdout?.read {
                         group.addTask {
-                            defer {
-                                try? stdoutHandle.close()
-                            }
-
                             let dispatchIO = DispatchIO(
                                 type: .stream,
                                 fileDescriptor: stdoutHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
-                            ) { error in
+                            ) { _ in
+                                // DispatchIO relinquishes the fd in its cleanup handler.
+                                // Close here to avoid closing a potentially recycled fd.
+                                try? stdoutHandle.close()
                             }
 
                             defer {
@@ -580,18 +544,14 @@ struct ExecRoute: RouteCollection {
                         }
                     }
 
-                    if let stderrHandle = stderrPipe?.fileHandleForReading {
+                    if let stderrHandle = pipes.stderr?.read {
                         group.addTask {
-                            defer {
-                                try? stderrHandle.close()
-                            }
-
                             let dispatchIO = DispatchIO(
                                 type: .stream,
                                 fileDescriptor: stderrHandle.fileDescriptor,
                                 queue: DispatchQueue.global(qos: .userInteractive)
-                            ) { error in
-                                // Cleanup handled automatically
+                            ) { _ in
+                                try? stderrHandle.close()
                             }
 
                             defer {
@@ -670,10 +630,10 @@ struct ExecRoute: RouteCollection {
                         // Give a small delay for any final output to be processed
                         try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
 
-                        // Close all pipes to signal EOF to readers
-                        try? stdoutPipe?.fileHandleForWriting.close()
-                        try? stderrPipe?.fileHandleForWriting.close()
-                        try? stdinPipe?.fileHandleForWriting.close()
+                        // DockerTCPHandler owns stdinPipe?.write after setStdinWriter(); it closes
+                        // it via writeQueue on channelInactive / inputClosed. Closing it here too
+                        // would be a double-close that can kill a reused fd.
+                        // stdout/stderr write ends are Apple-owned — also do not close them.
 
                         // Close the channel gracefully
                         _ = channel.eventLoop.submit {

--- a/Sources/socktainer/Utilities/DockerConnectionUtility.swift
+++ b/Sources/socktainer/Utilities/DockerConnectionUtility.swift
@@ -32,6 +32,195 @@ public final class DockerConnectionState: @unchecked Sendable {
 /// Shared allocator for memory efficiency across Docker operations
 public let sharedAllocator = ByteBufferAllocator()
 
+/// Low-level pipe pair created via pipe(2) with closeOnDealloc:false.
+///
+/// **Prefer `StdioPipes`** for all container stdio wiring — it handles EMFILE
+/// validation and provides `closeAll()` / `closeAfterHandoff()` so every error
+/// path is covered without manual per-fd calls. `ProcessPipe` is an
+/// implementation detail exposed only for testing the raw fd ownership contract.
+///
+/// Ownership model:
+///   - stdout/stderr: pass `.write` to createProcess/bootstrap; Apple owns that close.
+///     Caller explicitly closes `.read` when the reader task finishes.
+///   - stdin: pass `.read` to createProcess/bootstrap; Apple owns that close.
+///     Caller explicitly closes `.write` when done writing.
+struct ProcessPipe: @unchecked Sendable {
+    let read: FileHandle
+    let write: FileHandle
+
+    static func make() -> ProcessPipe? {
+        var fds: [Int32] = [0, 0]
+        guard Darwin.pipe(&fds) == 0 else { return nil }
+        return ProcessPipe(
+            read: FileHandle(fileDescriptor: fds[0], closeOnDealloc: false),
+            write: FileHandle(fileDescriptor: fds[1], closeOnDealloc: false)
+        )
+    }
+}
+
+/// Collects the three stdio pipe pairs for a container process, with centralised
+/// allocation, validation, and cleanup that eliminates per-call-site boilerplate
+/// and prevents fd leaks on every error path.
+///
+/// Ownership after `createProcess(stdio:)` / `bootstrap(id:stdio:)`:
+///   - Apple owns and will close: `stdin?.read`, `stdout?.write`, `stderr?.write`
+///   - Caller owns and must close: `stdin?.write`, `stdout?.read`, `stderr?.read`
+///
+/// Usage pattern:
+/// ```swift
+/// guard let pipes = StdioPipes.make([.stdin, .stdout, .stderr]) else {
+///     throw Abort(.internalServerError, reason: "Failed to create I/O pipes")
+/// }
+/// let process: ClientProcess
+/// do {
+///     process = try await ContainerClient().createProcess(..., stdio: pipes.stdioArray)
+/// } catch {
+///     pipes.closeAll()   // Apple never took ownership
+///     throw error
+/// }
+/// do {
+///     try await process.start()
+/// } catch {
+///     pipes.closeAfterHandoff()   // Apple owns the passed ends
+///     throw error
+/// }
+/// ```
+struct StdioPipes: @unchecked Sendable {
+
+    /// Which stdio channels to allocate. Use as an OptionSet:
+    ///   `StdioPipes.make([.stdout, .stderr])`  or  `StdioPipes.make(.all)`
+    struct Channels: OptionSet {
+        let rawValue: UInt8
+        static let stdin = Channels(rawValue: 1 << 0)
+        static let stdout = Channels(rawValue: 1 << 1)
+        static let stderr = Channels(rawValue: 1 << 2)
+        static let all: Channels = [.stdin, .stdout, .stderr]
+    }
+
+    let stdin: ProcessPipe?
+    let stdout: ProcessPipe?
+    let stderr: ProcessPipe?
+
+    /// `[stdin.read, stdout.write, stderr.write]` — the array to pass to createProcess/bootstrap.
+    var stdioArray: [FileHandle?] { [stdin?.read, stdout?.write, stderr?.write] }
+
+    /// Allocates pipes for the requested channels. Returns `nil` (and closes any
+    /// partially-allocated pipes) if any required pipe cannot be created (EMFILE).
+    ///
+    /// Prefer the OptionSet overload for static channel selection:
+    ///   `StdioPipes.make([.stdout, .stderr])`  or  `StdioPipes.make(.all)`
+    /// Use the Bool overload (`make(stdin:stdout:stderr:)`) when channels are
+    /// computed dynamically from config flags.
+    ///
+    /// The `makePipe` parameter defaults to `ProcessPipe.make` and exists solely
+    /// as a test seam — inject a custom factory to exercise the partial-allocation
+    /// cleanup path without exhausting process-wide file descriptors.
+    static func make(_ channels: Channels, makePipe: () -> ProcessPipe? = ProcessPipe.make) -> StdioPipes? {
+        let stdinPipe = channels.contains(.stdin) ? makePipe() : nil
+        let stdoutPipe = channels.contains(.stdout) ? makePipe() : nil
+        let stderrPipe = channels.contains(.stderr) ? makePipe() : nil
+
+        let allOk =
+            (!channels.contains(.stdin) || stdinPipe != nil)
+            && (!channels.contains(.stdout) || stdoutPipe != nil)
+            && (!channels.contains(.stderr) || stderrPipe != nil)
+
+        guard allOk else {
+            try? stdinPipe?.read.close()
+            try? stdinPipe?.write.close()
+            try? stdoutPipe?.read.close()
+            try? stdoutPipe?.write.close()
+            try? stderrPipe?.read.close()
+            try? stderrPipe?.write.close()
+            return nil
+        }
+        return StdioPipes(stdin: stdinPipe, stdout: stdoutPipe, stderr: stderrPipe)
+    }
+
+    /// Convenience overload for dynamic channel selection from boolean config flags.
+    /// Use the OptionSet overload for static cases: `make([.stdout, .stderr])`.
+    static func make(stdin: Bool, stdout: Bool, stderr: Bool) -> StdioPipes? {
+        var channels: Channels = []
+        if stdin { channels.insert(.stdin) }
+        if stdout { channels.insert(.stdout) }
+        if stderr { channels.insert(.stderr) }
+        return make(channels)
+    }
+
+    /// Close all six fds. Use when createProcess/bootstrap has NOT yet taken ownership
+    /// (e.g. the call threw before completing the dup).
+    func closeAll() {
+        try? stdin?.read.close()
+        try? stdin?.write.close()
+        try? stdout?.read.close()
+        try? stdout?.write.close()
+        try? stderr?.read.close()
+        try? stderr?.write.close()
+    }
+
+    /// Close the fds we retain after createProcess/bootstrap has taken ownership:
+    /// `stdin?.write`, `stdout?.read`, `stderr?.read`.
+    ///
+    /// Safe to call even when `stdin?.write` was already closed (e.g. pre-closed
+    /// for non-interactive attach) — `FileHandle.close()` is idempotent on the
+    /// same object.
+    func closeAfterHandoff() {
+        try? stdin?.write.close()
+        try? stdout?.read.close()
+        try? stderr?.read.close()
+    }
+
+    /// Collect stdout and stderr as `Data` while concurrently waiting for the
+    /// process via `wait`. Draining must happen before waiting: if the child
+    /// writes more than the pipe buffer holds it blocks on write, so calling
+    /// `wait` first would deadlock.
+    ///
+    /// On error the wait closure's error is rethrown immediately. The drain
+    /// tasks continue in the background and exit naturally when the process
+    /// exits and Apple closes the write ends.
+    ///
+    /// - Parameter wait: async closure that waits for the process and returns
+    ///   its exit code (e.g. `{ try await process.wait() }`).
+    func collectOutput(waiting wait: () async throws -> Int32) async throws -> (
+        exitCode: Int32, stdout: Data, stderr: Data
+    ) {
+        let stdoutReader = stdout?.read
+        let stderrReader = stderr?.read
+
+        // `read(upToCount:)` loop is used instead of `readDataToEndOfFile()` /
+        // `readToEnd()`. Both of those can raise NSException when the fd is
+        // closed from the error path below. `read(upToCount:)` returns nil on
+        // EBADF (swallowed by `try?`), which cleanly breaks the loop.
+        let stdoutTask = Task.detached { () -> Data in
+            defer { try? stdoutReader?.close() }
+            var data = Data()
+            while let chunk = try? stdoutReader?.read(upToCount: 65_536), !chunk.isEmpty {
+                data.append(chunk)
+            }
+            return data
+        }
+        let stderrTask = Task.detached { () -> Data in
+            defer { try? stderrReader?.close() }
+            var data = Data()
+            while let chunk = try? stderrReader?.read(upToCount: 65_536), !chunk.isEmpty {
+                data.append(chunk)
+            }
+            return data
+        }
+
+        do {
+            let code = try await wait()
+            return (code, await stdoutTask.value, await stderrTask.value)
+        } catch {
+            // Do NOT close read ends here — concurrent close(2) + read(2) on the same
+            // fd is unsafe and can raise NSException. The drain tasks will exit on
+            // their own once the process fully exits and Apple closes the write ends.
+            // We rethrow immediately rather than awaiting them.
+            throw error
+        }
+    }
+}
+
 /// This provides TCP connection hijacking for Docker exec endpoints
 public struct DockerTCPUpgrader: Upgrader, Sendable {
     let execId: String

--- a/Tests/socktainerTests/Routes/StdioPipesTests.swift
+++ b/Tests/socktainerTests/Routes/StdioPipesTests.swift
@@ -1,0 +1,308 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+// All fd-ownership tests share a single parent suite that is .serialized.
+// Each child suite's tests run sequentially within the parent, preventing the
+// fd-reuse race where a parallel test opens a new pipe and gets the same fd
+// number that a just-closed pipe held (causing fcntl checks to see ≥0).
+@Suite("Pipe fd ownership", .serialized)
+struct PipeFdOwnershipTests {
+
+    // MARK: - StdioPipes
+
+    /// Tests for `StdioPipes` — the high-level stdio pipe manager.
+    ///
+    /// `StdioPipes` centralises allocation, EMFILE validation, and cleanup for all
+    /// three stdio channels passed to `createProcess(stdio:)` / `bootstrap(id:stdio:)`.
+    @Suite("StdioPipes — allocation and cleanup")
+    struct StdioPipesTests {
+
+        @Test("make() returns valid fds for all requested streams")
+        func makeReturnsValidFds() {
+            guard let pipes = StdioPipes.make(.all) else {
+                Issue.record("StdioPipes.make() returned nil")
+                return
+            }
+            for fd in [
+                pipes.stdin?.read.fileDescriptor, pipes.stdin?.write.fileDescriptor,
+                pipes.stdout?.read.fileDescriptor, pipes.stdout?.write.fileDescriptor,
+                pipes.stderr?.read.fileDescriptor, pipes.stderr?.write.fileDescriptor,
+            ].compactMap({ $0 }) {
+                #expect(Darwin.fcntl(fd, F_GETFD) >= 0, "fd \(fd) not valid")
+            }
+            pipes.closeAll()
+        }
+
+        @Test("make() returns nil for streams not requested")
+        func makeReturnsNilForUnrequestedStreams() {
+            guard let pipes = StdioPipes.make([.stdout]) else {
+                Issue.record("StdioPipes.make() returned nil")
+                return
+            }
+            #expect(pipes.stdin == nil)
+            #expect(pipes.stdout != nil)
+            #expect(pipes.stderr == nil)
+            pipes.closeAll()
+        }
+
+        @Test("stdioArray ordering: stdin.read, stdout.write, stderr.write")
+        func stdioArrayHasCorrectOrdering() {
+            guard let pipes = StdioPipes.make(.all) else {
+                Issue.record("StdioPipes.make() returned nil")
+                return
+            }
+            let array = pipes.stdioArray
+            #expect(array.count == 3)
+            #expect(array[0] === pipes.stdin?.read)
+            #expect(array[1] === pipes.stdout?.write)
+            #expect(array[2] === pipes.stderr?.write)
+            pipes.closeAll()
+        }
+
+        @Test("closeAll() closes all six fds")
+        func closeAllClosesSixFds() {
+            var fds: [Int32] = []
+            do {
+                guard let pipes = StdioPipes.make(.all) else {
+                    Issue.record("StdioPipes.make() returned nil")
+                    return
+                }
+                fds = [
+                    pipes.stdin!.read.fileDescriptor, pipes.stdin!.write.fileDescriptor,
+                    pipes.stdout!.read.fileDescriptor, pipes.stdout!.write.fileDescriptor,
+                    pipes.stderr!.read.fileDescriptor, pipes.stderr!.write.fileDescriptor,
+                ]
+                pipes.closeAll()
+                // pipes released here — closeOnDealloc:false means deinit won't re-close
+            }
+            for fd in fds {
+                #expect(Darwin.fcntl(fd, F_GETFD) == -1, "fd \(fd) should be closed after closeAll()")
+            }
+        }
+
+        /// Verifies the post-handoff ownership split:
+        /// - closeAfterHandoff() closes: stdin.write, stdout.read, stderr.read (caller-owned)
+        /// - closeAfterHandoff() leaves open: stdin.read, stdout.write, stderr.write (Apple-owned)
+        @Test("closeAfterHandoff() closes only caller-owned fds, leaves Apple-owned fds open")
+        func closeAfterHandoffClosesOnlyCallerOwnedFds() {
+            var stdinRead: Int32 = -1
+            var stdinWrite: Int32 = -1
+            var stdoutRead: Int32 = -1
+            var stdoutWrite: Int32 = -1
+            var stderrRead: Int32 = -1
+            var stderrWrite: Int32 = -1
+
+            do {
+                guard let pipes = StdioPipes.make(.all) else {
+                    Issue.record("StdioPipes.make() returned nil")
+                    return
+                }
+                stdinRead = pipes.stdin!.read.fileDescriptor
+                stdinWrite = pipes.stdin!.write.fileDescriptor
+                stdoutRead = pipes.stdout!.read.fileDescriptor
+                stdoutWrite = pipes.stdout!.write.fileDescriptor
+                stderrRead = pipes.stderr!.read.fileDescriptor
+                stderrWrite = pipes.stderr!.write.fileDescriptor
+                pipes.closeAfterHandoff()
+            }
+
+            // Caller-owned ends are closed
+            #expect(Darwin.fcntl(stdinWrite, F_GETFD) == -1, "stdin.write (caller-owned) must be closed")
+            #expect(Darwin.fcntl(stdoutRead, F_GETFD) == -1, "stdout.read (caller-owned) must be closed")
+            #expect(Darwin.fcntl(stderrRead, F_GETFD) == -1, "stderr.read (caller-owned) must be closed")
+
+            // Apple-owned ends remain open (closeAfterHandoff must not touch them)
+            #expect(Darwin.fcntl(stdinRead, F_GETFD) >= 0, "stdin.read (Apple-owned) must stay open")
+            #expect(Darwin.fcntl(stdoutWrite, F_GETFD) >= 0, "stdout.write (Apple-owned) must stay open")
+            #expect(Darwin.fcntl(stderrWrite, F_GETFD) >= 0, "stderr.write (Apple-owned) must stay open")
+
+            Darwin.close(stdinRead)
+            Darwin.close(stdoutWrite)
+            Darwin.close(stderrWrite)
+        }
+    }
+
+    @Test("make() closes partially-allocated fds when a later pipe allocation fails")
+    func makeCleansUpPartialAllocationOnFailure() {
+        // Capture fds from the first successful allocation so we can verify
+        // the guard-else block closes them when the second allocation fails.
+        var capturedRead: Int32 = -1
+        var capturedWrite: Int32 = -1
+        var callCount = 0
+
+        let result = StdioPipes.make([.stdin, .stdout]) { () -> ProcessPipe? in
+            callCount += 1
+            guard let pipe = ProcessPipe.make() else { return nil }
+            if callCount == 1 {
+                capturedRead = pipe.read.fileDescriptor
+                capturedWrite = pipe.write.fileDescriptor
+                return pipe  // first allocation succeeds
+            }
+            // Simulate EMFILE on the second allocation; close the real pipe we made.
+            try? pipe.read.close()
+            try? pipe.write.close()
+            return nil
+        }
+
+        #expect(result == nil, "make() must return nil when any required pipe fails")
+        #expect(callCount == 2, "factory called twice: once for stdin (ok), once for stdout (fail)")
+        // The guard-else block must have closed the first pipe's fds.
+        #expect(Darwin.fcntl(capturedRead, F_GETFD) == -1, "first pipe read fd must be closed by guard-else")
+        #expect(Darwin.fcntl(capturedWrite, F_GETFD) == -1, "first pipe write fd must be closed by guard-else")
+    }
+
+    // MARK: - collectOutput
+
+    @Suite("StdioPipes.collectOutput — concurrent drain while waiting")
+    struct CollectOutputTests {
+
+        @Test("success path: collects stdout and stderr, returns exit code")
+        func collectsOutputOnSuccess() async throws {
+            guard let pipes = StdioPipes.make([.stdout, .stderr]) else {
+                Issue.record("StdioPipes.make() returned nil")
+                return
+            }
+
+            // Write test data to write ends (simulating container output), then close
+            // so readers see EOF immediately when collectOutput starts draining.
+            let stdoutPayload = "hello stdout".data(using: .utf8)!
+            let stderrPayload = "hello stderr".data(using: .utf8)!
+            try pipes.stdout!.write.write(contentsOf: stdoutPayload)
+            try pipes.stderr!.write.write(contentsOf: stderrPayload)
+            try? pipes.stdout!.write.close()
+            try? pipes.stderr!.write.close()
+
+            let (exitCode, stdout, stderr) = try await pipes.collectOutput { 0 }
+
+            #expect(exitCode == 0)
+            #expect(stdout == stdoutPayload)
+            #expect(stderr == stderrPayload)
+        }
+
+        @Test("error path: wait error is rethrown; drain tasks exit when write ends close")
+        func rethrowsWaitError() async throws {
+            guard let pipes = StdioPipes.make([.stdout, .stderr]) else {
+                Issue.record("StdioPipes.make() returned nil")
+                return
+            }
+
+            struct FakeWaitError: Error {}
+            do {
+                _ = try await pipes.collectOutput { throw FakeWaitError() }
+                Issue.record("Expected collectOutput to rethrow FakeWaitError")
+            } catch is FakeWaitError {
+                // Expected: collectOutput rethrows immediately without awaiting drain tasks.
+                // Drain tasks will exit once write ends are closed (EOF).
+            }
+            // Close write ends to unblock background drain tasks (no concurrent fd close hazard
+            // because we're not inside collectOutput anymore).
+            try? pipes.stdout!.write.close()
+            try? pipes.stderr!.write.close()
+        }
+    }
+
+    // MARK: - ProcessPipe
+
+    /// Tests for `ProcessPipe`, the internal low-level primitive backing `StdioPipes`.
+    ///
+    /// Root cause of issue #107: `createProcess(stdio:)/bootstrap(id:stdio:)` dups
+    /// the passed fds into the container then closes the parent copies. When code
+    /// used Foundation's `Pipe()`, the freed fd could be reused (e.g. as a NIO
+    /// socket) before `Pipe.deinit` ran its own close, double-closing the reused
+    /// fd and corrupting NIO's fd table (writev/kevent EBADF crash).
+    ///
+    /// Fix: `ProcessPipe` uses `pipe(2)` + `FileHandle(closeOnDealloc:false)` so
+    /// Apple is the sole closer of the end passed to createProcess/bootstrap.
+    @Suite("ProcessPipe — fd ownership contract")
+    struct ProcessPipeTests {
+
+        // MARK: - ProcessPipe API
+
+        @Test("ProcessPipe.make() returns two distinct, valid fds")
+        func makePipeReturnsValidFds() {
+            guard let pipe = ProcessPipe.make() else {
+                Issue.record("ProcessPipe.make() returned nil")
+                return
+            }
+            let r = pipe.read.fileDescriptor
+            let w = pipe.write.fileDescriptor
+            #expect(r >= 0)
+            #expect(w >= 0)
+            #expect(r != w)
+            #expect(Darwin.fcntl(r, F_GETFD) >= 0, "read fd not valid")
+            #expect(Darwin.fcntl(w, F_GETFD) >= 0, "write fd not valid")
+            Darwin.close(r)
+            Darwin.close(w)
+        }
+
+        /// Core invariant: `ProcessPipe` deinit does not call `close()` on either fd.
+        /// Without this guarantee, an fd freed by Apple and recycled by NIO as a socket
+        /// could be closed by the deinit, corrupting NIO's fd table (writev EBADF crash).
+        @Test("ProcessPipe deinit does not close fds (closeOnDealloc:false)")
+        func deinitDoesNotCloseFds() {
+            var readFd: Int32 = -1
+            var writeFd: Int32 = -1
+
+            // Inner scope forces deinit before the #expect calls below.
+            do {
+                guard let pipe = ProcessPipe.make() else {
+                    Issue.record("ProcessPipe.make() returned nil")
+                    return
+                }
+                readFd = pipe.read.fileDescriptor
+                writeFd = pipe.write.fileDescriptor
+                // pipe released here — deinit fires immediately (ARC is synchronous)
+            }
+
+            // Both fds must still be open — deinit must not have touched them.
+            #expect(Darwin.fcntl(readFd, F_GETFD) >= 0, "read fd closed by ProcessPipe deinit")
+            #expect(Darwin.fcntl(writeFd, F_GETFD) >= 0, "write fd closed by ProcessPipe deinit")
+
+            Darwin.close(readFd)
+            Darwin.close(writeFd)
+        }
+
+        // MARK: - Low-level primitives (regression tests for the building blocks)
+
+        @Test("closeOnDealloc:false — fd stays valid after FileHandle is released")
+        func fdStaysOpenAfterFileHandleReleased() throws {
+            var fds: [Int32] = [0, 0]
+            try #require(Darwin.pipe(&fds) == 0)
+            let readFd = fds[0]
+            let writeFd = fds[1]
+
+            do {
+                _ = FileHandle(fileDescriptor: readFd, closeOnDealloc: false)
+                _ = FileHandle(fileDescriptor: writeFd, closeOnDealloc: false)
+            }
+            #expect(Darwin.fcntl(readFd, F_GETFD) >= 0, "read fd closed prematurely")
+            #expect(Darwin.fcntl(writeFd, F_GETFD) >= 0, "write fd closed prematurely")
+
+            Darwin.close(readFd)
+            Darwin.close(writeFd)
+        }
+
+        @Test("write-end external close leaves read end usable")
+        func writeEndExternalCloseDoesNotInvalidateReadEnd() throws {
+            var fds: [Int32] = [0, 0]
+            try #require(Darwin.pipe(&fds) == 0)
+            let readFd = fds[0]
+            let writeFd = fds[1]
+
+            let byte: [UInt8] = [0x42]
+            _ = Darwin.write(writeFd, byte, 1)
+            Darwin.close(writeFd)
+            #expect(Darwin.fcntl(writeFd, F_GETFD) == -1, "write fd should be closed")
+
+            let readHandle = FileHandle(fileDescriptor: readFd, closeOnDealloc: false)
+            let data = try readHandle.readToEnd()
+            #expect(data?.count == 1)
+            #expect(data?.first == 0x42)
+
+            try readHandle.close()
+        }
+    }
+
+}  // end PipeFdOwnershipTests

--- a/scripts/lint-pipes.sh
+++ b/scripts/lint-pipes.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Rejects Foundation's Pipe() in ContainerClient code paths — use StdioPipes instead.
+# See AGENTS.md for the ownership contract and the reason this matters.
+set -euo pipefail
+
+PATTERN='(=[[:space:]]*|Foundation\.)Pipe\(\)'
+EXCLUDE='ClientRegistryService.swift'
+
+if grep -rEn "$PATTERN" Sources/socktainer/ \
+        --include="*.swift" \
+        --exclude="$EXCLUDE" \
+    | grep -q .; then
+    echo "ERROR: Pipe() found in a ContainerClient code path."
+    echo "       Use StdioPipes (DockerConnectionUtility.swift) instead — see AGENTS.md."
+    grep -rEn "$PATTERN" Sources/socktainer/ \
+        --include="*.swift" \
+        --exclude="$EXCLUDE"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Apple's `ContainerClient.createProcess(stdio:)` and `bootstrap(id:stdio:)` dup the passed fds into the container then **immediately close the parent copies**. Foundation's `Pipe()` was unaware of this — its `deinit` later called `close()` on the same fd number, which by then could be a recycled NIO socket, corrupting NIO's fd table and causing `writev`/`kevent` EBADF crashes under concurrent high-output `docker exec` load.

Root cause proved by fd-trace instrumentation: `APPLE CLOSED stdout_w=19` then our code closed fd 19 a second time, killing a live NIO socket. Reproduced with 3 concurrent `docker exec sh -c 'yes s | head -100000'` — 100% crash rate before, 0% after.

## Related Issue

Fixes #107

## Changes

- **`ProcessPipe`** (internal) — raw `pipe(2)` + `FileHandle(closeOnDealloc:false)`. Apple is the sole closer of the fd end it receives.
- **`StdioPipes`** (internal) — allocates all three stdio channels atomically, handles EMFILE internally (closes partial pipes and returns `nil`), and exposes `closeAll()` / `closeAfterHandoff()` so every error path is one line instead of 4–6 manual closes.
- **All six `Pipe()` call sites converted**: ExecRoutes (HTTP + TCP), ContainerAttachRoute (output-only + interactive, HTTP + TCP), ContainerAttachWSRoute, ClientArchiveService, ClientBuilderService.
- **Bugs fixed during iterative review:**
  - EMFILE validation threw without closing already-created pipes (4 fd leak per request)
  - `attachStoppedOutputOnly` start-failure leaked stdout/stderr read ends
  - ExecRoutes TCP: `setStdinWriter` was called before `createProcess` — moved after so a `createProcess` failure can't race with `DockerTCPHandler`
  - `ContainerAttachWSRoute`: `stdinPipe.write` double-close when `stdin=false`
  - `ClientBuilderService`: `process.wait()` bare throw leaked read ends
  - `ClientArchiveService`: `process.wait()` failure orphaned `stderrTask`; read end closed to unblock the blocking read before awaiting
  - Several bootstrap/start failure paths missing fd cleanup
- **`make lint-pipes`** — new CI check (prerequisite of `make test`) that rejects `= Pipe()` in all source files except `ClientRegistryService.swift` (which uses Foundation's `Process`, not Apple Container APIs)
- **Documentation** — `AGENTS.md` and `README.md` Developer Notes updated with `StdioPipes` usage pattern and fd ownership contract

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (317 tests, includes `make lint-pipes`)
- [x] `ProcessPipe` unit tests: fd stays open after deinit, external close leaves read end usable
- [x] `StdioPipes` unit tests: allocation, nil streams, `stdioArray` ordering, `closeAll`, `closeAfterHandoff` ownership split
- [x] Manual: 10 × 3-concurrent × 100k-line `docker exec` flood — zero crashes (was 100% crash rate)
- [x] Manual: `docker run --rm alpine echo hello` — ContainerAttachRoute verified
- [x] Manual: output line count correct (100 000 in → 100 000 out), exit code propagation correct

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)