### PR TITLE
fix(ci): use quay.io/podman/hello to avoid Docker Hub / ECR Public flakiness

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -199,7 +199,9 @@ jobs:
 
       - name: check container root
         run: |
-          sudo container image pull hello-world
+          # quay.io/podman/hello has no auth or rate-limit issues and is already
+          # used later in this workflow. Avoids Docker Hub / ECR Public flakiness.
+          sudo container image pull quay.io/podman/hello
           sudo container image ls
 
       - name: install docker cli
@@ -208,8 +210,8 @@ jobs:
 
       - name: check docker image with socktainer
         run: |
-          # expect that hello-world is present
-          sudo docker image ls | grep hello-world
+          # expect that the image pulled above is present
+          sudo docker image ls | grep 'podman/hello'
           # pull httpd image
           sudo docker image pull httpd:latest
           # list images


### PR DESCRIPTION
## Summary

The integration test's \"check container root\" step pulls a small image via the Apple Container CLI to verify the container runtime is working. Two registries have proven unreliable:

- **Docker Hub** (`hello-world`) — `auth.docker.io/token` returns intermittent 404
- **AWS ECR Public** (`public.ecr.aws/docker/library/hello-world`) — returns 429 (rate-limited) on first attempt

Replace with **`quay.io/podman/hello`** which:
- Requires no authentication
- Has no rate-limiting issues in CI environments
- Is already pulled with a pinned digest later in this same workflow (`sha256:41316c18...`), proving it works reliably

Update the downstream `grep hello-world` check to `grep 'podman/hello'` to match.

## Related Issue

This flakiness blocks PRs from getting green CI (e.g. #245). The integration test failure is infrastructure noise, not a code regression.

## Testing

- [x] Two-line change to CI workflow only — no code impact
- [x] `quay.io/podman/hello` is already pulled later in the same workflow (proven reliable)

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)