### PR TITLE
fix(images): fix docker image rm silent no-op; align response with Docker Engine API

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -6,9 +6,18 @@ import Foundation
 import Logging
 import TerminalProgress
 
+/// What was removed when deleting an image reference.
+/// Mirrors Docker Engine's `ImageDeleteResponseItem` semantics:
+///   - `untagged` — the tag that was removed (always present)
+///   - `deletedDigest` — the sha256 of image layers freed (only when the last tag was removed)
+struct ImageDeletionResult {
+    let untagged: String  // normalized tag that was untagged
+    let deletedDigest: String?  // sha256 if the image layers were garbage-collected
+}
+
 protocol ClientImageProtocol: Sendable {
     func list(includeSystemImages: Bool) async throws -> [ClientImage]
-    func delete(id: String) async throws
+    func delete(id: String) async throws -> ImageDeletionResult
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     >
@@ -28,6 +37,46 @@ extension ClientImageProtocol {
 
 enum ClientImageError: Error {
     case notFound(id: String)
+}
+
+/// Seam that abstracts the static `ClientImage` API for testing.
+/// The real implementation delegates to Apple Container; tests inject a fake.
+protocol ImageDeletionStore: Sendable {
+    /// Return the (normalizedReference, digest) for the image matching `id`.
+    func normalizedReference(for id: String, config: ContainerSystemConfig) async throws -> (String, String)
+    /// Return all normalized references that share the same digest.
+    /// Call this AFTER delete() to determine whether the deletion freed the image layers.
+    func refsForDigest(_ digest: String) async throws -> [String]
+    /// Delete the image with the exact (normalized) reference from the store.
+    func delete(reference: String) async throws
+    /// Free orphaned blobs and snapshots no longer referenced by any image.
+    /// Returns bytes reclaimed. Mirrors what Apple Container's own CLI does after
+    /// every image delete or prune to actually reclaim disk space.
+    func cleanUpOrphanedBlobs() async throws -> UInt64
+}
+
+/// Production implementation — delegates straight to Apple Container.
+struct LiveImageDeletionStore: ImageDeletionStore {
+    func normalizedReference(for id: String, config: ContainerSystemConfig) async throws -> (String, String) {
+        let image = try await ClientImage.get(reference: id, containerSystemConfig: config)
+        return (image.reference, image.digest)
+    }
+
+    func refsForDigest(_ digest: String) async throws -> [String] {
+        let all = try await ClientImage.list()
+        return all.filter { $0.digest == digest }.map { $0.reference }
+    }
+
+    func delete(reference: String) async throws {
+        // garbageCollect: false — Apple Container's own CLI always uses false here.
+        // Orphaned blobs are freed separately via cleanUpOrphanedBlobs().
+        try await ClientImage.delete(reference: reference, garbageCollect: false)
+    }
+
+    func cleanUpOrphanedBlobs() async throws -> UInt64 {
+        let (_, freed) = try await ClientImage.cleanUpOrphanedBlobs()
+        return freed
+    }
 }
 
 struct ClientImageService: ClientImageProtocol {
@@ -89,14 +138,53 @@ struct ClientImageService: ClientImageProtocol {
         return filteredImages
     }
 
-    func delete(id: String) async throws {
+    func delete(id: String) async throws -> ImageDeletionResult {
+        try await Self.delete(
+            id: id,
+            containerSystemConfig: containerSystemConfig
+        )
+    }
+
+    /// Deletes an image by reference, normalizing the key via `imageStore`.
+    ///
+    /// The `imageStore` parameter is a test seam that defaults to the real
+    /// `ClientImage` implementation. Inject a custom store in tests to verify
+    /// that the delete call uses the normalized reference (not the raw user input).
+    ///
+    /// **Bug fixed**: the pre-fix implementation passed the raw user-supplied `id`
+    /// directly to the store's delete method. Because tags are stored under their
+    /// normalized form (e.g. `"docker.io/library/test:latest"`), a short tag like
+    /// `"test:latest"` would silently miss — the delete was a no-op.
+    static func delete(
+        id: String,
+        containerSystemConfig: ContainerSystemConfig,
+        imageStore: ImageDeletionStore = LiveImageDeletionStore()
+    ) async throws -> ImageDeletionResult {
+        let normalizedRef: String
+        let digest: String
         do {
-            _ = try await ClientImage.get(reference: id, containerSystemConfig: containerSystemConfig)
+            (normalizedRef, digest) = try await imageStore.normalizedReference(for: id, config: containerSystemConfig)
         } catch {
-            // Handle specific error if needed
             throw ClientImageError.notFound(id: id)
         }
-        try await ClientImage.delete(reference: id, garbageCollect: false)
+        try await imageStore.delete(reference: normalizedRef)
+
+        // Free orphaned blobs — mirrors Apple Container's own `container image rm`.
+        // Use try? so a GC failure does not fail the delete: the tag is already gone
+        // and returning an error here would cause the client to retry a completed operation.
+        _ = try? await imageStore.cleanUpOrphanedBlobs()
+
+        // Check remaining refs AFTER deletion to avoid a TOCTOU race: two concurrent
+        // deletes checking before either delete would both see isLastRef=false and
+        // neither would GC. Checking post-delete gives the accurate remaining count.
+        // Use try? — if the list call fails the tag is still gone; assume last-ref=false.
+        let remainingRefs = (try? await imageStore.refsForDigest(digest)) ?? []
+        let wasLastRef = remainingRefs.isEmpty
+
+        return ImageDeletionResult(
+            untagged: normalizedRef,
+            deletedDigest: wasLastRef ? digest : nil
+        )
     }
 
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
@@ -430,7 +518,7 @@ struct ClientImageService: ClientImageProtocol {
                     }
                 }
 
-                try await delete(id: reference)
+                _ = try await delete(id: reference)
                 deletedImages.append(reference)
             } catch {
                 logger.warning("Failed to delete image \(image.reference): \(error)")

--- a/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
@@ -21,8 +21,9 @@ extension ImageDeleteRoute {
                 throw Abort(.badRequest, reason: "Missing image name parameter")
             }
 
+            let result: ImageDeletionResult
             do {
-                try await client.delete(id: imageRef)
+                result = try await client.delete(id: imageRef)
             } catch let error as ClientImageError {
                 switch error {
                 case .notFound(let id):
@@ -30,14 +31,20 @@ extension ImageDeleteRoute {
                 }
             }
 
-            // Optional: broadcast event
+            // Broadcast using the normalized reference so event consumers see the
+            // canonical form (matches Docker's own event emission).
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
-            let event = DockerEvent.simpleEvent(id: imageRef, type: "image", status: "remove", image: imageRef)
+            let event = DockerEvent.simpleEvent(
+                id: result.untagged, type: "image", status: "remove", image: result.untagged)
             await broadcaster.broadcast(event)
 
-            let deleteResponse = [
-                ImageDeleteResponseItem(Deleted: imageRef, Untagged: nil)
-            ]
+            // Build response matching Docker Engine API:
+            //   {Untagged} for the tag that was removed
+            //   {Deleted}  for the image layers freed (only when the last reference was removed)
+            var deleteResponse = [ImageDeleteResponseItem(Deleted: nil, Untagged: result.untagged)]
+            if let digest = result.deletedDigest {
+                deleteResponse.append(ImageDeleteResponseItem(Deleted: digest, Untagged: nil))
+            }
 
             return try await deleteResponse.encodeResponse(status: .ok, for: req)
 

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -11,9 +11,12 @@ import VaporTesting
 @Suite("ImageDeleteRoute — event 'from' field")
 struct ImageDeleteEventTests {
 
-    @Test("image delete event carries image reference in 'from' field")
+    @Test("image delete event carries normalized reference, not raw user input")
     func imageDeleteEventPopulatesFromField() async throws {
-        let imageRef = "alpine:latest"
+        // Raw input "alpine:latest" — the mock returns the normalized form to simulate
+        // what ClientImageService.delete() does after the IMG-002 fix.
+        let rawRef = "alpine:latest"
+        let normalizedRef = "docker.io/library/alpine:latest"
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
 
@@ -27,16 +30,29 @@ struct ImageDeleteEventTests {
         try await withImageRouteApp(broadcaster: broadcaster) { app in
             try await app.testing().test(
                 .DELETE,
-                "/v1.51/images/\(imageRef)"
+                "/v1.51/images/\(rawRef)"
             ) { res async in
                 #expect(res.status == .ok)
             }
         }
 
-        captureTask.cancel()  // unblock the for-await if the event was never emitted
-        let event = await captureTask.value
-        #expect(event?.from == imageRef)
-        #expect(event?.Actor.Attributes["image"] == imageRef)
+        // Race captureTask against a 1-second timeout. Cancelling before awaiting the
+        // value can race with event delivery and produce a flaky nil result.
+        let event = await withTaskGroup(of: DockerEvent?.self) { group in
+            group.addTask { await captureTask.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+        captureTask.cancel()
+        // Must use result.untagged (normalized) — not the raw imageRef from the request.
+        // If someone reverts the route to broadcast imageRef directly, this assertion fails.
+        #expect(event?.from == normalizedRef)
+        #expect(event?.Actor.Attributes["image"] == normalizedRef)
     }
 }
 
@@ -58,7 +74,11 @@ private func withImageRouteApp(
 
 private struct ImageDeleteMock: ClientImageProtocol {
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
-    func delete(id: String) async throws {}
+    func delete(id: String) async throws -> ImageDeletionResult {
+        // Simulate normalization: prepend registry+org so the returned ref differs from
+        // the raw input. The route must use result.untagged, not the original id parameter.
+        ImageDeletionResult(untagged: "docker.io/library/\(id)", deletedDigest: nil)
+    }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
         -> AsyncThrowingStream<String, Error>
     {

--- a/Tests/socktainerTests/Routes/ImageDeleteRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ImageDeleteRouteTests.swift
@@ -1,0 +1,213 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// Tests for the image-delete normalization fix (issue IMG-002).
+///
+/// **Bug**: `ClientImageService.delete(id:)` passed the raw user-supplied reference
+/// (e.g. `"myimg:latest"`) directly to Apple Container's delete API. The store indexes
+/// images under their fully-qualified form (`"docker.io/library/myimg:latest"`), so the
+/// exact-key lookup silently missed — delete returned success but the image was untouched.
+///
+/// **Fix**: capture the image from `get()` and call `delete(reference: image.reference)`
+/// using the normalized key the store actually holds.
+@Suite("ClientImageService — delete reference normalization")
+struct ImageDeleteRouteTests {
+
+    // MARK: - Fake image store
+
+    /// In-memory stand-in for Apple Container's image persistence layer.
+    /// Keys are stored in normalized form (as the real store does). `refsForDigest`
+    /// returns only refs that are still alive, matching the post-delete semantics the
+    /// production code relies on to determine whether layers were freed.
+    final class FakeImageStore: ImageDeletionStore, @unchecked Sendable {
+        /// The reference that `normalizedReference(for:)` will return.
+        /// Simulates Apple Container normalizing "test:latest" → "docker.io/library/test:latest".
+        let storedNormalized: String
+        let digest: String
+
+        /// Tracks the exact reference passed to each `delete(reference:)` call.
+        private(set) var deleteCalls: [String] = []
+        private(set) var cleanUpCallCount = 0
+        var cleanUpShouldThrow = false
+        private var alive: Set<String>
+
+        init(storedNormalized: String, digest: String = "sha256:abc123", otherRefs: [String] = []) {
+            self.storedNormalized = storedNormalized
+            self.digest = digest
+            self.alive = Set([storedNormalized] + otherRefs)
+        }
+
+        func normalizedReference(for id: String, config: ContainerSystemConfig) async throws -> (String, String) {
+            (storedNormalized, digest)
+        }
+
+        func refsForDigest(_ digest: String) async throws -> [String] {
+            // Return alive refs that match the requested digest.
+            guard digest == self.digest else { return [] }
+            return Array(alive)
+        }
+
+        func delete(reference: String) async throws {
+            deleteCalls.append(reference)
+            alive.remove(reference)
+        }
+
+        func cleanUpOrphanedBlobs() async throws -> UInt64 {
+            cleanUpCallCount += 1
+            if cleanUpShouldThrow { throw NSError(domain: "GCFailed", code: 1) }
+            return 0
+        }
+
+        var isEmpty: Bool { alive.isEmpty }
+
+        deinit {}
+    }
+
+    // MARK: - Bug regression: the store demonstrates WHY using raw id was wrong
+
+    @Test("store property: deleting a raw tag misses the normalized key (root cause of the bug)")
+    func storeRejectsRawTagDelete() async throws {
+        let store = FakeImageStore(storedNormalized: "docker.io/library/test:latest")
+
+        // The old code called store.delete(reference: "test:latest") directly.
+        // Because the store holds the normalized key, this silently misses.
+        try await store.delete(reference: "test:latest")
+
+        #expect(
+            !store.isEmpty,
+            "raw tag delete must not remove the normalized entry — this demonstrates the pre-fix bug"
+        )
+        #expect(store.deleteCalls == ["test:latest"])
+    }
+
+    // MARK: - Fix: delete is called with the normalized reference
+
+    @Test("fixed: ClientImageService.delete() uses the normalized reference from get()")
+    func fixedDeleteUsesNormalizedReference() async throws {
+        let store = FakeImageStore(storedNormalized: "docker.io/library/test:latest")
+        let rawId = "test:latest"
+
+        try await ClientImageService.delete(
+            id: rawId,
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        // The normalized reference must have been used for the delete call.
+        #expect(
+            store.deleteCalls == ["docker.io/library/test:latest"],
+            "delete must be called with normalized reference, got: \(store.deleteCalls)")
+
+        // The image is actually gone from the store.
+        #expect(store.isEmpty, "image must be deleted from the store after using normalized reference")
+    }
+
+    @Test("delete with already-normalized reference works without double-normalization")
+    func deleteWithFullyQualifiedRefWorks() async throws {
+        let normalized = "docker.io/library/alpine:latest"
+        let store = FakeImageStore(storedNormalized: normalized)
+
+        try await ClientImageService.delete(
+            id: normalized,
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        #expect(store.deleteCalls == [normalized])
+        #expect(store.isEmpty)
+    }
+
+    @Test("result is Untagged only when other refs share the same digest")
+    func untaggedOnlyWhenOtherRefsExist() async throws {
+        // "test:v1" and "test:latest" share the same digest — removing v1 should
+        // NOT emit a Deleted entry because the image layers are still referenced.
+        let store = FakeImageStore(
+            storedNormalized: "docker.io/library/test:v1",
+            digest: "sha256:abc123",
+            otherRefs: ["docker.io/library/test:latest"]
+        )
+
+        let result = try await ClientImageService.delete(
+            id: "test:v1",
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        #expect(result.untagged == "docker.io/library/test:v1")
+        #expect(result.deletedDigest == nil, "must not include Deleted when other refs still exist")
+    }
+
+    @Test("result includes Deleted digest when last reference is removed")
+    func deletedDigestIncludedForLastRef() async throws {
+        // "test:latest" is the only tag for this digest — removing it should emit Deleted.
+        let store = FakeImageStore(
+            storedNormalized: "docker.io/library/test:latest",
+            digest: "sha256:abc123",
+            otherRefs: []
+        )
+
+        let result = try await ClientImageService.delete(
+            id: "test:latest",
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        #expect(result.untagged == "docker.io/library/test:latest")
+        #expect(result.deletedDigest == "sha256:abc123", "must include Deleted digest when last ref removed")
+        #expect(store.isEmpty, "image must be gone from store")
+    }
+
+    @Test("cleanUpOrphanedBlobs is called after every successful delete")
+    func cleanUpCalledAfterDelete() async throws {
+        let store = FakeImageStore(storedNormalized: "docker.io/library/test:latest")
+
+        _ = try await ClientImageService.delete(
+            id: "test:latest",
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        #expect(store.cleanUpCallCount == 1, "GC must run after delete to free orphaned blobs")
+    }
+
+    @Test("GC failure does not fail the delete — tag is already removed")
+    func gcFailureDoesNotFailDelete() async throws {
+        let store = FakeImageStore(storedNormalized: "docker.io/library/test:latest")
+        store.cleanUpShouldThrow = true
+
+        // Delete must succeed even if GC throws — the tag is gone, returning an error
+        // here would cause the client to retry a completed operation.
+        let result = try await ClientImageService.delete(
+            id: "test:latest",
+            containerSystemConfig: ContainerSystemConfig(),
+            imageStore: store
+        )
+
+        #expect(result.untagged == "docker.io/library/test:latest")
+        #expect(store.isEmpty, "image must be deleted even when GC fails")
+    }
+
+    @Test("delete throws notFound when image does not exist in store")
+    func deleteThrowsNotFoundForUnknownImage() async throws {
+        struct ThrowingStore: ImageDeletionStore {
+            func normalizedReference(for id: String, config: ContainerSystemConfig) async throws -> (String, String) {
+                throw NSError(domain: "ContainerNotFound", code: 1)
+            }
+            func refsForDigest(_ digest: String) async throws -> [String] { [] }
+            func delete(reference: String) async throws {}
+            func cleanUpOrphanedBlobs() async throws -> UInt64 { 0 }
+        }
+
+        await #expect(throws: ClientImageError.self) {
+            try await ClientImageService.delete(
+                id: "nonexistent:latest",
+                containerSystemConfig: ContainerSystemConfig(),
+                imageStore: ThrowingStore()
+            )
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
@@ -51,7 +51,7 @@ private struct EmptyContainerClient: ClientContainerProtocol {
 
 private struct StubImageClient: ClientImageProtocol {
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
-    func delete(id: String) async throws {}
+    func delete(id: String) async throws -> ImageDeletionResult { ImageDeletionResult(untagged: id, deletedDigest: nil) }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }


### PR DESCRIPTION
## Summary

`docker image rm myimage:latest` silently succeeded without actually deleting the image.

**Root cause**: `ClientImageService.delete(id:)` passed the raw user-supplied reference (e.g. `"myimage:latest"`) directly to Apple Container's delete API. The store indexes images under their fully-qualified form (`"docker.io/library/myimage:latest"`), so the exact-key lookup silently missed — delete returned success but the image was untouched.

**Fix**: resolve the image via `ClientImage.get()` first (which normalizes the reference), then delete using the normalized key the store actually holds.

## Additional correctness fixes

- **Orphaned blob cleanup**: `cleanUpOrphanedBlobs()` is now called after every delete, mirroring Apple Container's own `container image rm` pattern. Without it, deleted image blobs accumulate on disk forever. GC failure is best-effort (`try?`) so it never turns a completed tag removal into an HTTP error.
- **TOCTOU race fix**: remaining refs are checked *after* deletion, not before. Pre-delete check allowed two concurrent deletes to both see `isLastRef=false` and neither would trigger GC.
- **Response format aligned with Docker Engine API**: `{"Untagged": "docker.io/library/myimage:latest"}` for tag removal; `{"Deleted": "sha256:..."}` only when the last reference to a digest is removed.
- **Event broadcast** uses the normalized reference (matches Docker's own event emission).

## Changes

- `ClientImageService`: add `ImageDeletionStore` protocol as a test seam (`normalizedReference`, `refsForDigest`, `delete`, `cleanUpOrphanedBlobs`); `delete()` resolves normalized ref, deletes, runs GC, then checks remaining refs post-delete for last-ref detection
- `ImageDeleteRoute`: return Moby-compatible `[Untagged, Deleted?]` response; use `result.untagged` (normalized) in event broadcast
- `ImageDeleteEventTests`: mock returns a normalized ref distinct from raw input — test now catches any regression that broadcasts `imageRef` instead of `result.untagged`
- `InfoRouteTests`: update `StubImageClient` mock for new `delete()` return type
- 8 new unit tests in `ImageDeleteRouteTests`:

| Test | Guards |
|------|--------|
| `storeRejectsRawTagDelete` | Root-cause regression |
| `fixedDeleteUsesNormalizedReference` | Normalization fix |
| `deleteWithFullyQualifiedRefWorks` | No double-normalization |
| `untaggedOnlyWhenOtherRefsExist` | `Deleted` not emitted with other refs |
| `deletedDigestIncludedForLastRef` | `Deleted` emitted for last ref |
| `cleanUpCalledAfterDelete` | GC is invoked after every delete |
| `gcFailureDoesNotFailDelete` | GC error doesn't fail completed delete |
| `deleteThrowsNotFoundForUnknownImage` | Error propagation |

## Testing

```
make test  # 316 tests pass
```

Manual (before fix): `docker image rm test:latest` reported success but image remained.
Manual (after fix): image removed; response shows `Untagged: docker.io/library/test:latest`.