### PR TITLE
fix(networks): make POST /networks/create idempotent on "already exists"

### DIFF
--- a/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
@@ -36,7 +36,21 @@ struct NetworkCreateRoute: RouteCollection {
         if let mapping = LabelNormalization.buildMapping(originalLabels) {
             labels[LabelNormalization.mappingKey] = mapping
         }
-        let response = try await client.create(name: query.Name, labels: labels, logger: logger)
+        let response: RESTNetworkCreate
+        do {
+            response = try await client.create(name: query.Name, labels: labels, logger: logger)
+        } catch {
+            // Docker's `network create` is effectively create-to-ensure for tools
+            // (e.g. the Supabase CLI) that may issue it more than once during a
+            // single bring-up; socktainer's create throws "already exists", which
+            // those tools treat as a fatal "failed to create docker network".
+            // Only treat that specific conflict as idempotent — return the
+            // existing network; any other failure is a real error and propagates.
+            // (Mirrors VolumeCreateRoute's idempotent create.)
+            guard "\(error)".lowercased().contains("already exists") else { throw error }
+            guard let existing = try await client.getNetwork(id: query.Name, logger: logger) else { throw error }
+            response = RESTNetworkCreate(Id: existing.Id, Warning: "")
+        }
         return try await response.encodeResponse(for: req)
     }
 }

--- a/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
@@ -1,0 +1,186 @@
+import ContainerResource
+import ContainerizationExtras
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression tests for the idempotent `POST /networks/create` fix (#249).
+///
+/// Docker's `network create` is create-to-ensure: tools such as the Supabase CLI
+/// issue it more than once for the same name during a single bring-up and treat a
+/// duplicate-create error as fatal. socktainer's underlying create throws
+/// "already exists"; the route must catch *that specific* conflict and return the
+/// existing network, while still letting every other failure propagate.
+/// (Mirrors the idempotent `VolumeCreateRoute`.)
+@Suite("NetworkCreateRoute — idempotent create")
+struct NetworkCreateRouteTests {
+
+    @Test("first create returns 200 with the created network")
+    func firstCreateSucceeds() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let created = try res.content.decode(RESTNetworkCreate.self)
+                #expect(created.Id == "net-a")
+            }
+        }
+        #expect(client.createCalls == 1)
+        #expect(client.getNetworkCalls == 0)
+    }
+
+    @Test("duplicate create is idempotent: returns the existing network, not an error (#249)")
+    func duplicateCreateIsIdempotent() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            // First create — establishes the network.
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+            // Second create for the same name — must NOT be fatal.
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode(RESTNetworkCreate.self)
+                #expect(body.Id == "net-a")
+            }
+        }
+        #expect(client.createCalls == 2, "both creates reach the backend")
+        #expect(client.getNetworkCalls == 1, "the conflict is resolved by looking up the existing network")
+    }
+
+    @Test("a non-\"already exists\" create failure still propagates (not swallowed)")
+    func otherErrorPropagates() async throws {
+        let client = FakeNetworkClient()
+        client.createThrowsOther = true
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .internalServerError)
+            }
+        }
+        #expect(client.createCalls == 1)
+        #expect(client.getNetworkCalls == 0, "non-conflict errors must not trigger an existing-network lookup")
+    }
+
+    @Test("\"already exists\" but the network can't be found rethrows the original error")
+    func vanishedNetworkRethrows() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            // Establish the network so the second create hits "already exists".
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+            // Simulate the network being deleted between the failed create and the
+            // lookup — the route must not return a bogus 200, it rethrows.
+            client.getNetworkReturnsNil = true
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .internalServerError)
+            }
+        }
+        #expect(client.createCalls == 2)
+        #expect(client.getNetworkCalls == 1)
+    }
+}
+
+// MARK: - Helpers
+
+private func withNetworkRouteApp(
+    client: ClientNetworkProtocol,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { app in
+        // Surface a thrown (rethrown) error as a 500 so the propagation tests can
+        // observe it; without it an uncaught error has no defined HTTP mapping.
+        app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+    }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        try app.register(collection: NetworkCreateRoute(client: client))
+        try await test(app)
+    }
+}
+
+private struct AlreadyExistsError: Error, CustomStringConvertible {
+    let name: String
+    var description: String { "network \(name) already exists" }
+}
+
+private struct OtherError: Error, CustomStringConvertible {
+    var description: String { "some unrelated failure" }
+}
+
+private func makeNetworkResource(name: String) throws -> NetworkResource {
+    let configuration = try NetworkConfiguration(
+        name: name,
+        mode: .nat,
+        ipv4Subnet: nil,
+        labels: ResourceLabels([:]),
+        plugin: "container-network-vmnet"
+    )
+    let status = NetworkStatus(
+        ipv4Subnet: try CIDRv4("192.168.100.0/24"),
+        ipv4Gateway: try IPv4Address("192.168.100.1"),
+        ipv6Subnet: nil
+    )
+    return NetworkResource(configuration: configuration, status: status)
+}
+
+/// In-memory `ClientNetworkProtocol`. `create` is first-wins: a second create for
+/// a name it already holds throws an "already exists" error, exactly as the Apple
+/// Container backend does.
+private final class FakeNetworkClient: ClientNetworkProtocol, @unchecked Sendable {
+    private(set) var createCalls = 0
+    private(set) var getNetworkCalls = 0
+    /// When true, `getNetwork` reports the network as absent (simulates a network
+    /// deleted between the failed create and the lookup).
+    var getNetworkReturnsNil = false
+    /// When true, `create` fails with a non-"already exists" error.
+    var createThrowsOther = false
+    private var existing: Set<String> = []
+
+    func list(filters: String?, logger: Logger) async throws -> [RESTNetworkSummary] { [] }
+
+    func getNetwork(id: String, logger: Logger) async throws -> RESTNetworkSummary? {
+        getNetworkCalls += 1
+        guard !getNetworkReturnsNil, existing.contains(id) else { return nil }
+        return RESTNetworkSummary(networkResource: try makeNetworkResource(name: id))
+    }
+
+    func delete(id: String, logger: Logger) async throws {}
+
+    func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate {
+        createCalls += 1
+        if createThrowsOther { throw OtherError() }
+        guard existing.insert(name).inserted else { throw AlreadyExistsError(name: name) }
+        return RESTNetworkCreate(Id: name, Warning: "")
+    }
+
+    deinit {}
+}


### PR DESCRIPTION
## What

Make `POST /networks/create` idempotent: when a network with the requested
`Name` already exists, return the existing network instead of erroring.

Fixes #249.

## Why

`docker network create` is effectively create-to-ensure for many tools. The
Supabase CLI, for instance, issues `POST /networks/create` more than once for
the same network name during a single `supabase start` bring-up. Today the
first create succeeds and the second throws "already exists", which the Docker
client receives as `{"error":true,"reason":"Something went wrong."}`. The CLI
treats that as fatal (`failed to create docker network`) and tears the whole
stack down.

socktainer **already solves this exact class of problem for volumes** in
`VolumeCreateRoute` (it catches "already exists" and returns the existing
volume). This change brings `NetworkCreateRoute` in line with that precedent.

## How

Mirror `VolumeCreateRoute`'s idempotent-create. `ClientNetworkProtocol` already
exposes `getNetwork(id:logger:)`, so no client changes are needed — only the
specific "already exists" conflict is treated as idempotent; any other failure
still propagates.

```swift
let response: RESTNetworkCreate
do {
    response = try await client.create(name: query.Name, labels: labels, logger: logger)
} catch {
    guard "\(error)".lowercased().contains("already exists") else { throw error }
    guard let existing = try await client.getNetwork(id: query.Name, logger: logger) else { throw error }
    response = RESTNetworkCreate(Id: existing.Id, Warning: "")
}
return try await response.encodeResponse(for: req)
```

## Testing

Adds `NetworkCreateRouteTests` (Swift Testing + `VaporTesting`, mirroring the
existing route tests) covering the new behaviour:

- first create returns `200` with the created network;
- a duplicate create returns the **existing** network (the guarantee in #249);
- a non-"already exists" create failure still propagates (not swallowed);
- "already exists" but the network can't be found rethrows the original error
  rather than fabricating a `200`.

```
swift test --filter NetworkCreateRoute
…
Suite "NetworkCreateRoute — idempotent create" passed after 0.013 seconds.
Test run with 4 tests in 1 suite passed.
```

Also built from this branch and ran against a real `supabase start` on macOS 26
/ Apple Silicon (Apple Container 1.0.0). Before: the bring-up aborted at the
network stage on the duplicate create. After: the duplicate create returns the
existing network and the bring-up proceeds past the network stage.

Repro for the original failure:

```sh
export DOCKER_HOST=unix://$HOME/.socktainer/container.sock
npx --yes supabase start   # previously failed at the network stage
```

Or more directly: any two `POST /v1.51/networks/create` calls with the same
`Name` — the second now returns the existing network instead of an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
