### PR TITLE
fix(dns): resolve containers by their own name, not only compose aliases

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -61,6 +61,10 @@ extension ContainerDeleteRoute {
                         dnsServer.unregister(hostname: hostname)
                     }
 
+                    // Mirror of the container-name registration in the start route.
+                    if !container.id.isEmpty {
+                        unregisterIfOwned(container.id)
+                    }
                     if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
                         for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
                             unregisterIfOwned(name)

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -75,6 +75,18 @@ extension ContainerStartRoute {
             {
                 let ip = firstAttachment.ipv4Address.address.description
 
+                // Register the container's own name. Docker's embedded DNS resolves a
+                // container by its name on every network it is attached to — not only by
+                // Compose aliases. Tools that address peers by container name get NXDOMAIN
+                // without this, because the name never appears in `socktainer.dns.names`
+                // or the compose labels handled below. Supabase is the motivating case:
+                // its services dial the database at its container name (e.g.
+                // `supabase_db_<project>`), which is otherwise unresolvable.
+                if !snapshot.id.isEmpty {
+                    dnsServer.register(hostname: snapshot.id, ip: ip)
+                    req.logger.info("[dns] registered container name '\(snapshot.id)' → \(ip)")
+                }
+
                 // Names stored at create time (Compose service aliases via socktainer.dns.names)
                 if let namesLabel = snapshot.configuration.labels["socktainer.dns.names"] {
                     for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -68,8 +68,8 @@ struct ComposeDNSTests {
             "no qualified alias without project label")
     }
 
-    @Test("Start does not register compose DNS for non-compose containers")
-    func startSkipsComposeDNSWithoutLabels() async throws {
+    @Test("Start registers only the container name (no compose aliases) when compose labels are absent")
+    func startRegistersContainerNameWithoutLabels() async throws {
         let snapshot = try makeSnapshot(nativeId: "plain-container", ip: "192.168.65.22", labels: [:])
         let dnsServer = SocktainerDNSServer()
 
@@ -84,7 +84,40 @@ struct ComposeDNSTests {
             try await app.testing().test(.POST, "/v1.51/containers/abc789/start") { _ async in }
         }
 
-        #expect(dnsServer.listEntries().isEmpty, "no DNS entries for non-compose container")
+        // Docker resolves a container by its name regardless of Compose; the name is
+        // registered, but no compose-style aliases are invented.
+        let entries = dnsServer.listEntries()
+        #expect(entries == ["plain-container": "192.168.65.22"], "only the container name is registered")
+    }
+
+    @Test("Start registers the container's own name alongside socktainer.dns.names aliases")
+    func startRegistersContainerNameWithDNSNames() async throws {
+        // Mirrors Supabase: services dial the database by its container name
+        // (`supabase_db_<project>`), while only short aliases land in socktainer.dns.names.
+        let nativeId = "supabase_db_proj"
+        let ip = "192.168.65.21"
+        let snapshot = try makeSnapshot(
+            nativeId: nativeId, ip: ip,
+            labels: ["socktainer.dns.names": "db,db.supabase.internal"])
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/abc790/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries[nativeId] == ip, "the container name must be resolvable (the bug this fixes)")
+        #expect(entries["db"] == ip, "short alias from socktainer.dns.names is still registered")
+        #expect(entries["db.supabase.internal"] == ip, "qualified alias from socktainer.dns.names is still registered")
     }
 
     // MARK: - Delete route unregisters compose DNS aliases
@@ -149,6 +182,35 @@ struct ComposeDNSTests {
         let entries = dnsServer.listEntries()
         #expect(entries["web"] == "192.168.65.31", "alias owned by another container must be preserved")
         #expect(entries["web.shop"] == "192.168.65.31", "qualified alias owned by another container must be preserved")
+    }
+
+    @Test("Delete unregisters the container's own name")
+    func deleteUnregistersContainerName() async throws {
+        let nativeId = "supabase_db_proj"
+        let ip = "192.168.65.21"
+        let snapshot = try makeSnapshot(
+            nativeId: nativeId, ip: ip,
+            labels: ["socktainer.dns.names": "db"])
+        let dnsServer = SocktainerDNSServer()
+        dnsServer.register(hostname: nativeId, ip: ip)
+        dnsServer.register(hostname: "db", ip: ip)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/abc002") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries[nativeId] == nil, "container name must be unregistered on delete")
+        #expect(entries["db"] == nil, "alias must be unregistered on delete")
     }
 
     // MARK: - Network connect/disconnect return 200

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -41,6 +41,7 @@ struct ComposeDNSTests {
         let entries = dnsServer.listEntries()
         #expect(entries["db"] == ip, "short service name must be registered with correct IP")
         #expect(entries["db.myapp"] == ip, "qualified service.project alias must be registered")
+        #expect(entries[nativeId] == ip, "the container's own name must register in the compose-label path too")
     }
 
     @Test("Start registers only service alias when project label is absent")
@@ -122,17 +123,23 @@ struct ComposeDNSTests {
 
     // MARK: - Delete route unregisters compose DNS aliases
 
-    @Test("Delete unregisters both service and service.project aliases")
+    @Test("Delete unregisters the container name plus service and service.project aliases")
     func deleteUnregistersComposeDNSAliases() async throws {
+        let nativeId = "compose-web"
+        let ip = "192.168.65.30"
         let snapshot = try makeSnapshot(
-            nativeId: "compose-web", ip: "192.168.65.30",
+            nativeId: nativeId, ip: ip,
             labels: [
                 "com.docker.compose.service": "web",
                 "com.docker.compose.project": "shop",
             ])
         let dnsServer = SocktainerDNSServer()
-        dnsServer.register(hostname: "web", ip: "192.168.65.30")
-        dnsServer.register(hostname: "web.shop", ip: "192.168.65.30")
+        // The start route registers all three (container name + both aliases);
+        // delete must remove all three together.
+        dnsServer.register(hostname: nativeId, ip: ip)
+        dnsServer.register(hostname: "web", ip: ip)
+        dnsServer.register(hostname: "web.shop", ip: ip)
+        #expect(dnsServer.listEntries()[nativeId] != nil)
         #expect(dnsServer.listEntries()["web"] != nil)
         #expect(dnsServer.listEntries()["web.shop"] != nil)
 
@@ -149,6 +156,7 @@ struct ComposeDNSTests {
             }
         }
 
+        #expect(dnsServer.listEntries()[nativeId] == nil, "container name must be unregistered on delete")
         #expect(dnsServer.listEntries()["web"] == nil, "service alias must be unregistered on delete")
         #expect(dnsServer.listEntries()["web.shop"] == nil, "qualified alias must be unregistered on delete")
     }

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -221,6 +221,36 @@ struct ComposeDNSTests {
         #expect(entries["db"] == nil, "alias must be unregistered on delete")
     }
 
+    @Test("Delete preserves the container's own name when another container has taken ownership")
+    func deletePreservesNativeNameOwnedByAnotherContainer() async throws {
+        let nativeId = "supabase_db_proj"
+        let snapshot = try makeSnapshot(
+            nativeId: nativeId, ip: "192.168.65.21",
+            labels: ["socktainer.dns.names": "db"])
+        let dnsServer = SocktainerDNSServer()
+        // A replacement container has claimed the same native name (and alias) before
+        // this one is deleted — the ownership check must leave both entries intact.
+        dnsServer.register(hostname: nativeId, ip: "192.168.65.99")
+        dnsServer.register(hostname: "db", ip: "192.168.65.99")
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/abc003") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let entries = dnsServer.listEntries()
+        #expect(entries[nativeId] == "192.168.65.99", "container name owned by another container must be preserved")
+        #expect(entries["db"] == "192.168.65.99", "alias owned by another container must be preserved")
+    }
+
     // MARK: - Network connect/disconnect return 200
 
     @Test("POST /networks/{id}/connect returns 200")


### PR DESCRIPTION
## Problem

Docker's embedded DNS resolves a container by its **name** on every network it's attached to — not only by its network aliases. socktainer's `ContainerStartRoute` registers only the Compose aliases:

- `socktainer.dns.names` (from `EndpointsConfig.Aliases`)
- `com.docker.compose.service` / `…service.project`

…but **never the container's own name**. So any peer that dials a container by name gets `NXDOMAIN` — and because unknown single-label names are forwarded to the upstream resolver (1.1.1.1), the failure also surfaces intermittently as an i/o timeout or `EAI_AGAIN` rather than a clean error.

### Concrete repro (Supabase `supabase start`)

Supabase's services connect to the database by its **container name** (`supabase_db_<project>`):

- `gotrue` → `host=supabase_db_<project>`
- `postgrest` → `PGRST_DB_URI=…@supabase_db_<project>:5432/…`
- `logflare` → `DB_HOSTNAME=supabase_db_<project>`

The socktainer DNS log shows the alias registered but the name queried and missed:

```
[dns] registered db → 192.168.65.21
[dns] registered db.supabase.internal → 192.168.65.21
[dns] supabase_db_<project> not in table, forwarding to 1.1.1.1   ← the bug
```

Result: `auth` / `storage-api` / `analytics` fail at boot with `nxdomain` / `i/o timeout` / `EAI_AGAIN`, while `db` (the alias) resolves fine. (`postgrest`/`pg_meta` only *look* healthy because their HTTP healthchecks don't re-resolve the db.)

## Fix

Register the container's own name (`snapshot.id`) in `ContainerStartRoute`, alongside the existing aliases, and unregister it symmetrically (ownership-checked) in `ContainerDeleteRoute`. This matches Docker's embedded-DNS behavior: resolve by name **and** aliases.

## Tests

- `ComposeDNSTests`: the prior "no entries without compose labels" test now asserts the container **name** is registered (the corrected behavior), plus two new tests — name registered alongside `socktainer.dns.names` aliases, and name unregistered on delete.
- Full suite green: **334 tests / 51 suites**. `make fmt` clean. DCO signed.

## Verified end-to-end

With this fix (built into the binary), `supabase start` brings up the **entire** stack healthy (db/auth/storage/analytics/rest/realtime/kong/vector/pg_meta/inbucket/edge_runtime), and `getent hosts supabase_db_<project>` from inside the previously-failing `auth` container resolves to the db IP.

Context / tracking: socktainer#253.
