### PR TITLE
fix(containers): return raw log stream for TTY containers

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -21,6 +21,12 @@ extension ContainerLogsRoute {
                 throw Abort(.notFound, reason: "Container not found")
             }
 
+            // Containers started with a TTY produce a raw, unmultiplexed log
+            // stream; non-TTY containers use Docker's 8-byte stdcopy framing.
+            // The docker CLI decides how to read the stream from the container's
+            // Tty setting, so the framing here must match it.
+            let isTTY = container.configuration.initProcess.terminal
+
             // always use the container's log, not the boot of the container
             let boot = false
             let fhs = try await ContainerClient().logs(id: container.id)
@@ -41,7 +47,7 @@ extension ContainerLogsRoute {
                             buffer.append(data)
 
                             // Process complete frames from buffer
-                            buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer) { outputBuffer in
+                            buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer, ttyMode: isTTY) { outputBuffer in
                                 _ = writer.write(.buffer(outputBuffer))
                             }
                         }
@@ -71,7 +77,7 @@ extension ContainerLogsRoute {
                             while let data = try fileHandle.read(upToCount: 4096), !data.isEmpty {
                                 gotData = true
                                 buffer.append(data)
-                                buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer) { outputBuffer in
+                                buffer = try ContainerLogsRoute.processDockerLogFrames(from: buffer, ttyMode: isTTY) { outputBuffer in
                                     frames.append(outputBuffer)
                                 }
                             }
@@ -107,30 +113,18 @@ extension ContainerLogsRoute {
         }
     }
 
-    private static func processDockerLogFrames(from buffer: Data, writeOutput: (ByteBuffer) -> Void) throws -> Data {
-        // Since the buffer contains raw log data, we need to format it as Docker log frames
-        // with stdout stream type (0x01)
+    static func processDockerLogFrames(from buffer: Data, ttyMode: Bool, writeOutput: (ByteBuffer) -> Void) throws -> Data {
         guard !buffer.isEmpty else {
             return buffer
         }
 
-        // Create a Docker log frame with stdout stream type
-        let streamType: UInt8 = 0x01  // stdout
-        let frameSize = UInt32(buffer.count)
-
-        // Create the 8-byte header: [stream_type, 0, 0, 0, size_bytes...]
-        var frame = Data(capacity: 8 + buffer.count)
-        frame.append(streamType)
-        frame.append(contentsOf: [0, 0, 0])  // padding
-        frame.append(contentsOf: withUnsafeBytes(of: frameSize.bigEndian) { Data($0) })
-        frame.append(buffer)
-
-        // Write the complete frame
-        var outputBuffer = ByteBufferAllocator().buffer(capacity: frame.count)
-        outputBuffer.writeBytes(frame)
+        // Match the container's TTY mode: a TTY produces a raw, unmultiplexed
+        // stream, while non-TTY logs use Docker's 8-byte stdcopy framing. Shared
+        // with the attach/exec routes via writeDockerFrame so the wire format is
+        // defined in exactly one place.
+        var outputBuffer = ByteBufferAllocator().buffer(capacity: buffer.count + (ttyMode ? 0 : 8))
+        outputBuffer.writeDockerFrame(streamType: .stdout, data: buffer, ttyMode: ttyMode)
         writeOutput(outputBuffer)
-
-        // Return empty data since we've processed all the buffer
         return Data()
     }
 }

--- a/Tests/socktainerTests/Routes/ContainerLogsFramingTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerLogsFramingTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import NIOCore
+import Testing
+
+@testable import socktainer
+
+/// Tests for `ContainerLogsRoute.processDockerLogFrames`, which must match the
+/// container's TTY mode: non-TTY logs are multiplexed with Docker's 8-byte
+/// stdcopy header, TTY logs are passed through raw.
+@Suite("ContainerLogsRoute — log stream framing")
+struct ContainerLogsFramingTests {
+
+    private func collect(_ buffer: Data, ttyMode: Bool) throws -> ([UInt8], Data) {
+        var out = ByteBuffer()
+        let remainder = try ContainerLogsRoute.processDockerLogFrames(from: buffer, ttyMode: ttyMode) { frame in
+            out.writeImmutableBuffer(frame)
+        }
+        return (Array(out.readableBytesView), remainder)
+    }
+
+    @Test("non-TTY logs are wrapped in the 8-byte stdcopy header")
+    func nonTTYIsFramed() throws {
+        let payload = Data("hello".utf8)
+        let (bytes, remainder) = try collect(payload, ttyMode: false)
+
+        // header: [stream=stdout(1), 0, 0, 0, size big-endian (4 bytes)] + payload
+        #expect(bytes.count == 8 + payload.count)
+        #expect(bytes[0] == 0x01)
+        #expect(Array(bytes[1...3]) == [0, 0, 0])
+        #expect(Array(bytes[4...7]) == [0, 0, 0, UInt8(payload.count)])
+        #expect(Array(bytes[8...]) == Array(payload))
+        #expect(remainder.isEmpty)
+    }
+
+    @Test("TTY logs are passed through raw, without any framing header")
+    func ttyIsRaw() throws {
+        let payload = Data("hello".utf8)
+        let (bytes, remainder) = try collect(payload, ttyMode: true)
+
+        #expect(bytes == Array(payload))
+        #expect(remainder.isEmpty)
+    }
+
+    @Test("empty input produces no output in both modes")
+    func emptyInput() throws {
+        let (framed, r1) = try collect(Data(), ttyMode: false)
+        let (raw, r2) = try collect(Data(), ttyMode: true)
+        #expect(framed.isEmpty)
+        #expect(raw.isEmpty)
+        #expect(r1.isEmpty)
+        #expect(r2.isEmpty)
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerLogsFramingTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerLogsFramingTests.swift
@@ -32,6 +32,18 @@ struct ContainerLogsFramingTests {
         #expect(remainder.isEmpty)
     }
 
+    @Test("non-TTY length field uses all four big-endian header bytes (payload > 255B)")
+    func nonTTYLengthUsesAllHeaderBytes() throws {
+        let payload = Data(repeating: 0x61, count: 300)  // 300 = 0x0000012C
+        let (bytes, remainder) = try collect(payload, ttyMode: false)
+
+        // The sibling test covers the header shape for a small payload; this one
+        // exists to verify the upper length bytes, so it asserts all four.
+        #expect(Array(bytes[4...7]) == [0, 0, 1, 44])  // 300 big-endian = 0x00 0x00 0x01 0x2C
+        #expect(Array(bytes[8...]) == Array(payload))
+        #expect(remainder.isEmpty)
+    }
+
     @Test("TTY logs are passed through raw, without any framing header")
     func ttyIsRaw() throws {
         let payload = Data("hello".utf8)


### PR DESCRIPTION
## Summary

`GET /containers/{id}/logs` always wrapped its output in Docker's 8-byte stdcopy frame header. For a container started with a TTY (`-t`), Docker returns the log stream **raw** (unmultiplexed), and the docker CLI reads it that way based on the container's `Tty` setting. socktainer injected the header anyway, so the first 8 bytes of every read showed up as garbage and the output was corrupted for any `-t` container.

This mirrors the framing rule the attach/exec routes already implement: raw stream when the container has a TTY, 8-byte stdcopy framing otherwise.
(Related TTY handling was previously fixed for `exec` in #244.)

## Reproduction

```bash
docker run -dt --name ttylog alpine sh -c 'echo HELLO-TTY; sleep 120'
docker logs ttylog | xxd
```

### Before

```
00000000: 0100 0000 0000 000b 4845 4c4c 4f2d 5454  ........HELLO-TT
00000010: 590d 0a                                  Y..
```

On screen (control chars made visible with `cat -v`):

```
^A^@^@^@^@^@^@^KHELLO-TTY^M
```

The leading `01 00 00 00 00 00 00 0b` is the stdcopy header leaking into a
stream the client expects to be raw.

### After

```
00000000: 4845 4c4c 4f2d 5454 590d 0a              HELLO-TTY..
```

```
HELLO-TTY^M
```

Non-TTY containers are unaffected — they keep the 8-byte stdcopy framing.

## Changes

- `ContainerLogsRoute.processDockerLogFrames` now takes a `ttyMode` flag and  frames the stream through the shared `ByteBuffer.writeDockerFrame` helper (already used by the attach and exec routes), so the wire format lives in one place instead of being hand-rolled here.
- The call sites pass `container.configuration.initProcess.terminal`.
- Adds unit tests covering both the TTY (raw) and non-TTY (framed) paths.

## Testing

- [x] `swift build`
- [x] `swift test` — full suite passes (335 tests)
- [x] `swift format lint --strict` clean
- [x] Manual before/after with a `-t` container (see Reproduction)
- [x] All commits signed off (DCO)

Verified on macOS 26.5 / Apple `container` 1.0.0.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
