### PR TITLE
fix: align create/delete success status codes with Docker Engine API

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -54,7 +54,7 @@ struct CreateContainerRequest: Content {
 }
 
 extension ContainerCreateRoute {
-    static func handler(client: ClientContainerProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> RESTContainerCreate {
+    static func handler(client: ClientContainerProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> Response {
         { req in
             let query = try req.query.decode(ContainerCreateQuery.self)
 
@@ -501,10 +501,14 @@ extension ContainerCreateRoute {
                 throw Abort(.internalServerError, reason: "Failed to create container: \(error)")
             }
 
-            return RESTContainerCreate(
+            // Docker Engine API: POST /containers/create returns 201 Created.
+            let createResponse = RESTContainerCreate(
                 Id: DockerContainerID.hexId(for: container),
                 Warnings: []
             )
+            let httpResponse = try await createResponse.encodeResponse(for: req)
+            httpResponse.status = .created
+            return httpResponse
         }
     }
 }

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -97,7 +97,8 @@ extension ContainerDeleteRoute {
             }
 
             await broadcastRemove()
-            return .ok
+            // Docker Engine API: DELETE /containers/{id} returns 204 No Content.
+            return .noContent
         }
     }
 }

--- a/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
@@ -51,6 +51,9 @@ struct NetworkCreateRoute: RouteCollection {
             guard let existing = try await client.getNetwork(id: query.Name, logger: logger) else { throw error }
             response = RESTNetworkCreate(Id: existing.Id, Warning: "")
         }
-        return try await response.encodeResponse(for: req)
+        // Docker Engine API: POST /networks/create returns 201 Created.
+        let httpResponse = try await response.encodeResponse(for: req)
+        httpResponse.status = .created
+        return httpResponse
     }
 }

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -12,7 +12,7 @@ struct VolumeCreateRoute: RouteCollection {
 
     /// Creates a volume, returning the existing volume when one with the same
     /// name already exists (idempotent, matching Docker's `POST /volumes/create`).
-    func handler(_ req: Request) async throws -> Volume {
+    func handler(_ req: Request) async throws -> Response {
         let createRequest = try req.content.decode(VolumeRequest.self)
         let resolvedName = (createRequest.Name?.isEmpty == false) ? createRequest.Name! : "volume-\(UUID().uuidString)"
 
@@ -41,8 +41,10 @@ struct VolumeCreateRoute: RouteCollection {
             Options: driverOpts,
             Labels: labels
         )
+        // Docker Engine API: POST /volumes/create returns 201 Created.
+        let volume: Volume
         do {
-            return try await client.create(request: restRequest)
+            volume = try await client.create(request: restRequest)
         } catch {
             // Docker's `volume create` is idempotent: creating a volume that
             // already exists returns the existing one rather than erroring.
@@ -52,7 +54,10 @@ struct VolumeCreateRoute: RouteCollection {
             // idempotent — return the existing volume; any other failure is a
             // real error and must propagate.
             guard "\(error)".lowercased().contains("already exists") else { throw error }
-            return try await client.inspect(name: resolvedName)
+            volume = try await client.inspect(name: resolvedName)
         }
+        let httpResponse = try await volume.encodeResponse(for: req)
+        httpResponse.status = .created
+        return httpResponse
     }
 }

--- a/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
@@ -13,7 +13,8 @@ struct VolumeDeleteRoute: RouteCollection {
         }
         do {
             try await client.delete(name: name)
-            return Response(status: .ok, body: .init(string: "{}"))
+            // Docker Engine API: DELETE /volumes/{name} returns 204 No Content.
+            return Response(status: .noContent)
         } catch {
             if let abortError = error as? AbortError {
                 throw abortError

--- a/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
+++ b/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
@@ -107,7 +107,7 @@ struct ContainerDeleteEventLabelTests {
             try app.register(collection: ContainerDeleteRoute(client: EventMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/\(id)") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -152,7 +152,7 @@ struct ComposeDNSTests {
             try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/abc000") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 
@@ -183,7 +183,7 @@ struct ComposeDNSTests {
             try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/abc001") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 
@@ -212,7 +212,7 @@ struct ComposeDNSTests {
             try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/abc002") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 
@@ -242,7 +242,7 @@ struct ComposeDNSTests {
             try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/abc003") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -153,6 +153,8 @@ struct ComposeDNSTests {
 
             try await app.testing().test(.DELETE, "/v1.51/containers/abc000") { res async in
                 #expect(res.status == .noContent)
+                // 204 No Content must carry an empty body.
+                #expect(res.body.readableBytes == 0)
             }
         }
 

--- a/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
@@ -106,6 +106,8 @@ struct ContainerDeleteHealthcheckTests {
 
             try await app.testing().test(.DELETE, "/v1.51/containers/\(nativeId)") { res async in
                 #expect(res.status == .noContent)
+                // 204 No Content must carry an empty body.
+                #expect(res.body.readableBytes == 0)
             }
         }
 

--- a/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerDeleteHealthcheckTests.swift
@@ -51,7 +51,7 @@ struct ContainerDeleteHealthcheckTests {
 
             // DELETE with a hex id that resolves to nil — fallback path exercises the warning log
             try await app.testing().test(.DELETE, "/v1.51/containers/\(hexId)") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 
@@ -105,7 +105,7 @@ struct ContainerDeleteHealthcheckTests {
             try app.register(collection: ContainerDeleteRoute(client: KnownContainerDeleteMock(snapshot: snapshot)))
 
             try await app.testing().test(.DELETE, "/v1.51/containers/\(nativeId)") { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .noContent)
             }
         }
 

--- a/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
@@ -18,7 +18,7 @@ import VaporTesting
 @Suite("NetworkCreateRoute — idempotent create")
 struct NetworkCreateRouteTests {
 
-    @Test("first create returns 200 with the created network")
+    @Test("first create returns 201 with the created network")
     func firstCreateSucceeds() async throws {
         let client = FakeNetworkClient()
         try await withNetworkRouteApp(client: client) { app in
@@ -27,7 +27,7 @@ struct NetworkCreateRouteTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Name":"net-a"}"#)
             ) { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .created)
                 let created = try res.content.decode(RESTNetworkCreate.self)
                 #expect(created.Id == "net-a")
             }
@@ -46,7 +46,7 @@ struct NetworkCreateRouteTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Name":"net-a"}"#)
             ) { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .created)
             }
             // Second create for the same name — must NOT be fatal.
             try await app.testing().test(
@@ -54,7 +54,7 @@ struct NetworkCreateRouteTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Name":"net-a"}"#)
             ) { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .created)
                 let body = try res.content.decode(RESTNetworkCreate.self)
                 #expect(body.Id == "net-a")
             }
@@ -90,7 +90,7 @@ struct NetworkCreateRouteTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Name":"net-a"}"#)
             ) { res async in
-                #expect(res.status == .ok)
+                #expect(res.status == .created)
             }
             // Simulate the network being deleted between the failed create and the
             // lookup — the route must not return a bogus 200, it rethrows.


### PR DESCRIPTION
## Summary

Several success responses did not match the Docker Engine API's documented status codes.
they returned a generic `200 OK` where Docker specifies `201 Created` (resource creation) or `204 No Content` (body-less success). The docker CLI is lenient about the exact 2xx code, so this is invisible from the CLI, but stricter clients/SDKs (testcontainers, docker-py, custom HTTP clients) that assert on the status code can misbehave.

This aligns the create/delete success codes with the spec. No behavior other than the status line changes; error paths are untouched.

## Before (measured against the current build)

```
POST   /containers/create   → 200   (Docker spec: 201)
POST   /volumes/create      → 200   (Docker spec: 201)
POST   /networks/create     → 200   (Docker spec: 201)
DELETE /containers/{id}     → 200   (Docker spec: 204)
DELETE /volumes/{name}      → 200   (Docker spec: 204)
```

## After

| Endpoint | Status |
|---|---|
| `POST /containers/create` | **201 Created** |
| `POST /volumes/create` | **201 Created** |
| `POST /networks/create` | **201 Created** |
| `DELETE /containers/{id}` | **204 No Content** (empty body) |
| `DELETE /volumes/{name}` | **204 No Content** (empty body) |

Already-correct routes are left as-is (`POST /images/{name}/tag` → 201,
`DELETE /networks/{id}` → 204, `kill`/`restart` → 204,
`POST /networks/{id}/connect|disconnect` → 200).

## Notes

- The idempotent `volumes/create` / `networks/create` paths (return the existing resource when it already exists) also return 201, matching a fresh  create in real Docker.
- `DELETE /volumes/{name}` previously returned `200` with a `{}` body; it now returns `204` with an empty body per the spec.
- Each route change is its own commit, with the affected route tests updated to assert the new codes.

## Testing

- [x] `swift build`
- [x] `swift test` — full suite passes (350 tests)
- [x] `swift format lint --strict` clean
- [x] Before/after status codes verified against a running daemon
- [x] All commits signed off (DCO)

Verified on macOS 26.5 / Apple `container` 1.0.0.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
