### PR TITLE
fix(volumes): AND multiple label filters on volume list/prune

### DIFF
--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -75,7 +75,10 @@ struct ClientVolumeService: ClientVolumeProtocol {
                 matches = matches && drivers.contains(volume.Driver)
             }
             if let labels = parsedFilters["label"], !labels.isEmpty, let volumeLabels = volume.Labels {
-                let labelMatches = labels.contains { labelFilter in
+                // Docker treats multiple `--filter label=...` as AND: a volume must
+                // match every label filter, not just one. (The negative `label!`
+                // and dict paths below already use allSatisfy.)
+                let labelMatches = labels.allSatisfy { labelFilter in
                     guard let eqIdx = labelFilter.firstIndex(of: "=") else {
                         return LabelNormalization.filterContainsKey(labelFilter, in: volumeLabels)
                     }

--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -74,10 +74,13 @@ struct ClientVolumeService: ClientVolumeProtocol {
             if let drivers = parsedFilters["driver"], !drivers.isEmpty {
                 matches = matches && drivers.contains(volume.Driver)
             }
-            if let labels = parsedFilters["label"], !labels.isEmpty, let volumeLabels = volume.Labels {
+            if let labels = parsedFilters["label"], !labels.isEmpty {
                 // Docker treats multiple `--filter label=...` as AND: a volume must
-                // match every label filter, not just one. (The negative `label!`
-                // and dict paths below already use allSatisfy.)
+                // match every label filter, not just one. A volume with no labels
+                // matches none of them, so treat a missing label set as empty —
+                // consistent with the negative `label!` path below (without this,
+                // an unlabeled volume would skip the block and wrongly pass).
+                let volumeLabels = volume.Labels ?? [:]
                 let labelMatches = labels.allSatisfy { labelFilter in
                     guard let eqIdx = labelFilter.firstIndex(of: "=") else {
                         return LabelNormalization.filterContainsKey(labelFilter, in: volumeLabels)

--- a/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import socktainer
 
-@Suite("Volume prune — negative label filter")
+@Suite("Volume prune — label filters")
 struct VolumePruneFilterTests {
 
     private let logger = Logger(label: "test")

--- a/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
@@ -100,6 +100,17 @@ struct VolumePruneFilterTests {
         let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label": ["env=dev"]])
         #expect(result.map(\.Name) == ["vol-dev"])
     }
+
+    @Test("a volume with no labels is excluded by a positive label filter")
+    func unlabeledVolumeExcludedByPositiveLabel() {
+        let volumes = [
+            makeVolume(name: "vol-dev", labels: ["env": "dev"]),
+            makeVolume(name: "vol-none"),  // Labels: nil
+        ]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label": ["env=dev"]])
+        // Docker excludes label-less volumes when a positive label filter is set.
+        #expect(result.map(\.Name) == ["vol-dev"])
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
+++ b/Tests/socktainerTests/Utilitites/VolumePruneFilterTests.swift
@@ -75,6 +75,31 @@ struct VolumePruneFilterTests {
         let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label!": ["env"]])
         #expect(result.isEmpty)
     }
+
+    // MARK: - Positive label matching is AND across multiple filters
+
+    @Test("multiple label filters are ANDed: only a volume matching every label is kept")
+    func multipleLabelFiltersAreAnded() {
+        let volumes = [
+            makeVolume(name: "vol-both", labels: ["env": "dev", "team": "a"]),
+            makeVolume(name: "vol-env-only", labels: ["env": "dev", "team": "b"]),
+            makeVolume(name: "vol-team-only", labels: ["env": "prod", "team": "a"]),
+        ]
+        let result = ClientVolumeService.applyFilters(
+            volumes, parsedFilters: ["label": ["env=dev", "team=a"]])
+        // Docker semantics: env=dev AND team=a → only vol-both, not vol-env-only (OR would keep all three).
+        #expect(result.map(\.Name) == ["vol-both"])
+    }
+
+    @Test("single label filter still matches as before")
+    func singleLabelFilterMatches() {
+        let volumes = [
+            makeVolume(name: "vol-dev", labels: ["env": "dev"]),
+            makeVolume(name: "vol-prod", labels: ["env": "prod"]),
+        ]
+        let result = ClientVolumeService.applyFilters(volumes, parsedFilters: ["label": ["env=dev"]])
+        #expect(result.map(\.Name) == ["vol-dev"])
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary

Docker treats multiple `--filter label=...` arguments as **AND** — a resource　must match every label filter. `ClientVolumeService.applyFilters` combined the positive `label` filters with `contains` (OR), so `docker volume ls` and `docker volume prune` returned volumes that matched only a single label.

This is more than a cosmetic listing issue: `docker volume prune --filter label=a --filter label=b` selects volumes for deletion, so the OR behavior can delete volumes the user intended to keep.

## Before (measured against the current build)

```bash
docker volume create --label env=dev  --label team=a wa
docker volume create --label env=dev  --label team=b wb
docker volume create --label env=prod --label team=a wc

docker volume ls --filter label=env=dev --filter label=team=a
# Docker: only `wa` (env=dev AND team=a)
# socktainer (before): wa, wb, wc   ← OR
```

## Changes

- **`fix(volumes): AND multiple label filters`** — switch the positive `label` match from `contains` to `allSatisfy`, so all label filters must match. This matches the negative `label!` path and the image filter, which already AND.
- **`fix(volumes): exclude unlabeled volumes from positive label filter`**  the block was guarded by `let volumeLabels = volume.Labels`, so a volume with   a nil label set skipped the block and wrongly passed. Treat a missing label  set as empty (`?? [:]`), mirroring the negative path, so an unlabeled volume is excluded by a positive label filter. (The live backend returns an empty  dict rather than nil, so this hardens the `applyFilters` contract; found via  code review.)
- Unit tests for the multi-label AND case, the single-label case, and the unlabeled-exclusion case.

## Testing

- [x] `swift build`
- [x] `swift test` — full suite passes (353 tests)
- [x] `swift format lint --strict` clean
- [x] OR→AND behavior verified against a running daemon (see Before)
- [x] All commits signed off (DCO)

Verified on macOS 26.5 / Apple `container` 1.0.0.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
