### PR TITLE
fix(dns): tag the embedded forwarder image so the DNS sidecar starts

### DIFF
--- a/Sources/socktainer/DNS/EmbeddedDNSImage.swift
+++ b/Sources/socktainer/DNS/EmbeddedDNSImage.swift
@@ -62,12 +62,23 @@ enum EmbeddedDNSImage {
             let resourceURL = SocktainerDNSImage.archiveURL
             log.info("[dns-embedded] importing embedded DNS forwarder image")
             let imageClient = ClientImageService(containerSystemConfig: containerSystemConfig)
-            _ = try await imageClient.load(
+            let loaded = try await imageClient.load(
                 tarballPath: resourceURL,
                 platform: .current,
                 appleContainerAppSupportUrl: appSupportURL,
                 logger: log
             )
+
+            // The OCI archive carries no repo:tag, so the image lands in the store
+            // untagged and cannot be resolved as `socktainer-dns:embedded`. Tag the
+            // freshly-loaded image so the forwarder can reference it locally
+            // (otherwise creating the DNS container falls back to a registry pull).
+            if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) == nil,
+                let loadedRef = loaded.first
+            {
+                let loadedImage = try await ClientImage.get(reference: loadedRef, containerSystemConfig: containerSystemConfig)
+                _ = try await loadedImage.tag(new: tag)
+            }
             log.info("[dns-embedded] DNS forwarder image ready: \(tag)")
         }
     }

--- a/Sources/socktainer/DNS/EmbeddedDNSImage.swift
+++ b/Sources/socktainer/DNS/EmbeddedDNSImage.swift
@@ -73,13 +73,19 @@ enum EmbeddedDNSImage {
             // untagged and cannot be resolved as `socktainer-dns:embedded`. Tag the
             // freshly-loaded image so the forwarder can reference it locally
             // (otherwise creating the DNS container falls back to a registry pull).
-            if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) == nil,
-                let loadedRef = loaded.first
-            {
-                let loadedImage = try await ClientImage.get(reference: loadedRef, containerSystemConfig: containerSystemConfig)
-                _ = try await loadedImage.tag(new: tag)
+            // Fail loudly if the import produced no image rather than reporting a
+            // readiness we cannot back.
+            guard let loadedRef = loaded.first else {
+                throw EmbeddedDNSError.importReturnedNoImage
             }
+            let loadedImage = try await ClientImage.get(reference: loadedRef, containerSystemConfig: containerSystemConfig)
+            _ = try await loadedImage.tag(new: tag)
             log.info("[dns-embedded] DNS forwarder image ready: \(tag)")
         }
+    }
+
+    enum EmbeddedDNSError: Error {
+        /// The embedded archive was loaded but produced no image reference to tag.
+        case importReturnedNoImage
     }
 }

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -153,9 +153,12 @@ actor NetworkDNSManager {
         )
 
         let platform = Platform.current
-        let image = try await ClientImage.fetch(
+        // The embedded DNS image was just imported into the local store by
+        // EmbeddedDNSImage.ensure(); look it up locally. Using ClientImage.fetch
+        // here would normalize "socktainer-dns:embedded" to a Docker Hub
+        // reference and try to pull it (401), since it is not a registry image.
+        let image = try await ClientImage.get(
             reference: EmbeddedDNSImage.tag,
-            platform: platform,
             containerSystemConfig: containerSystemConfig
         )
         _ = try await image.getCreateSnapshot(platform: platform)


### PR DESCRIPTION

## Summary

#238/#248 ship the DNS forwarder as an embedded OCI image so the per-network sidecar starts **with no registry access at runtime**. In practice the sidecar never starts: the embedded image loads into the store **untagged**, so it cannot be resolved as `socktainer-dns:embedded`, and `NetworkDNSManager` then calls `ClientImage.fetch` — which normalizes the reference to Docker Hub and tries to **pull** it, failing with `401 Unauthorized`. The result is no DNS forwarder, so compose containers cannot resolve each other by name.

This change makes the embedded image actually usable locally — i.e. it completes the offline-DNS behavior #238/#248 intended.

## Root cause

- The embedded OCI archive has no `repo:tag`, so `imageStore.load` registers it  untagged (`Loaded image: untagged@sha256:…`). `EmbeddedDNSImage.ensure`  imported it but never tagged it as `socktainer dns:embedded`.
- `NetworkDNSManager` looked the image up with `ClientImage.fetch` (a registry pull) instead of a local lookup, so even a present image would be re-pulled.

## Before

`compose.yaml` (services on a project network):

```yaml
name: stackdemo
services:
  web:   { image: nginx:alpine, ports: ["8090:80"] }
  api:   { image: alpine, command: sleep 600 }
  db:    { image: redis:alpine }
  cache: { image: redis:alpine }
```

```bash
docker compose up -d
docker exec stackdemo-api-1 nslookup db
docker exec stackdemo-api-1 wget -qS -O /dev/null http://web/
```

Daemon log — the forwarder never starts:

```
[dns-manager] creating DNS forwarder container for network stackdemo_default
[dns-embedded] DNS forwarder image ready: socktainer-dns:embedded
[WARNING] Could not start DNS container for stackdemo_default: internalError:
  "HTTP request to https://registry-1.docker.io/v2/library/socktainer-dns/manifests/embedded
   failed with response: 401 Unauthorized. ... no credentials found for host registry-1.docker.io"
```

Result: no `socktainer-dns-*` sidecar; `nslookup db` returns no answer;
`wget http://web/` fails. Container-to-container DNS does not work.

## After

```
[dns-embedded] DNS forwarder image ready: socktainer-dns:embedded
# sidecar is running:
socktainer-dns-stackdemo_default   socktainer-dns:embedded   running   192.168.65.2

docker exec stackdemo-api-1 nslookup db    → 192.168.65.5
docker exec stackdemo-api-1 nslookup cache → 192.168.65.6
docker exec stackdemo-api-1 nslookup web   → 192.168.65.4
docker exec stackdemo-api-1 wget -qS -O /dev/null http://web/ → HTTP/1.1 200 OK
```

Service names (and container names) resolve, and containers reach each other.

## Changes

- `EmbeddedDNSImage.ensure`: after importing the embedded archive, tag the freshly-loaded image as `socktainer-dns:embedded` (only if not already  present) so it is resolvable locally.
- `NetworkDNSManager`: look the image up with `ClientImage.get` (local store) instead of `ClientImage.fetch` (registry pull). This mirrors the local lookup  `EmbeddedDNSImage.ensure` already uses on its fast path.

## Testing

- [x] `swift test` — full suite passes (401 tests)
- [x] `make release` builds clean; `swift format lint --strict` clean
- [x] Clean runtime, `docker compose up`: per-network DNS forwarder starts; services resolve each other by name and reach each other over HTTP/TCP  (verified after a daemon restart with the embedded image removed, so the import+tag path runs from scratch)
- [x] All commits signed off (DCO)

Verified on macOS 26.5 / Apple `container` 1.0.0.

## Out of scope (possible follow-ups)

- `EmbeddedDNSImage.ImportGate` caches a completed import for the daemon's lifetime, so if the image is removed while the daemon runs it is not re-imported. Harmless in normal use; noting for completeness.
- The Homebrew `--HEAD` build does not ship the `SocktainerDNSImage` SwiftPM  resource bundle next to the installed binary, so the daemon hits `Fatal error: could not load resource bundle` when a DNS forwarder is created. That is a packaging concern, separate from this change.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
