### PR TITLE
fix(dns,network): reliable inter-container DNS across restart, sidecar loss, and cold start

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,14 @@ services:
 
 If inter-container connections start failing with `no route to host` / `EHOSTUNREACH` after heavy use (many networks created and destroyed), Apple Container's `vmnet` state has degraded — reset it with `container system stop && container system start`, then restart socktainer.
 
+### Network subnets (IPAM)
+
+Socktainer pins a stable subnet on each network it creates so that inter-container DNS keeps working across a `container system` restart (an unpinned network's subnet is reassigned by `vmnet` on restart, which would leave containers' DNS nameservers pointing at a dead address). An explicit `--subnet` / Compose `ipam.config.subnet` is honored; otherwise a free `192.168.x.0/24` is chosen automatically.
+
+`IPAM.Config` fields other than `Subnet` — `Gateway`, `IPRange`, and `AuxiliaryAddresses` — are **not supported** by the Apple Container backend (the gateway is always the subnet's `.1` and addresses are allocated by `vmnet`). They are ignored, and a `WARNING` is logged when requested.
+
+> **Note:** networks created before this behavior shipped are not pinned retroactively — recreate them (`docker compose down && docker compose up`) to get a stable subnet.
+
 ### Label key normalization
 
 Apple Container only accepts lowercase label keys matching `[a-z0-9](?:[a-z0-9\-\.\/]*[a-z0-9])?`. Docker allows mixed-case, underscores, and other characters. Socktainer automatically normalizes label keys at create time:

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -1,6 +1,7 @@
 import ContainerAPIClient
 import ContainerNetworkClient
 import ContainerResource
+import ContainerizationExtras
 import Foundation
 import Logging
 
@@ -8,7 +9,7 @@ protocol ClientNetworkProtocol: Sendable {
     func list(filters: String?, logger: Logger) async throws -> [RESTNetworkSummary]
     func getNetwork(id: String, logger: Logger) async throws -> RESTNetworkSummary?
     func delete(id: String, logger: Logger) async throws
-    func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate
+    func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate
 }
 
 struct ClientNetworkService: ClientNetworkProtocol {
@@ -137,11 +138,13 @@ struct ClientNetworkService: ClientNetworkProtocol {
         logger.debug("Deleted network with id: \(id)")
     }
 
-    func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate {
+    func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate {
         // NOTE: We will only create networks of type NAT for the time being (mimic the container CLI)
+        let pinnedSubnet = try ipv4Subnet.map { try CIDRv4($0) }
         let configuration = try NetworkConfiguration(
             name: name,
             mode: NetworkMode.nat,
+            ipv4Subnet: pinnedSubnet,
             labels: ResourceLabels(labels),
             plugin: "container-network-vmnet"
         )

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -185,7 +185,10 @@ extension RESTNetworkSummary {
             Internal: false,
             Attachable: false,
             Ingress: false,  // Only applicable for Swarm
-            IPAM: NetworkIPAM(Driver: "", Config: []),  // Currently, there are no IPAM capabilities
+            IPAM: NetworkIPAM(
+                Driver: "default",
+                Config: subnet.isEmpty ? [] : [NetworkIPAMConfig(Subnet: subnet, IPRange: nil, Gateway: gateway, AuxiliaryAddresses: nil)]
+            ),
             Options: options,
             Containers: nil,
             ConfigFrom: nil,

--- a/Sources/socktainer/DNS/EmbeddedDNSImage.swift
+++ b/Sources/socktainer/DNS/EmbeddedDNSImage.swift
@@ -4,115 +4,67 @@ import Foundation
 import Logging
 import SocktainerDNSImage
 
-/// Manages the embedded DNS forwarder OCI image.
-///
-/// The image ships as a SwiftPM resource in the `dns-forwarder` package (swiftpm branch)
-/// and is imported into Apple Container's image store on first use. Replaces the
-/// `coredns/coredns` pull — no network access required at runtime.
 enum EmbeddedDNSImage {
     static let tag = SocktainerDNSImage.reference
     private static let log = Logger(label: "socktainer.dns.embedded")
 
-    /// Serializes concurrent first-use imports across all networks.
-    /// Without this, two networks starting simultaneously both miss the
-    /// `ClientImage.get` check and both call `load`, making startup racy.
     actor ImportGate {
         static let shared = ImportGate()
-        private var task: Task<Void, Error>?
+        private var task: Task<ClientImage, Error>?
 
-        func ensureOnce(perform: @escaping @Sendable () async throws -> Void) async throws {
+        func ensureOnce(perform: @escaping @Sendable () async throws -> ClientImage) async throws -> ClientImage {
             if let existing = task {
-                // A prior or in-flight import — wait for it; success or failure is shared.
-                try await existing.value
-                return
+                return try await existing.value
             }
             let t = Task { try await perform() }
             task = t
             do {
-                try await t.value
+                return try await t.value
             } catch {
-                // Reset on failure so the next caller can retry — a transient resource
-                // error or store hiccup must not permanently poison every future import.
                 task = nil
                 throw error
             }
         }
     }
 
-    /// Ensures the embedded DNS image is available in Apple Container's image store.
-    /// Imports from the SwiftPM-bundled resource if not already present. Concurrent
-    /// callers coalesce on a single import; subsequent calls return immediately once
-    /// the image is in the store.
+    /// Returns the freshly-tagged handle directly: a get-by-tag right after tagging can miss on a cold store.
     static func ensure(
         containerSystemConfig: ContainerSystemConfig,
         appSupportURL: URL
-    ) async throws {
-        // Fast path: image already in store (common case after first use).
-        if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) != nil {
-            return
+    ) async throws -> ClientImage {
+        if let image = try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig) {
+            return image
         }
-
-        // Slow path: serialize through ImportGate so concurrent first-use callers
-        // don't each call load() independently.
-        try await ImportGate.shared.ensureOnce {
-            // Re-check inside the gate — a concurrent caller may have just loaded it.
-            if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) != nil {
-                return
+        return try await ImportGate.shared.ensureOnce {
+            if let image = try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig) {
+                return image
             }
-            let resourceURL = SocktainerDNSImage.archiveURL
-            log.info("[dns-embedded] importing embedded DNS forwarder image")
-            let imageClient = ClientImageService(containerSystemConfig: containerSystemConfig)
-            let loaded = try await imageClient.load(
-                tarballPath: resourceURL,
-                platform: .current,
-                appleContainerAppSupportUrl: appSupportURL,
-                logger: log
-            )
-
-            // The OCI archive carries no repo:tag, so the image lands in the store
-            // untagged and cannot be resolved as `socktainer-dns:embedded`. Tag the
-            // freshly-loaded image so the forwarder can reference it locally
-            // (otherwise creating the DNS container falls back to a registry pull).
-            // Fail loudly if the import produced no image rather than reporting a
-            // readiness we cannot back.
-            guard let loadedRef = loaded.first else {
-                throw EmbeddedDNSError.importReturnedNoImage
-            }
-            let loadedImage = try await ClientImage.get(reference: loadedRef, containerSystemConfig: containerSystemConfig)
-            _ = try await loadedImage.tag(new: tag)
-
-            // The tag is written over XPC, but the image list a later
-            // `ClientImage.get(reference: tag)` reads can lag briefly. Confirm the tag
-            // resolves before returning so the caller (NetworkDNSManager) can't miss it
-            // and silently skip the DNS sidecar on the first `compose up`.
-            for attempt in 0..<tagVisibilityMaxAttempts {
-                // Sleep before every check except the first, so the final check happens
-                // after the last sleep — a tag that appears at the end of the budget is
-                // still caught rather than treated as a timeout.
-                if attempt > 0 {
-                    try await Task.sleep(for: tagVisibilityPollInterval)
-                }
-                if (try? await ClientImage.get(reference: tag, containerSystemConfig: containerSystemConfig)) != nil {
-                    log.info("[dns-embedded] DNS forwarder image ready: \(tag)")
-                    return
-                }
-            }
-            // Tag write succeeded but the list still hasn't caught up within the budget.
-            // Don't fail setup over it: return and let the caller proceed. Its lookup
-            // either now sees the tag (DNS set up) or falls back to starting the
-            // container without DNS — the same graceful degradation as before — and a
-            // later `compose up` resolves once the image list catches up.
-            log.warning("[dns-embedded] tag \(tag) not yet resolvable within budget; proceeding (DNS may be set up on a later run)")
+            return try await importAndTag(containerSystemConfig: containerSystemConfig, appSupportURL: appSupportURL)
         }
     }
 
-    // The embedded image tag is confirmed visible within this budget (~2s) before
-    // ensure() returns; see the poll loop above.
-    private static let tagVisibilityMaxAttempts = 100
-    private static let tagVisibilityPollInterval: Duration = .milliseconds(20)
+    private static func importAndTag(
+        containerSystemConfig: ContainerSystemConfig,
+        appSupportURL: URL
+    ) async throws -> ClientImage {
+        log.info("[dns-embedded] importing embedded DNS forwarder image")
+        let imageClient = ClientImageService(containerSystemConfig: containerSystemConfig)
+        let loaded = try await imageClient.load(
+            tarballPath: SocktainerDNSImage.archiveURL,
+            platform: .current,
+            appleContainerAppSupportUrl: appSupportURL,
+            logger: log
+        )
+        guard let loadedRef = loaded.first else {
+            throw EmbeddedDNSError.importReturnedNoImage
+        }
+        let loadedImage = try await ClientImage.get(reference: loadedRef, containerSystemConfig: containerSystemConfig)
+        let tagged = try await loadedImage.tag(new: tag)
+        log.info("[dns-embedded] DNS forwarder image ready: \(tag)")
+        return tagged
+    }
 
     enum EmbeddedDNSError: Error {
-        /// The embedded archive was loaded but produced no image reference to tag.
         case importReturnedNoImage
     }
 }

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -31,7 +31,6 @@ actor NetworkDNSManager {
     private let appSupportURL: URL
     private let dnsPort: Int
     private let containerSystemConfig: ContainerSystemConfig
-    private var containerIPs: [String: String] = [:]  // networkId → DNS forwarder container IP
     private var pendingCreation: [String: Task<String, Error>] = [:]
     private var log = Logger(label: "socktainer.dns.manager")
 
@@ -43,20 +42,13 @@ actor NetworkDNSManager {
 
     // MARK: - Public API
 
-    /// Returns the IP of the DNS forwarder container for `networkId`, creating it lazily.
-    /// Concurrent callers for the same network are coalesced — only one container is created.
     func ensureDNSContainer(networkId: String) async throws -> String {
-        if let ip = containerIPs[networkId] {
-            log.info("[dns-manager] reusing cached DNS forwarder at \(ip) for network \(networkId)")
-            return ip
-        }
-
         if let pending = pendingCreation[networkId] {
             log.info("[dns-manager] waiting for in-flight DNS forwarder creation for network \(networkId)")
             return try await pending.value
         }
 
-        log.info("[dns-manager] creating DNS forwarder container for network \(networkId)")
+        log.info("[dns-manager] ensuring DNS forwarder container for network \(networkId)")
         let appSupportURL = self.appSupportURL
         let dnsPort = self.dnsPort
         let containerSystemConfig = self.containerSystemConfig
@@ -67,7 +59,6 @@ actor NetworkDNSManager {
 
         do {
             let ip = try await task.value
-            containerIPs[networkId] = ip
             pendingCreation.removeValue(forKey: networkId)
             log.info("[dns-manager] DNS forwarder running at \(ip) for network \(networkId)")
             return ip
@@ -77,10 +68,9 @@ actor NetworkDNSManager {
         }
     }
 
-    /// Removes the DNS forwarder container for `networkId` and clears its cached IP.
+    /// Removes the DNS forwarder container for `networkId`.
     /// Called when a user network is deleted.
     func cleanupDNSContainer(networkId: String) async {
-        containerIPs.removeValue(forKey: networkId)
         let containerId = ContainerNameUtility.sanitize(Self.containerPrefix + networkId)
         let client = ContainerClient()
         do {
@@ -123,7 +113,6 @@ actor NetworkDNSManager {
             if container.status == .running { try? await client.stop(id: container.id) }
             try? await client.delete(id: container.id)
         }
-        containerIPs.removeAll()
     }
 
     // MARK: - Private implementation
@@ -146,21 +135,12 @@ actor NetworkDNSManager {
         let networkResource = try await NetworkClient().get(id: networkId)
         let gatewayIP = networkResource.status.ipv4Gateway.description
 
-        // Ensure the embedded DNS forwarder image is available (imports from bundle on first use)
-        try await EmbeddedDNSImage.ensure(
+        let image = try await EmbeddedDNSImage.ensure(
             containerSystemConfig: containerSystemConfig,
             appSupportURL: appSupportURL
         )
 
         let platform = Platform.current
-        // The embedded DNS image was just imported into the local store by
-        // EmbeddedDNSImage.ensure(); look it up locally. Using ClientImage.fetch
-        // here would normalize "socktainer-dns:embedded" to a Docker Hub
-        // reference and try to pull it (401), since it is not a registry image.
-        let image = try await ClientImage.get(
-            reference: EmbeddedDNSImage.tag,
-            containerSystemConfig: containerSystemConfig
-        )
         _ = try await image.getCreateSnapshot(platform: platform)
 
         let processConfig = ProcessConfiguration(

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -107,6 +107,7 @@ extension ContainerAttachRoute {
         // before the polling loop finds the log file, silently dropping all output.
         // Pipe-based bootstrapping captures output directly and eliminates the race.
         if container.status == .stopped {
+            await ContainerStartRoute.ensureDNSSidecarBeforeStart(for: container, req: req)
             guard stdin else {
                 // Output-only attach (docker run / docker run -a STDOUT -a STDERR).
                 // Docker CLI sends Connection: Upgrade even without -i, so we accept the

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -64,6 +64,8 @@ extension ContainerAttachWSRoute {
         let stderr = query.stderr ?? true
         let isTTY = container.configuration.initProcess.terminal
 
+        await ContainerStartRoute.ensureDNSSidecarBeforeStart(for: container, req: req)
+
         guard let pipes = StdioPipes.make(stdin: true, stdout: stdout, stderr: stderr && !isTTY) else {
             try? await ws.close(code: .unexpectedServerError)
             return

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -40,6 +40,8 @@ extension ContainerStartRoute {
                     throw Abort(.notFound, reason: "No such container: \(id)")
                 }
 
+                await ContainerStartRoute.ensureDNSSidecarBeforeStart(for: container, req: req)
+
                 // If container is already running, return success (Docker CLI behavior)
                 if container.status == .running {
                     req.logger.debug("Container \(id) is already running")
@@ -226,5 +228,26 @@ extension ContainerStartRoute {
 
             return .noContent
         }
+    }
+
+    static func ensureDNSSidecarBeforeStart(for container: ContainerSnapshot, req: Request) async {
+        guard container.status != .running,
+            let dnsManager = req.application.storage[NetworkDNSManagerKey.self],
+            let network = sidecarNetwork(
+                configuredNetworks: container.configuration.networks.map { $0.network },
+                roleLabel: container.configuration.labels[NetworkDNSManager.roleLabel]
+            )
+        else { return }
+        do {
+            _ = try await dnsManager.ensureDNSContainer(networkId: network)
+        } catch {
+            req.logger.warning("Could not ensure DNS sidecar for \(network) on start: \(error)")
+        }
+    }
+
+    static func sidecarNetwork(configuredNetworks: [String], roleLabel: String?) -> String? {
+        if roleLabel == NetworkDNSManager.dnsRole { return nil }
+        let reserved: Set<String> = ["default", "bridge", "host", "none"]
+        return configuredNetworks.first { !$0.isEmpty && !reserved.contains($0) }
     }
 }

--- a/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
@@ -38,7 +38,8 @@ struct NetworkCreateRoute: RouteCollection {
         }
         let response: RESTNetworkCreate
         do {
-            response = try await client.create(name: query.Name, labels: labels, logger: logger)
+            response = try await NetworkCreateRoute.createPinned(
+                client: client, name: query.Name, labels: labels, ipam: query.IPAM, logger: logger)
             // moby network events carry {name, type} where type is the driver.
             // Only broadcast on actual creation — not on the idempotent "already exists" path.
             if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
@@ -63,5 +64,36 @@ struct NetworkCreateRoute: RouteCollection {
         let httpResponse = try await response.encodeResponse(for: req)
         httpResponse.status = .created
         return httpResponse
+    }
+
+    static func createPinned(
+        client: ClientNetworkProtocol,
+        name: String,
+        labels: [String: String],
+        ipam: NetworkIPAM?,
+        logger: Logger
+    ) async throws -> RESTNetworkCreate {
+        if let requestedSubnet = ipam?.Config.first(where: { !($0.Subnet ?? "").isEmpty })?.Subnet {
+            return try await client.create(name: name, labels: labels, ipv4Subnet: requestedSubnet, logger: logger)
+        }
+
+        let usedSubnets = ((try? await client.list(filters: nil, logger: logger)) ?? []).compactMap { $0.Subnet }
+        var excludedOctets: Set<Int> = []
+        while let subnet = SubnetAllocator.nextFreeSubnet(usedSubnets: usedSubnets, excluded: excludedOctets) {
+            do {
+                return try await client.create(name: name, labels: labels, ipv4Subnet: subnet, logger: logger)
+            } catch {
+                guard isSubnetConflict(error) else { throw error }
+                if let octet = SubnetAllocator.thirdOctet(of: subnet) { excludedOctets.insert(octet) }
+            }
+        }
+        logger.warning("[networks] no free pinnable subnet for \(name); creating without a pinned subnet")
+        return try await client.create(name: name, labels: labels, ipv4Subnet: nil, logger: logger)
+    }
+
+    static func isSubnetConflict(_ error: Error) -> Bool {
+        let message = "\(error)".lowercased()
+        guard !message.contains("already exists") else { return false }
+        return message.contains("subnet") || message.contains("overlap") || message.contains("in use")
     }
 }

--- a/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Networks/NetworkCreateRoute.swift
@@ -1,3 +1,4 @@
+import ContainerizationExtras
 import Vapor
 
 struct NetworksCreateQuery: Content {
@@ -73,13 +74,22 @@ struct NetworkCreateRoute: RouteCollection {
         ipam: NetworkIPAM?,
         logger: Logger
     ) async throws -> RESTNetworkCreate {
+        let unsupported = unsupportedIPAMFields(ipam)
+        if !unsupported.isEmpty {
+            logger.warning("[networks] ignoring IPAM fields unsupported by the Apple Container backend: \(unsupported.joined(separator: ", "))")
+        }
+
         if let requestedSubnet = ipam?.Config.first(where: { !($0.Subnet ?? "").isEmpty })?.Subnet {
+            guard (try? CIDRv4(requestedSubnet)) != nil else {
+                throw Abort(.badRequest, reason: "invalid subnet '\(requestedSubnet)'")
+            }
             return try await client.create(name: name, labels: labels, ipv4Subnet: requestedSubnet, logger: logger)
         }
 
         let usedSubnets = ((try? await client.list(filters: nil, logger: logger)) ?? []).compactMap { $0.Subnet }
         var excludedOctets: Set<Int> = []
-        while let subnet = SubnetAllocator.nextFreeSubnet(usedSubnets: usedSubnets, excluded: excludedOctets) {
+        for _ in 0..<maxSubnetConflictRetries {
+            guard let subnet = SubnetAllocator.nextFreeSubnet(usedSubnets: usedSubnets, excluded: excludedOctets) else { break }
             do {
                 return try await client.create(name: name, labels: labels, ipv4Subnet: subnet, logger: logger)
             } catch {
@@ -91,9 +101,22 @@ struct NetworkCreateRoute: RouteCollection {
         return try await client.create(name: name, labels: labels, ipv4Subnet: nil, logger: logger)
     }
 
+    static let maxSubnetConflictRetries = 5
+
     static func isSubnetConflict(_ error: Error) -> Bool {
         let message = "\(error)".lowercased()
         guard !message.contains("already exists") else { return false }
         return message.contains("subnet") || message.contains("overlap") || message.contains("in use")
+    }
+
+    static func unsupportedIPAMFields(_ ipam: NetworkIPAM?) -> [String] {
+        guard let configs = ipam?.Config else { return [] }
+        var fields: Set<String> = []
+        for config in configs {
+            if !(config.Gateway ?? "").isEmpty { fields.insert("Gateway") }
+            if !(config.IPRange ?? "").isEmpty { fields.insert("IPRange") }
+            if !(config.AuxiliaryAddresses ?? [:]).isEmpty { fields.insert("AuxiliaryAddresses") }
+        }
+        return fields.sorted()
     }
 }

--- a/Sources/socktainer/Utilities/SubnetAllocator.swift
+++ b/Sources/socktainer/Utilities/SubnetAllocator.swift
@@ -1,0 +1,21 @@
+enum SubnetAllocator {
+    private static let networkPrefix = "192.168"
+    private static let lowestThirdOctet = 16
+    private static let highestThirdOctet = 254
+
+    static func nextFreeSubnet(usedSubnets: [String], excluded: Set<Int> = []) -> String? {
+        let taken = excluded.union(usedSubnets.compactMap(thirdOctet))
+        return stride(from: highestThirdOctet, through: lowestThirdOctet, by: -1)
+            .first { !taken.contains($0) }
+            .map { "\(networkPrefix).\($0).0/24" }
+    }
+
+    static func thirdOctet(of cidrOrAddress: String) -> Int? {
+        let octets = cidrOrAddress.prefix { $0 != "/" }.split(separator: ".")
+        guard octets.count >= 4,
+            octets.prefix(2).joined(separator: ".") == networkPrefix,
+            let third = Int(octets[2])
+        else { return nil }
+        return third
+    }
+}

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -1,3 +1,6 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
 import Darwin
 import Foundation
 import SocktainerDNSImage
@@ -269,8 +272,19 @@ struct EmbeddedDNSImageTests {
 
         // Second call: must succeed — gate must have cleared the failed task.
         let retryCount = ActorCounter()
-        try await gate.ensureOnce { await retryCount.increment() }
+        let image = try await gate.ensureOnce {
+            await retryCount.increment()
+            return makeTestImage()
+        }
         #expect(await retryCount.value == 1, "gate must allow retry after a prior failure")
+        #expect(image.reference == EmbeddedDNSImage.tag, "gate must return the image produced by the retried perform")
+    }
+
+    @Test("ImportGate.ensureOnce returns the image produced by perform")
+    func importGateReturnsPerformImage() async throws {
+        let gate = EmbeddedDNSImage.ImportGate()
+        let image = try await gate.ensureOnce { makeTestImage(reference: EmbeddedDNSImage.tag) }
+        #expect(image.reference == EmbeddedDNSImage.tag)
     }
 
     // Regression for the concurrent first-use race (Finding #1 in CodeRabbit review):
@@ -284,22 +298,38 @@ struct EmbeddedDNSImageTests {
         let callCount = ActorCounter()
 
         // Start two tasks concurrently; both will race into ensureOnce.
-        async let t1: Void = gate.ensureOnce {
+        async let t1: ClientImage = gate.ensureOnce {
             await callCount.increment()
             // Brief yield so the second task has a chance to arrive while the first is
             // in-flight, proving the "in-flight task" branch of ensureOnce is exercised.
             try await Task.sleep(nanoseconds: 10_000_000)
+            return makeTestImage()
         }
-        async let t2: Void = gate.ensureOnce {
+        async let t2: ClientImage = gate.ensureOnce {
             await callCount.increment()
             try await Task.sleep(nanoseconds: 10_000_000)
+            return makeTestImage()
         }
-        try await t1
-        try await t2
+        let r1 = try await t1
+        let r2 = try await t2
 
         let count = await callCount.value
         #expect(count == 1, "perform must execute exactly once — concurrent callers must coalesce, not each run the body")
+        #expect(r1.reference == r2.reference, "coalesced callers must all receive the single leader's image")
     }
+}
+
+private func makeTestImage(reference: String = EmbeddedDNSImage.tag) -> ClientImage {
+    ClientImage(
+        description: ImageDescription(
+            reference: reference,
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:" + String(repeating: "0", count: 64),
+                size: 0
+            )
+        )
+    )
 }
 
 // MARK: - Helpers
@@ -388,5 +418,50 @@ struct FirstNamedNetworkTests {
             networkMode: nil
         )
         #expect(result == "user-net", "must skip 'default' and return the first non-reserved key")
+    }
+}
+
+// MARK: - sidecarNetwork (DNS forwarder ensured on container start, not only create)
+
+@Suite("ContainerStartRoute.sidecarNetwork")
+struct SidecarNetworkTests {
+
+    @Test("Returns the first user-defined network the container is attached to")
+    func returnsNamedNetwork() {
+        let result = ContainerStartRoute.sidecarNetwork(configuredNetworks: ["stackdemo_default"], roleLabel: nil)
+        #expect(result == "stackdemo_default")
+    }
+
+    @Test("Reserved networks return nil")
+    func reservedNetworksReturnNil() {
+        for net in ["default", "bridge", "host", "none"] {
+            let result = ContainerStartRoute.sidecarNetwork(configuredNetworks: [net], roleLabel: nil)
+            #expect(result == nil, "network '\(net)' has no DNS forwarder and must not trigger ensure")
+        }
+    }
+
+    @Test("Skips reserved and returns the first user-defined network")
+    func skipsReserved() {
+        let result = ContainerStartRoute.sidecarNetwork(configuredNetworks: ["default", "user-net"], roleLabel: nil)
+        #expect(result == "user-net")
+    }
+
+    @Test("No networks returns nil")
+    func noNetworksReturnsNil() {
+        #expect(ContainerStartRoute.sidecarNetwork(configuredNetworks: [], roleLabel: nil) == nil)
+    }
+
+    @Test("Empty network names are skipped")
+    func emptyNamesSkipped() {
+        #expect(ContainerStartRoute.sidecarNetwork(configuredNetworks: [""], roleLabel: nil) == nil)
+    }
+
+    @Test("A DNS sidecar container returns nil even on a user network")
+    func dnsSidecarReturnsNil() {
+        let result = ContainerStartRoute.sidecarNetwork(
+            configuredNetworks: ["stackdemo_default"],
+            roleLabel: NetworkDNSManager.dnsRole
+        )
+        #expect(result == nil, "a DNS sidecar must not ensure another sidecar for its own network")
     }
 }

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -466,7 +466,7 @@ private struct StubNetworkClient: ClientNetworkProtocol {
             IPAM: NetworkIPAM(Driver: "", Config: []), Options: [:], Containers: nil,
             ConfigFrom: nil, Labels: [:], Subnet: nil, Gateway: nil)
     }
-    func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate {
+    func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate {
         RESTNetworkCreate(Id: "net-abc123", Warning: "")
     }
     func delete(id: String, logger: Logger) async throws {}

--- a/Tests/socktainerTests/Network/NetworkResourceMappingTests.swift
+++ b/Tests/socktainerTests/Network/NetworkResourceMappingTests.swift
@@ -113,6 +113,23 @@ struct NetworkResourceMappingTests {
         let summary = RESTNetworkSummary(networkResource: resource)
         #expect(summary.Containers == nil)
     }
+
+    @Test("IPAM.Config carries the subnet and gateway (Docker-standard location)")
+    func ipamConfigCarriesSubnetAndGateway() throws {
+        let resource = try makeNetworkResource(configSubnet: "10.0.0.0/8", gateway: "10.0.0.1")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.IPAM.Driver == "default")
+        #expect(summary.IPAM.Config.count == 1)
+        #expect(summary.IPAM.Config.first?.Subnet == "10.0.0.0/8")
+        #expect(summary.IPAM.Config.first?.Gateway == "10.0.0.1")
+    }
+
+    @Test("IPAM.Config subnet falls back to status subnet when configuration.ipv4Subnet is nil")
+    func ipamConfigFallsBackToStatusSubnet() throws {
+        let resource = try makeNetworkResource(configSubnet: nil, statusSubnet: "172.20.0.0/16")
+        let summary = RESTNetworkSummary(networkResource: resource)
+        #expect(summary.IPAM.Config.first?.Subnet == "172.20.0.0/16")
+    }
 }
 
 // MARK: - AppleContainerTimestampResolver.networkCreationDate

--- a/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
@@ -136,6 +136,85 @@ struct NetworkCreateRouteTests {
         }
         #expect(client.lastSubnet == "192.168.55.0/24", "a client-requested subnet must be pinned as-is")
     }
+
+    @Test("auto-pick retries on a subnet conflict and pins the next free subnet")
+    func retriesOnSubnetConflict() async throws {
+        let client = FakeNetworkClient()
+        client.subnetConflictsBeforeSuccess = 1
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(client.createCalls == 2, "must retry once after the subnet conflict")
+        #expect(
+            client.triedSubnets == ["192.168.254.0/24", "192.168.253.0/24"],
+            "must exclude the conflicted subnet and pick the next free one")
+    }
+
+    @Test("auto-pick gives up after a bounded number of subnet conflicts and falls back to unpinned")
+    func retryIsBounded() async throws {
+        let client = FakeNetworkClient()
+        client.conflictAllPinned = true
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(
+            client.createCalls == NetworkCreateRoute.maxSubnetConflictRetries + 1,
+            "must cap pinned attempts and then make one unpinned fallback create")
+        #expect(client.lastSubnet == nil, "the final create must be the unpinned fallback")
+    }
+
+    @Test("an invalid explicit subnet returns 400, not 500, and never reaches the backend")
+    func invalidSubnetReturns400() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a","IPAM":{"Driver":"default","Config":[{"Subnet":"not-a-cidr"}]}}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+        #expect(client.createCalls == 0, "an invalid subnet must be rejected before reaching the backend")
+    }
+
+    @Test("isSubnetConflict distinguishes subnet conflicts from name conflicts and unrelated errors")
+    func isSubnetConflictClassification() {
+        #expect(NetworkCreateRoute.isSubnetConflict(SubnetConflictError()) == true)
+        #expect(NetworkCreateRoute.isSubnetConflict(AlreadyExistsError(name: "net-a")) == false)
+        #expect(NetworkCreateRoute.isSubnetConflict(OtherError()) == false)
+    }
+
+    @Test("unsupportedIPAMFields reports only the set, unsupported fields")
+    func unsupportedIPAMFieldsDetection() {
+        #expect(NetworkCreateRoute.unsupportedIPAMFields(nil) == [])
+
+        let onlySubnet = NetworkIPAM(
+            Driver: "default",
+            Config: [NetworkIPAMConfig(Subnet: "192.168.5.0/24", IPRange: nil, Gateway: nil, AuxiliaryAddresses: nil)])
+        #expect(NetworkCreateRoute.unsupportedIPAMFields(onlySubnet) == [])
+
+        let withUnsupported = NetworkIPAM(
+            Driver: "default",
+            Config: [
+                NetworkIPAMConfig(
+                    Subnet: "192.168.5.0/24", IPRange: "192.168.5.128/25",
+                    Gateway: "192.168.5.254", AuxiliaryAddresses: ["host": "192.168.5.2"])
+            ])
+        #expect(NetworkCreateRoute.unsupportedIPAMFields(withUnsupported) == ["AuxiliaryAddresses", "Gateway", "IPRange"])
+    }
 }
 
 // MARK: - Helpers
@@ -164,6 +243,10 @@ private struct AlreadyExistsError: Error, CustomStringConvertible {
 
 private struct OtherError: Error, CustomStringConvertible {
     var description: String { "some unrelated failure" }
+}
+
+private struct SubnetConflictError: Error, CustomStringConvertible {
+    var description: String { "requested subnet is already in use" }
 }
 
 private func makeNetworkResource(name: String) throws -> NetworkResource {
@@ -195,6 +278,12 @@ private final class FakeNetworkClient: ClientNetworkProtocol, @unchecked Sendabl
     var getNetworkReturnsNil = false
     /// When true, `create` fails with a non-"already exists" error.
     var createThrowsOther = false
+    /// Number of leading `create` calls with a pinned subnet that fail with a subnet-conflict error.
+    var subnetConflictsBeforeSuccess = 0
+    /// When true, every `create` with a non-nil subnet fails with a subnet-conflict error.
+    var conflictAllPinned = false
+    /// Every subnet passed to `create`, in order — lets tests assert re-pick behavior.
+    private(set) var triedSubnets: [String?] = []
     private var existing: Set<String> = []
 
     func list(filters: String?, logger: Logger) async throws -> [RESTNetworkSummary] { [] }
@@ -210,7 +299,15 @@ private final class FakeNetworkClient: ClientNetworkProtocol, @unchecked Sendabl
     func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate {
         createCalls += 1
         lastSubnet = ipv4Subnet
+        triedSubnets.append(ipv4Subnet)
         if createThrowsOther { throw OtherError() }
+        if ipv4Subnet != nil {
+            if conflictAllPinned { throw SubnetConflictError() }
+            if subnetConflictsBeforeSuccess > 0 {
+                subnetConflictsBeforeSuccess -= 1
+                throw SubnetConflictError()
+            }
+        }
         guard existing.insert(name).inserted else { throw AlreadyExistsError(name: name) }
         return RESTNetworkCreate(Id: name, Warning: "")
     }

--- a/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/NetworkCreateRouteTests.swift
@@ -106,6 +106,36 @@ struct NetworkCreateRouteTests {
         #expect(client.createCalls == 2)
         #expect(client.getNetworkCalls == 1)
     }
+
+    @Test("create with no IPAM auto-pins a stable subnet from the allocator range")
+    func autoPinsSubnetWhenNoneRequested() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a"}"#)
+            ) { res async in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(client.lastSubnet == "192.168.254.0/24", "an unpinned create must pin the first free allocator subnet")
+    }
+
+    @Test("an explicit IPAM subnet is honored verbatim, not auto-picked")
+    func explicitIPAMSubnetHonored() async throws {
+        let client = FakeNetworkClient()
+        try await withNetworkRouteApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/networks/create",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Name":"net-a","IPAM":{"Driver":"default","Config":[{"Subnet":"192.168.55.0/24"}]}}"#)
+            ) { res async in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(client.lastSubnet == "192.168.55.0/24", "a client-requested subnet must be pinned as-is")
+    }
 }
 
 // MARK: - Helpers
@@ -158,6 +188,8 @@ private func makeNetworkResource(name: String) throws -> NetworkResource {
 private final class FakeNetworkClient: ClientNetworkProtocol, @unchecked Sendable {
     private(set) var createCalls = 0
     private(set) var getNetworkCalls = 0
+    /// The subnet passed to the most recent `create` — lets tests assert pinning.
+    private(set) var lastSubnet: String?
     /// When true, `getNetwork` reports the network as absent (simulates a network
     /// deleted between the failed create and the lookup).
     var getNetworkReturnsNil = false
@@ -175,8 +207,9 @@ private final class FakeNetworkClient: ClientNetworkProtocol, @unchecked Sendabl
 
     func delete(id: String, logger: Logger) async throws {}
 
-    func create(name: String, labels: [String: String], logger: Logger) async throws -> RESTNetworkCreate {
+    func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate {
         createCalls += 1
+        lastSubnet = ipv4Subnet
         if createThrowsOther { throw OtherError() }
         guard existing.insert(name).inserted else { throw AlreadyExistsError(name: name) }
         return RESTNetworkCreate(Id: name, Warning: "")

--- a/Tests/socktainerTests/Utilities/SubnetAllocatorTests.swift
+++ b/Tests/socktainerTests/Utilities/SubnetAllocatorTests.swift
@@ -1,0 +1,55 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("SubnetAllocator")
+struct SubnetAllocatorTests {
+
+    @Test("Picks the highest subnet in range on an empty network list")
+    func emptyPicksRangeTop() {
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: []) == "192.168.254.0/24")
+    }
+
+    @Test("Skips subnets already in use, scanning downward")
+    func skipsUsedScanningDown() {
+        let used = ["192.168.254.0/24", "192.168.253.0/24"]
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: used) == "192.168.252.0/24")
+    }
+
+    @Test("Subnets outside 192.168 never block allocation")
+    func ignoresOutOf192168() {
+        let used = ["192.168.64.0/24", "192.168.67.0/24", "10.0.0.0/24"]
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: used) == "192.168.254.0/24")
+    }
+
+    @Test("Accepts bare gateway addresses, not just CIDRs")
+    func acceptsBareAddresses() {
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: ["192.168.254.1"]) == "192.168.253.0/24")
+    }
+
+    @Test("Excluded octets are skipped after a subnet-collision race")
+    func excludedSkipped() {
+        let result = SubnetAllocator.nextFreeSubnet(usedSubnets: [], excluded: [254, 253])
+        #expect(result == "192.168.252.0/24")
+    }
+
+    @Test("Returns nil when the whole range is exhausted")
+    func exhaustedReturnsNil() {
+        let used = (16...254).map { "192.168.\($0).0/24" }
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: used) == nil)
+    }
+
+    @Test("Stays clear of common home-LAN subnets below the floor")
+    func staysAboveFloor() {
+        let usedAboveFloor = (16...254).map { "192.168.\($0).0/24" }
+        #expect(SubnetAllocator.nextFreeSubnet(usedSubnets: usedAboveFloor) == nil, "must not fall into 192.168.0/1.x")
+    }
+
+    @Test("thirdOctet parses 192.168 addresses and rejects others")
+    func thirdOctetParsing() {
+        #expect(SubnetAllocator.thirdOctet(of: "192.168.207.0/24") == 207)
+        #expect(SubnetAllocator.thirdOctet(of: "192.168.207.1") == 207)
+        #expect(SubnetAllocator.thirdOctet(of: "10.1.2.3") == nil)
+        #expect(SubnetAllocator.thirdOctet(of: "garbage") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #262: the embedded DNS forwarder shipped, but inter-container DNS still broke in several real scenarios. This makes the per-network forwarder sidecar reliable across daemon / `container system` restarts, out-of-band sidecar removal, and cold-store first runs, and pins network subnets so containers' baked nameservers stay valid.

## Related Issue

Follow-up to #262 (see [this review comment](https://github.com/socktainer/socktainer/pull/262#issuecomment-4827512510)). Supersedes the tag-visibility poll added in #263 (see root cause 4).

## Root causes fixed

1. **Subnet rotation on restart** — networks weren't pinned, so `vmnet` reassigned a network's subnet on a `container system` restart. Each container bakes its DNS nameserver (the forwarder at gateway+1) at create time, so after a restart that nameserver pointed at a dead subnet. → Pin `configuration.ipv4Subnet` at create (a pinned subnet survives the restart; an unpinned one rotates).
2. **Sidecar created only at container-create** — a `compose up` that merely *starts* existing containers, or a daemon restart that reaped the sidecar, left containers with no forwarder. → Ensure the sidecar on container **start** (before bootstrap), and likewise in the HTTP/WS **attach** paths that bootstrap stopped containers.
3. **Stale in-memory IP cache** — `NetworkDNSManager` cached the sidecar IP and returned it without checking the sidecar still existed, so after `docker rm -f` of the sidecar it kept reporting a forwarder that was gone. → Drop the cache; the live reuse-if-running check is the single source of truth.
4. **Cold-store first run** — `ensure()` re-resolved the tag via a `list()`-backed lookup that can miss right after tagging. → Return the freshly-tagged `ClientImage` handle directly, removing the re-resolve entirely. This makes #263's poll (and its ~2s first-run latency + degradation path) unnecessary — happy to keep it as defense-in-depth if preferred.

## Changes

- `fix(network)`: pin a stable subnet — `SubnetAllocator` picks a free `192.168.x.0/24` (scanning `.254`→`.16`, clear of the platform's low dynamic range); honors an explicit IPAM subnet.
- `fix(network)`: report subnet + gateway in `IPAM.Config` (`Driver: "default"`) — Docker parity, and makes the pinned subnet observable to clients.
- `fix(network)`: warn on unsupported IPAM fields (`Gateway` / `IPRange` / `AuxiliaryAddresses` — not supported by the Apple Container backend).
- `fix(dns)`: ensure the forwarder sidecar on container start and on attach-to-stopped.
- `fix(dns)`: return the tagged image handle from `ensure()`; drop the stale sidecar IP cache.
- `docs`: "Network subnets (IPAM)" limitations note in the README.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes — 423 tests (+~26 new: `SubnetAllocator`, `createPinned` / IPAM handling, `sidecarNetwork`, `ImportGate` return/coalesce, `IPAM.Config` mapping)
- [x] Unit tests added or updated — for all newly added **decision logic**. The integration paths (`NetworkDNSManager`, `EmbeddedDNSImage.ensure`, the sidecar-ensure on start/attach) call Apple's `ContainerClient` / `ClientImage` **directly** (not dependency-injected), so they aren't unit-testable without a DI refactor; they are covered by a local integration probe and verified at runtime.
- [x] Manual testing on macOS 26.5 / Apple `container` 1.0.0: cold `docker compose up`; `container system` restart (subnet held, `nslookup` resolves); `docker rm -f` of the sidecar + container restart (sidecar recreated, DNS resolves); attach-to-stopped recreates the sidecar.

## Notes / limitations

- Networks created before this change aren't pinned retroactively — a one-time `docker compose down && docker compose up` recreates them with a pinned subnet.
- `IPAM.Config` `Gateway` / `IPRange` / `AuxiliaryAddresses` remain unsupported at the Apple Container layer (logged, then ignored), consistent with socktainer's existing handling of unsupported network options.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
