### PR TITLE
feat(containers): forward SSH agent socket bind mounts via Apple Container's native relay

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -262,7 +262,11 @@ struct ClientContainerService: ClientContainerProtocol {
         let stdio = [stdin, stdout, stderr]
 
         do {
-            let process = try await containerClient.bootstrap(id: container.id, stdio: stdio)
+            let process = try await containerClient.bootstrap(
+                id: container.id,
+                stdio: stdio,
+                dynamicEnv: SSHAgentForwarding.bootstrapDynamicEnv(labels: container.configuration.labels)
+            )
             // Clear any exit code recorded by a previous run of this container so
             // /wait blocks for the new init process rather than immediately
             // returning the stale code (e.g. after a restart).

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -280,7 +280,11 @@ extension ContainerAttachRoute {
 
         let process: ClientProcess
         do {
-            process = try await ContainerClient().bootstrap(id: container.id, stdio: pipes.stdioArray)
+            process = try await ContainerClient().bootstrap(
+                id: container.id,
+                stdio: pipes.stdioArray,
+                dynamicEnv: SSHAgentForwarding.bootstrapDynamicEnv(labels: container.configuration.labels)
+            )
         } catch {
             pipes.closeAll()
             await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
@@ -456,7 +460,11 @@ extension ContainerAttachRoute {
 
         let process: ClientProcess
         do {
-            process = try await ContainerClient().bootstrap(id: container.id, stdio: pipes.stdioArray)
+            process = try await ContainerClient().bootstrap(
+                id: container.id,
+                stdio: pipes.stdioArray,
+                dynamicEnv: SSHAgentForwarding.bootstrapDynamicEnv(labels: container.configuration.labels)
+            )
         } catch {
             pipes.closeAll()
             if isBenignStartRace(error) {

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -209,6 +209,39 @@ extension ContainerCreateRoute {
                 }
             }
 
+            // SSH agent forwarding: translate the Docker bind-mount idiom into
+            // Apple Container's native SSH relay (see SSHAgentForwarding). The
+            // matched mount is excluded from filesystem processing below and the
+            // host socket path travels to bootstrap via a label.
+            var sshAgentCandidates: [(source: String, target: String)] = []
+            for bind in body.HostConfig?.Binds ?? [] {
+                let parts = bind.split(separator: ":").map(String.init)
+                if parts.count >= 2 {
+                    sshAgentCandidates.append((source: parts[0], target: parts[1]))
+                }
+            }
+            for mount in body.HostConfig?.Mounts ?? [] where mount.MountType.lowercased() == "bind" {
+                sshAgentCandidates.append((source: mount.Source, target: mount.Target))
+            }
+            let sshAgentForward = SSHAgentForwarding.detect(candidates: sshAgentCandidates, containerEnv: finalEnv)
+            // The matched mount is consumed by the relay — downstream filesystem
+            // processing sees the request as if it wasn't there.
+            var hostBinds = body.HostConfig?.Binds
+            var hostMounts = body.HostConfig?.Mounts
+            if let sshAgentForward {
+                if let declaredTarget = sshAgentForward.declaredTarget {
+                    finalEnv = SSHAgentForwarding.rewriteEnv(finalEnv, declaredTarget: declaredTarget)
+                }
+                hostBinds = hostBinds?.filter {
+                    $0.split(separator: ":").first.map(String.init) != sshAgentForward.source
+                }
+                hostMounts = hostMounts?.filter {
+                    !($0.MountType.lowercased() == "bind" && $0.Source == sshAgentForward.source)
+                }
+                req.logger.info(
+                    "[ssh-agent] forwarding host agent socket \(sshAgentForward.hostPath) → \(SSHAgentForwarding.guestSocketPath)")
+            }
+
             let publishedPorts: [PublishPort]
             do {
                 publishedPorts = try convertPortBindings(
@@ -436,6 +469,10 @@ extension ContainerCreateRoute {
                     req.logger.warning("Could not start DNS container for \(firstNetwork): \(error)")
                 }
             }
+            if let sshAgentForward {
+                containerLabels[SSHAgentForwarding.hostPathLabel] = sshAgentForward.hostPath
+                containerConfiguration.ssh = true
+            }
             containerConfiguration.labels = containerLabels
 
             var resolvedMounts: [Filesystem] = []
@@ -447,7 +484,7 @@ extension ContainerCreateRoute {
             // directories, not individual files or Unix domain sockets. Mounting a socket
             // would cause "operation not supported" at bootstrap time.
             let isSocketPath: (String) -> Bool = { $0.hasSuffix(".sock") || $0.hasSuffix(".socket") }
-            if let binds = body.HostConfig?.Binds {
+            if let binds = hostBinds {
                 for bind in binds {
                     let parts = bind.split(separator: ":").map(String.init)
                     if let source = parts.first, source.hasPrefix("/"), !isSocketPath(source) {
@@ -456,7 +493,7 @@ extension ContainerCreateRoute {
                     }
                 }
             }
-            if let mounts = body.HostConfig?.Mounts {
+            if let mounts = hostMounts {
                 for mount in mounts where mount.MountType.lowercased() == "bind" && !mount.Source.isEmpty && !isSocketPath(mount.Source) {
                     try? FileManager.default.createDirectory(
                         atPath: mount.Source, withIntermediateDirectories: true)
@@ -465,7 +502,7 @@ extension ContainerCreateRoute {
 
             // Process bind mounts from HostConfig.Binds — filter out socket files which
             // cannot be shared via virtiofs (Apple Container is VM-based).
-            let filteredBinds = (body.HostConfig?.Binds ?? []).filter { bind in
+            let filteredBinds = (hostBinds ?? []).filter { bind in
                 let source = bind.split(separator: ":").first.map(String.init) ?? ""
                 if isSocketPath(source) {
                     req.logger.warning("bind mount '\(source)' is a Unix socket — skipped (not supported in Apple Container VMs)")
@@ -480,7 +517,7 @@ extension ContainerCreateRoute {
 
             // Process mounts from HostConfig.Mounts
             var mountsOrFs: [VolumeOrFilesystem] = []
-            if let mounts = body.HostConfig?.Mounts, !mounts.isEmpty {
+            if let mounts = hostMounts, !mounts.isEmpty {
                 // Separate volume mounts from other mount types
                 let volumeMounts = mounts.filter { $0.MountType.lowercased() == "volume" }
                 let otherMounts = mounts.filter { $0.MountType.lowercased() != "volume" && !isSocketPath($0.Source) }

--- a/Sources/socktainer/Utilities/SSHAgentForwarding.swift
+++ b/Sources/socktainer/Utilities/SSHAgentForwarding.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Translates the Docker idiom for SSH agent forwarding into Apple Container's
+/// native SSH agent relay.
+///
+/// On Linux, `docker run -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent`
+/// bind-mounts the agent socket directly — host and containers share one kernel.
+/// Apple Container runs each container in its own VM, so a Unix socket cannot
+/// cross that boundary as a shared file; it must be relayed. Apple Container
+/// ships exactly such a relay (`container run --ssh`): setting
+/// `ContainerConfiguration.ssh = true` makes the runtime relay the host socket
+/// named by the `SSH_AUTH_SOCK` entry of the bootstrap `dynamicEnv` to a fixed
+/// guest path, and point every process's `SSH_AUTH_SOCK` at that path.
+///
+/// Detection is deliberately narrow so that unrelated Unix-socket mounts
+/// (gpg-agent, docker.sock, ...) never trigger the SSH relay. A bind mount is
+/// treated as SSH agent forwarding only when:
+/// 1. the container environment declares `SSH_AUTH_SOCK=<mount target>` —
+///    the standard Docker recipe, or
+/// 2. the mount source is the host's own `$SSH_AUTH_SOCK` socket, or
+/// 3. the mount source is Docker Desktop's well-known in-VM relay path,
+///    accepted for compatibility with configurations written for Docker
+///    Desktop on macOS (that path never exists on the host itself).
+enum SSHAgentForwarding {
+    /// Guest path used by Apple Container's SSH relay (RuntimeService).
+    static let guestSocketPath = "/var/host-services/ssh-auth.sock"
+
+    /// Docker Desktop's in-VM relay path. Never exists on the macOS host, so
+    /// mounting it unambiguously means "forward my SSH agent".
+    static let dockerDesktopSocketPath = "/run/host-services/ssh-auth.sock"
+
+    /// Label carrying the host socket path from create to start, where it is
+    /// passed to bootstrap as the relay source via `dynamicEnv`.
+    static let hostPathLabel = "socktainer.ssh-auth-sock.host-path"
+
+    static let environmentVariable = "SSH_AUTH_SOCK"
+
+    struct Match: Equatable {
+        /// Host socket the runtime should relay into the guest.
+        let hostPath: String
+        /// Mount source string as it appeared in the request, used to exclude
+        /// the mount from filesystem processing.
+        let source: String
+        /// The env-declared target to rewrite to `guestSocketPath`, if any.
+        let declaredTarget: String?
+    }
+
+    static func isUnixSocket(_ path: String) -> Bool {
+        var status = stat()
+        guard stat(path, &status) == 0 else { return false }
+        return (status.st_mode & S_IFMT) == S_IFSOCK
+    }
+
+    /// The value of `SSH_AUTH_SOCK` declared in a `KEY=VALUE` environment list.
+    static func declaredSocketPath(env: [String]) -> String? {
+        let prefix = environmentVariable + "="
+        return env.first { $0.hasPrefix(prefix) }.map { String($0.dropFirst(prefix.count)) }
+    }
+
+    /// Scans bind-mount candidates for the SSH agent forwarding idiom.
+    /// `candidates` are (source, target) pairs from `HostConfig.Binds` and
+    /// bind-type `HostConfig.Mounts`.
+    static func detect(
+        candidates: [(source: String, target: String)],
+        containerEnv: [String],
+        hostEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Match? {
+        let declared = declaredSocketPath(env: containerEnv)
+        let hostAgent = hostEnvironment[environmentVariable]
+
+        for candidate in candidates {
+            if candidate.source == dockerDesktopSocketPath {
+                guard let hostAgent, isUnixSocket(hostAgent) else { continue }
+                return Match(
+                    hostPath: hostAgent,
+                    source: candidate.source,
+                    declaredTarget: declared == candidate.target ? declared : nil
+                )
+            }
+            if let declared, declared == candidate.target, isUnixSocket(candidate.source) {
+                return Match(hostPath: candidate.source, source: candidate.source, declaredTarget: declared)
+            }
+            if let hostAgent, candidate.source == hostAgent, isUnixSocket(candidate.source) {
+                return Match(
+                    hostPath: candidate.source,
+                    source: candidate.source,
+                    declaredTarget: declared == candidate.target ? declared : nil
+                )
+            }
+        }
+        return nil
+    }
+
+    /// Rewrites a declared `SSH_AUTH_SOCK=<target>` entry to the fixed guest
+    /// relay path, so the standard Docker recipe works unchanged even though
+    /// the relay socket lands at `guestSocketPath` rather than the requested
+    /// target.
+    static func rewriteEnv(_ env: [String], declaredTarget: String) -> [String] {
+        let declaredEntry = "\(environmentVariable)=\(declaredTarget)"
+        let guestEntry = "\(environmentVariable)=\(guestSocketPath)"
+        return env.map { $0 == declaredEntry ? guestEntry : $0 }
+    }
+
+    /// The `dynamicEnv` to pass to bootstrap for a container created with SSH
+    /// forwarding: the runtime reads the relay's host socket path from the
+    /// `SSH_AUTH_SOCK` entry (RuntimeService.sshAuthSocketHostUrl).
+    static func bootstrapDynamicEnv(labels: [String: String]) -> [String: String] {
+        guard let hostPath = labels[hostPathLabel] else { return [:] }
+        return [environmentVariable: hostPath]
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -175,6 +175,152 @@ struct PeerHostnameRewriteTests {
     }
 }
 
+@Suite("ContainerCreateRoute — SSH agent forwarding")
+struct SSHAgentForwardingTests {
+
+    /// Creates a real Unix domain socket at a temp path so `stat` reports S_IFSOCK.
+    private func makeUnixSocket() throws -> (path: String, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Keep the path short: sun_path is limited to ~104 bytes on Darwin.
+        let path = dir.appendingPathComponent("agent").path
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(fd >= 0)
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutableBytes(of: &addr.sun_path) { raw in
+            path.utf8CString.withUnsafeBytes { src in
+                raw.copyMemory(from: UnsafeRawBufferPointer(rebasing: src.prefix(raw.count - 1)))
+            }
+        }
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        #expect(bindResult == 0)
+        let cleanup = {
+            close(fd)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        return (path, cleanup)
+    }
+
+    @Test("Declared SSH_AUTH_SOCK env matching the mount target triggers forwarding")
+    func envDeclaredMatch() throws {
+        let (socketPath, cleanup) = try makeUnixSocket()
+        defer { cleanup() }
+
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: socketPath, target: "/ssh-agent")],
+            containerEnv: ["FOO=bar", "SSH_AUTH_SOCK=/ssh-agent"],
+            hostEnvironment: [:]
+        )
+        #expect(match == SSHAgentForwarding.Match(hostPath: socketPath, source: socketPath, declaredTarget: "/ssh-agent"))
+    }
+
+    @Test("A socket mount without any SSH_AUTH_SOCK declaration is not treated as an agent")
+    func unrelatedSocketDoesNotMatch() throws {
+        let (socketPath, cleanup) = try makeUnixSocket()
+        defer { cleanup() }
+
+        // e.g. a gpg-agent or docker.sock style mount — no SSH_AUTH_SOCK env.
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: socketPath, target: "/gpg-agent")],
+            containerEnv: ["GPG_TTY=/dev/tty"],
+            hostEnvironment: [:]
+        )
+        #expect(match == nil)
+    }
+
+    @Test("Declared env pointing elsewhere does not match the socket mount")
+    func declaredTargetMismatch() throws {
+        let (socketPath, cleanup) = try makeUnixSocket()
+        defer { cleanup() }
+
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: socketPath, target: "/gpg-agent")],
+            containerEnv: ["SSH_AUTH_SOCK=/somewhere-else"],
+            hostEnvironment: [:]
+        )
+        #expect(match == nil)
+    }
+
+    @Test("A non-socket source never matches even with a declared env")
+    func nonSocketSourceDoesNotMatch() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: dir.path, target: "/ssh-agent")],
+            containerEnv: ["SSH_AUTH_SOCK=/ssh-agent"],
+            hostEnvironment: [:]
+        )
+        #expect(match == nil)
+    }
+
+    @Test("Mounting the host's own $SSH_AUTH_SOCK matches without an env declaration")
+    func hostAgentSourceMatch() throws {
+        let (socketPath, cleanup) = try makeUnixSocket()
+        defer { cleanup() }
+
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: socketPath, target: "/ssh-agent")],
+            containerEnv: [],
+            hostEnvironment: ["SSH_AUTH_SOCK": socketPath]
+        )
+        #expect(match == SSHAgentForwarding.Match(hostPath: socketPath, source: socketPath, declaredTarget: nil))
+    }
+
+    @Test("Docker Desktop's well-known path is an alias for the host agent socket")
+    func dockerDesktopCompatibilityPath() throws {
+        let (socketPath, cleanup) = try makeUnixSocket()
+        defer { cleanup() }
+
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: SSHAgentForwarding.dockerDesktopSocketPath, target: "/ssh-agent")],
+            containerEnv: ["SSH_AUTH_SOCK=/ssh-agent"],
+            hostEnvironment: ["SSH_AUTH_SOCK": socketPath]
+        )
+        #expect(
+            match
+                == SSHAgentForwarding.Match(
+                    hostPath: socketPath,
+                    source: SSHAgentForwarding.dockerDesktopSocketPath,
+                    declaredTarget: "/ssh-agent"
+                ))
+    }
+
+    @Test("Docker Desktop path without a host agent available does not match")
+    func dockerDesktopPathWithoutHostAgent() {
+        let match = SSHAgentForwarding.detect(
+            candidates: [(source: SSHAgentForwarding.dockerDesktopSocketPath, target: "/ssh-agent")],
+            containerEnv: ["SSH_AUTH_SOCK=/ssh-agent"],
+            hostEnvironment: [:]
+        )
+        #expect(match == nil)
+    }
+
+    @Test("rewriteEnv replaces the declared target with the guest relay path")
+    func rewriteEnvReplacesDeclaredTarget() {
+        let rewritten = SSHAgentForwarding.rewriteEnv(
+            ["FOO=bar", "SSH_AUTH_SOCK=/ssh-agent", "BAZ=qux"],
+            declaredTarget: "/ssh-agent"
+        )
+        #expect(rewritten == ["FOO=bar", "SSH_AUTH_SOCK=\(SSHAgentForwarding.guestSocketPath)", "BAZ=qux"])
+    }
+
+    @Test("bootstrapDynamicEnv exposes the labeled host path")
+    func bootstrapDynamicEnvFromLabel() {
+        #expect(SSHAgentForwarding.bootstrapDynamicEnv(labels: [:]).isEmpty)
+        #expect(
+            SSHAgentForwarding.bootstrapDynamicEnv(labels: [SSHAgentForwarding.hostPathLabel: "/tmp/agent.sock"])
+                == ["SSH_AUTH_SOCK": "/tmp/agent.sock"])
+    }
+}
+
 // MARK: - Helpers
 
 private func withCreateRouteApp(


### PR DESCRIPTION
## Summary

Make Docker's SSH agent forwarding idiom work through socktainer by translating it onto Apple Container's native SSH agent relay. `ssh`/`git` over agent auth now works inside containers and dev containers.

## Related Issue

<!-- none -->

## Problem

The standard Docker recipe for SSH agent forwarding —

```
docker run -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent ...
```

and the equivalent devcontainer/compose form —

```yaml
volumes:
  - ${SSH_AUTH_SOCK}:/ssh-agent
environment:
  SSH_AUTH_SOCK: /ssh-agent
```

does nothing through socktainer: the mount is silently skipped and `SSH_AUTH_SOCK` inside the container points at a path that does not exist, so `ssh-add -l` / `git` over agent auth fail.

## Cause

A Unix domain socket has a filesystem name but its endpoint is a kernel object. On native Linux Docker the container shares the host kernel, so bind-mounting the socket just works. Apple Container runs each container in its own VM, and virtiofs shares *file contents* — a socket cannot cross the VM boundary as a shared file. socktainer therefore (correctly) skips socket bind mounts, but offers no alternative, so agent forwarding is simply unavailable.

## Fix

Apple Container already ships a socket relay for exactly this purpose (`container run --ssh`): setting `ContainerConfiguration.ssh = true` makes the runtime relay the host socket named by the `SSH_AUTH_SOCK` bootstrap `dynamicEnv` entry to `/var/host-services/ssh-auth.sock` in the guest and point every process's `SSH_AUTH_SOCK` there. This PR detects the Docker idiom at container create and routes it onto that relay:

- **Narrow detection** (`Utilities/SSHAgentForwarding.swift`) — a bind mount is treated as SSH agent forwarding only when:
  1. the container environment declares `SSH_AUTH_SOCK=<mount target>` (the standard recipe), or
  2. the mount source is the host's own `$SSH_AUTH_SOCK` socket, or
  3. the source is Docker Desktop's well-known `/run/host-services/ssh-auth.sock` path (accepted so configs written for Docker Desktop on macOS work unchanged).

  Unrelated Unix-socket mounts (gpg-agent, `docker.sock`, …) never trigger the relay.
- At create, the matched mount is excluded from filesystem processing, the declared `SSH_AUTH_SOCK` value is rewritten to the fixed guest relay path, `ContainerConfiguration.ssh` is set, and the host socket path is stored on a container label.
- All three bootstrap sites (`ClientContainerService.start` and both `ContainerAttachRoute` paths) pass that host path to `bootstrap(dynamicEnv:)`, which the runtime uses as the relay source.

Existing socket-skipping behavior is unchanged for every non-matching mount.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (410 tests)
- [x] Unit tests added — `@Suite("ContainerCreateRoute — SSH agent forwarding")` with 9 cases covering each detection route and the non-triggering cases (gpg-agent-style socket, mismatched env, non-socket source), using a real bound Unix socket so `stat` exercises the `S_IFSOCK` check
- [x] Manual testing performed:
  - `docker run -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent alpine` → `ssh-add -l` lists host identities, and `ssh -T git@github.com` authenticates successfully through the relay
  - A Zed compose dev container (the `${SSH_AUTH_SOCK}:/ssh-agent` recipe) → agent reachable from inside the container

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
