### PR TITLE
feat(containers): honor Docker StopSignal on create and inspect

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -86,6 +86,11 @@ extension ContainerCreateRoute {
 
             req.logger.info("Creating container for image: \(body.Image)")
 
+            let requestedStopSignal = body.StopSignal.flatMap { $0.isEmpty ? nil : $0 }
+            if let requestedStopSignal, !DockerSignal.isValid(requestedStopSignal) {
+                throw Abort(.badRequest, reason: "invalid signal: \(requestedStopSignal)")
+            }
+
             let rawId = Utility.createContainerID(name: containerName)
             let id = ContainerNameUtility.sanitize(rawId)
             try Utility.validEntityName(id)
@@ -284,6 +289,7 @@ extension ContainerCreateRoute {
 
             var containerConfiguration = ContainerConfiguration(id: id, image: img.description, process: processConfig)
             containerConfiguration.platform = requestedPlatform
+            containerConfiguration.stopSignal = requestedStopSignal
 
             // Enable Rosetta when running amd64 images if on arm64 host
             if Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64" {

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -72,7 +72,7 @@ extension ContainerInspectRoute {
                     let restored = LabelNormalization.restore(container.configuration.labels)
                     return restored.isEmpty ? nil : restored
                 }(),
-                StopSignal: nil,  // no mechanism to derive this value
+                StopSignal: container.configuration.stopSignal,
                 StopTimeout: nil,  // no mechanism to derive this value
                 Shell: nil  // no mechanism to derive this value
             )

--- a/Sources/socktainer/Utilities/DockerSignal.swift
+++ b/Sources/socktainer/Utilities/DockerSignal.swift
@@ -1,0 +1,23 @@
+/// Accepts exactly the signals Docker accepts, mirroring moby's `signal.ParseSignal`
+/// (github.com/moby/sys signal_linux.go): a non-zero integer, or a case-insensitive
+/// name — optionally `SIG`-prefixed — from the Linux signal set.
+enum DockerSignal {
+    private static let names: Set<String> = {
+        var set: Set<String> = [
+            "ABRT", "ALRM", "BUS", "CHLD", "CLD", "CONT", "FPE", "HUP", "ILL", "INT",
+            "IO", "IOT", "KILL", "PIPE", "POLL", "PROF", "PWR", "QUIT", "SEGV", "STKFLT",
+            "STOP", "SYS", "TERM", "TRAP", "TSTP", "TTIN", "TTOU", "URG", "USR1", "USR2",
+            "VTALRM", "WINCH", "XCPU", "XFSZ", "RTMIN", "RTMAX",
+        ]
+        for n in 1...15 { set.insert("RTMIN+\(n)") }
+        for n in 1...14 { set.insert("RTMAX-\(n)") }
+        return set
+    }()
+
+    static func isValid(_ raw: String) -> Bool {
+        if let number = Int(raw) { return number != 0 }
+        var name = raw.uppercased()
+        if name.hasPrefix("SIG") { name.removeFirst(3) }
+        return names.contains(name)
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -214,3 +214,59 @@ private struct NoopContainerClient: ClientContainerProtocol {
         ([], 0)
     }
 }
+
+@Suite("DockerSignal.isValid")
+struct DockerSignalTests {
+
+    @Test("Accepts signal names — SIG-prefixed, bare, and case-insensitive")
+    func acceptsNames() {
+        for signal in ["SIGTERM", "TERM", "sigterm", "SIGKILL", "KILL", "SIGSEGV", "SEGV", "SIGWINCH", "SIGPWR", "STKFLT"] {
+            #expect(DockerSignal.isValid(signal), "\(signal) should be valid")
+        }
+    }
+
+    @Test("Accepts real-time signals and non-zero integers")
+    func acceptsRealtimeAndNumbers() {
+        #expect(DockerSignal.isValid("SIGRTMIN+3"))
+        #expect(DockerSignal.isValid("RTMAX-1"))
+        #expect(DockerSignal.isValid("9"))
+        #expect(DockerSignal.isValid("-1"))
+    }
+
+    @Test("Rejects unknown names, signal 0, and malformed input")
+    func rejectsInvalid() {
+        for signal in ["", "0", "FOO", "SIG", "SIGFOO", "9x", "; rm", "SIGTERM ", "RTMIN+99"] {
+            #expect(!DockerSignal.isValid(signal), "\(signal) should be invalid")
+        }
+    }
+}
+
+@Suite("ContainerCreateRoute — StopSignal validation")
+struct StopSignalValidationTests {
+
+    @Test("An invalid StopSignal is rejected with 400 before any image work")
+    func invalidStopSignalReturns400() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=bad-signal",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"whatever:latest","StopSignal":"BOGUS"}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("A valid StopSignal passes validation, failing later only at the image check")
+    func validStopSignalPassesValidation() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=good-signal",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","StopSignal":"SIGWINCH"}"#)
+            ) { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Honor Docker's `StopSignal` on container create and report it on inspect. socktainer accepted `StopSignal` in the create body but dropped it, and `docker inspect` reported `"StopSignal": null`.

## Related Issue

Closes #266

## Problem

`ContainerConfig.StopSignal` (`docker run --stop-signal …`) was parsed into the create request but never applied — `ContainerInspectRoute` even hardcoded `StopSignal: nil // no mechanism to derive this value`. That comment predates Apple `container` 1.0.0, which added `ContainerConfiguration.stopSignal` ([apple/container#1462](https://github.com/apple/container/pull/1462)), giving us the mechanism.

## Changes

- New `Utilities/DockerSignal.swift` — `isValid(_:)` mirrors moby's `signal.ParseSignal` (`github.com/moby/sys` `signal_linux.go`): a non-zero integer, or a case-insensitive signal name optionally `SIG`-prefixed, from the full Linux `SignalMap` (including `RTMIN+n` / `RTMAX-n`).
- `ContainerCreateRoute`: validate `StopSignal` **early** (before image work) — an invalid value is rejected with **`400 "invalid signal: …"`**, matching Docker (which returns 400 for an unparseable signal). A valid value is stored verbatim on `ContainerConfiguration.stopSignal`; absent/empty leaves the config unset.
- `ContainerInspectRoute`: report `container.configuration.stopSignal` instead of `nil`.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added — `DockerSignal.isValid` (names / `SIG`-prefix / case / numbers / real-time signals; rejects `0`, unknown names, malformed input) and a `ContainerCreateRoute — StopSignal validation` suite asserting `400` for a bad signal and pass-through (→ `404` image check) for a valid one. (The create→config wiring and inspect reporting run at runtime; `ContainerClient` isn't dependency-injected into these routes, so the full apply isn't unit-testable in isolation.)
- [x] Manual: `docker run --stop-signal SIGWINCH …` then `docker inspect --format '{{.Config.StopSignal}}'` reports `SIGWINCH`; `docker run --stop-signal BOGUS …` returns 400.

## Design note

`StopSignal` validation is intentionally **validation-only** and does not reuse `HostUtility.parseSignal` (which returns a Darwin `Int32` for `kill`/`stop` and cannot represent Linux-only signals like `SIGSTKFLT`/`SIGRTMIN` on a macOS build). The stored value is a string resolved by the Linux guest, so Docker acceptance parity is what matters here.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
