### PR TITLE
feat(containers): honor Docker HostConfig.ShmSize on container create

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -91,6 +91,10 @@ extension ContainerCreateRoute {
                 throw Abort(.badRequest, reason: "invalid signal: \(requestedStopSignal)")
             }
 
+            if let requestedShmSize = body.HostConfig?.ShmSize, requestedShmSize < 0 {
+                throw Abort(.badRequest, reason: "SHM size can not be less than 0")
+            }
+
             let rawId = Utility.createContainerID(name: containerName)
             let id = ContainerNameUtility.sanitize(rawId)
             try Utility.validEntityName(id)
@@ -290,6 +294,7 @@ extension ContainerCreateRoute {
             var containerConfiguration = ContainerConfiguration(id: id, image: img.description, process: processConfig)
             containerConfiguration.platform = requestedPlatform
             containerConfiguration.stopSignal = requestedStopSignal
+            containerConfiguration.shmSize = ContainerCreateRoute.shmSizeBytes(body.HostConfig?.ShmSize)
 
             // Enable Rosetta when running amd64 images if on arm64 host
             if Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64" {
@@ -639,6 +644,15 @@ extension ContainerCreateRoute {
         if let net = endpointsConfigKeys.first(where: { !$0.isEmpty && !reservedModes.contains($0) }) { return net }
         if let mode = networkMode, !mode.isEmpty, !reservedModes.contains(mode) { return mode }
         return nil
+    }
+
+    /// Mirrors moby's ShmSize handling: a positive request is used verbatim; 0 or omitted
+    /// falls back to Docker's DefaultShmSize (64 MiB). Negative is rejected earlier with 400.
+    static let defaultShmSize: UInt64 = 64 * 1024 * 1024
+
+    static func shmSizeBytes(_ raw: Int?) -> UInt64 {
+        guard let raw, raw > 0 else { return defaultShmSize }
+        return UInt64(raw)
     }
 
     /// Rewrite `127.0.0.1:PORT` → `gatewayIP:PORT` in URL-form env vars (`@` or `://` prefix).

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -270,3 +270,37 @@ struct StopSignalValidationTests {
         }
     }
 }
+
+@Suite("ContainerCreateRoute.shmSizeBytes")
+struct ShmSizeBytesTests {
+
+    @Test("A positive byte count is used verbatim")
+    func positiveVerbatim() {
+        #expect(ContainerCreateRoute.shmSizeBytes(67_108_864) == 67_108_864)
+        #expect(ContainerCreateRoute.shmSizeBytes(1) == 1)
+    }
+
+    @Test("nil or zero falls back to Docker's 64 MiB default, matching moby")
+    func defaultsToDockerDefault() {
+        #expect(ContainerCreateRoute.defaultShmSize == 64 * 1024 * 1024)
+        #expect(ContainerCreateRoute.shmSizeBytes(nil) == ContainerCreateRoute.defaultShmSize)
+        #expect(ContainerCreateRoute.shmSizeBytes(0) == ContainerCreateRoute.defaultShmSize)
+    }
+}
+
+@Suite("ContainerCreateRoute — ShmSize validation")
+struct ShmSizeValidationTests {
+
+    @Test("A negative ShmSize is rejected with 400 before any image work")
+    func negativeShmSizeReturns400() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=bad-shm",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"whatever:latest","HostConfig":{"ShmSize":-1}}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Honor Docker's `HostConfig.ShmSize` (`docker run --shm-size …`) on container create, matching moby's semantics. socktainer parsed the field but dropped it, so the container's shared-memory mount kept the runtime default size regardless of the request.

## Related Issue

Closes #268

## Problem

`HostConfig.ShmSize` was decoded into the create request but never applied. Apple `container` 1.0.0 added `ContainerConfiguration.shmSize` ([apple/container#1488](https://github.com/apple/container/pull/1488)), giving us the mechanism to size the shared-memory segment (needed by Chromium/Puppeteer, some databases).

## Changes — matching moby v28.5.2

Mirrors moby's ShmSize handling (`daemon/daemon_unix.go`):

- **`> 0`** → used verbatim.
- **`0` or omitted** → falls back to Docker's `DefaultShmSize` = **64 MiB** (`defaultShmSize`), rather than deferring to Apple's own default, so `/dev/shm` matches Docker's documented contract.
- **`< 0`** → rejected early with **`400 "SHM size can not be less than 0"`** (moby's exact message from `verifyPlatformContainerSettings`).

`ContainerCreateRoute` maps the result onto `ContainerConfiguration.shmSize`.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests — `ContainerCreateRoute.shmSizeBytes` (positive verbatim; `nil`/`0` → 64 MiB default) and a `ShmSize validation` route suite asserting **`400`** on a negative value. (The create→config wiring runs at runtime; `ContainerClient` isn't dependency-injected into the route, so the end-to-end apply isn't unit-testable in isolation.)
- [x] Manual: `docker run --shm-size=256m …` sizes the shared-memory mount accordingly; `--shm-size` omitted yields 64 MiB; a negative value returns 400.

## Out of scope

- Reporting `ShmSize` back in `docker inspect` — socktainer's inspect `HostConfig` is largely unpopulated today (built via the default initializer); surfacing it is a separate, small follow-up.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
