### PR TITLE
feat(containers): honor read-only, init, cap-add/drop, and sysctl on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Ownership rules:
 - Running third-party container workloads carries inherent risks. Review sandboxing and container configurations 🔒
 - Docker API compatibility is **partial**, focused on commonly used endpoints. See `Sources/socktainer/Routes/` for implemented routes
 - Private registry auth currently depends on Apple `container` behavior. If login succeeds but private pulls/builds still fail, a manual workaround may be required. See [apple/container#816 comment 3534438608](https://github.com/apple/container/issues/816#issuecomment-3534438608) and [comment 3503618765](https://github.com/apple/container/issues/816#issuecomment-3503618765).
+- `docker run --privileged` is **not supported** — Apple Container has no privileged mode. Use granular `--cap-add` / `--cap-drop` (and `--read-only`, `--sysctl`) instead; `--privileged` is currently ignored rather than granting all capabilities.
 
 ### Docker Compose — inter-service DNS
 

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -95,6 +95,15 @@ extension ContainerCreateRoute {
                 throw Abort(.badRequest, reason: "SHM size can not be less than 0")
             }
 
+            let normalizedCapabilities: (capAdd: [String], capDrop: [String])
+            do {
+                normalizedCapabilities = try Parser.capabilities(
+                    capAdd: body.HostConfig?.CapAdd ?? [],
+                    capDrop: body.HostConfig?.CapDrop ?? [])
+            } catch {
+                throw Abort(.badRequest, reason: "invalid capability: \(error)")
+            }
+
             let rawId = Utility.createContainerID(name: containerName)
             let id = ContainerNameUtility.sanitize(rawId)
             try Utility.validEntityName(id)
@@ -295,6 +304,11 @@ extension ContainerCreateRoute {
             containerConfiguration.platform = requestedPlatform
             containerConfiguration.stopSignal = requestedStopSignal
             containerConfiguration.shmSize = ContainerCreateRoute.shmSizeBytes(body.HostConfig?.ShmSize)
+            containerConfiguration.capAdd = normalizedCapabilities.capAdd
+            containerConfiguration.capDrop = normalizedCapabilities.capDrop
+            containerConfiguration.readOnly = body.HostConfig?.ReadonlyRootfs ?? false
+            containerConfiguration.useInit = body.HostConfig?.Init ?? false
+            containerConfiguration.sysctls = body.HostConfig?.Sysctls ?? [:]
 
             // Enable Rosetta when running amd64 images if on arm64 host
             if Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64" {

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -304,3 +304,34 @@ struct ShmSizeValidationTests {
         }
     }
 }
+
+@Suite("ContainerCreateRoute — capability validation")
+struct CapabilityValidationTests {
+
+    @Test("An unknown capability is rejected with 400 before any image work")
+    func unknownCapReturns400() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=bad-cap",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"whatever:latest","HostConfig":{"CapAdd":["NOTACAP"]}}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("Known capabilities pass validation, failing later only at the image check")
+    func knownCapsPassValidation() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=good-cap",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(
+                    string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"CapAdd":["NET_ADMIN"],"CapDrop":["MKNOD"]}}"#)
+            ) { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -334,4 +334,17 @@ struct CapabilityValidationTests {
             }
         }
     }
+
+    @Test("The special ALL capability is accepted, matching moby's --cap-add=ALL")
+    func allCapabilityPassesValidation() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=all-cap",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"CapAdd":["ALL"]}}"#)
+            ) { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Honor five Docker `HostConfig` create options that Apple `container` 1.0.0 supports but socktainer decoded and then dropped: `--cap-add`, `--cap-drop`, `--read-only`, `--init`, `--sysctl`.

## Related Issue

Closes #272

## Changes — following moby v28.5.2

- **`CapAdd` / `CapDrop`** → `ContainerConfiguration.capAdd` / `capDrop`, via Apple's `Parser.capabilities`, which mirrors moby's `NormalizeLegacyCapabilities` (uppercase, add `CAP_` prefix, accept the `ALL` magic value) and validates against the known capability set. An **unknown capability is rejected with `400`** (moby returns `InvalidParameter`), validated early before any image work.
- **`ReadonlyRootfs`** → `readOnly`, **`Init`** → `useInit` — direct Bool mapping; absent → `false` (Docker's default).
- **`Sysctls`** → `sysctls` — pass-through, matching moby, which applies no API-layer allowlist and defers sysctl validation to the OCI runtime (runc/kernel), only adding safe net defaults itself.

## Not supported / out of scope

- **`--privileged`**: Apple Container has no privileged mode. It is left **ignored** (not faked as "all caps") and documented in the README limitations — use granular `--cap-add` / `--cap-drop`.
- **CPU limits** (`--cpus` / `NanoCpus` / `CpuShares` → `resources.cpus`): needs a unit conversion; tracked separately.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (432 tests)
- [x] Unit/route tests added — `capability validation` suite asserts **`400`** on an unknown cap and pass-through (→ `404` image check) for known caps (`NET_ADMIN` / `MKNOD`), confirming Apple's validator accepts the bare Docker forms. (`readOnly`/`useInit`/`sysctls` and the cap→config wiring apply at runtime; `ContainerClient` isn't dependency-injected into the route, so the end-to-end apply isn't unit-testable in isolation — the validation logic, which is, is covered.)
- [x] Manual: `docker run --read-only --cap-add NET_ADMIN --sysctl net.core.somaxconn=1024 …` is honored; `--cap-add BOGUS` returns 400.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
