### PR TITLE
feat(containers): honor --cpus (HostConfig.NanoCpus) on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Ownership rules:
 - Docker API compatibility is **partial**, focused on commonly used endpoints. See `Sources/socktainer/Routes/` for implemented routes
 - Private registry auth currently depends on Apple `container` behavior. If login succeeds but private pulls/builds still fail, a manual workaround may be required. See [apple/container#816 comment 3534438608](https://github.com/apple/container/issues/816#issuecomment-3534438608) and [comment 3503618765](https://github.com/apple/container/issues/816#issuecomment-3503618765).
 - `docker run --privileged` is **not supported** — Apple Container has no privileged mode. Use granular `--cap-add` / `--cap-drop` (and `--read-only`, `--sysctl`) instead; `--privileged` is currently ignored rather than granting all capabilities.
+- `docker run --cpus` is honored, but Apple Container allocates a **whole vCPU count** to each container's VM rather than throttling a shared kernel's CFS quota. A fractional value is floored to the nearest whole core (minimum 1) — e.g. `--cpus=1.5` gets 1 vCPU, `--cpus=0.5` still gets 1. `--cpu-shares` (relative weighting) and `--cpu-period`/`--cpu-quota` have no equivalent and are not applied.
 
 ### Docker Compose — inter-service DNS
 

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -104,6 +104,10 @@ extension ContainerCreateRoute {
                 throw Abort(.badRequest, reason: "invalid capability: \(error)")
             }
 
+            if let cpuValidationError = ContainerCreateRoute.validateCpuLimits(hostConfig: body.HostConfig) {
+                throw Abort(.badRequest, reason: cpuValidationError)
+            }
+
             let rawId = Utility.createContainerID(name: containerName)
             let id = ContainerNameUtility.sanitize(rawId)
             try Utility.validEntityName(id)
@@ -611,6 +615,10 @@ extension ContainerCreateRoute {
                 containerConfiguration.resources.memoryInBytes = memoryBytes
             }
 
+            if let nanoCpus = body.HostConfig?.NanoCpus, nanoCpus > 0 {
+                containerConfiguration.resources.cpus = ContainerCreateRoute.vCpus(fromNanoCpus: nanoCpus)
+            }
+
             let options = ContainerCreateOptions(autoRemove: body.HostConfig?.AutoRemove ?? false)
             let container: ContainerSnapshot
             do {
@@ -713,6 +721,42 @@ extension ContainerCreateRoute {
             name: container.id,
             labels: LabelNormalization.restore(container.configuration.labels)
         )
+    }
+
+    /// Mirrors moby's daemon_unix.go cpu subsystem checks (v28.5.2): NanoCpus and the CFS
+    /// period/quota knobs are mutually exclusive, NanoCpus must fall within the host's core
+    /// count, and CpuShares must be a positive weight. Returns the moby-verbatim error message
+    /// to send as a 400, or nil if the request is valid.
+    static func validateCpuLimits(hostConfig: HostConfig?) -> String? {
+        let nanoCpus = hostConfig?.NanoCpus ?? 0
+        let cpuPeriod = hostConfig?.CpuPeriod ?? 0
+        let cpuQuota = hostConfig?.CpuQuota ?? 0
+        let cpuShares = hostConfig?.CpuShares ?? 0
+
+        if nanoCpus > 0 && cpuPeriod > 0 {
+            return "Conflicting options: Nano CPUs and CPU Period cannot both be set"
+        }
+        if nanoCpus > 0 && cpuQuota > 0 {
+            return "Conflicting options: Nano CPUs and CPU Quota cannot both be set"
+        }
+        if nanoCpus != 0 {
+            let hostCores = ProcessInfo.processInfo.activeProcessorCount
+            if nanoCpus < 0 || nanoCpus > hostCores * 1_000_000_000 {
+                return "range of CPUs is from 0.01 to \(hostCores).00, as there are only \(hostCores) CPUs available"
+            }
+        }
+        if cpuShares < 0 {
+            return "invalid CPU shares (\(cpuShares)): value must be a positive integer"
+        }
+        return nil
+    }
+
+    /// Docker's `--cpus` (NanoCpus, billionths of a CPU) is a fractional CFS quota; Apple's
+    /// `resources.cpus` is a whole vCPU count provisioned to the container's VM. Floors rather
+    /// than rounds — `--cpus` is a cap, so flooring never grants more compute than requested
+    /// (a sub-1-core request like 0.5 still needs at least one whole vCPU to run at all).
+    static func vCpus(fromNanoCpus nanoCpus: Int) -> Int {
+        max(1, nanoCpus / 1_000_000_000)
     }
 }
 // Function to convert PortBindings from HostConfig to PublishedPorts

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -348,3 +348,114 @@ struct CapabilityValidationTests {
         }
     }
 }
+
+@Suite("ContainerCreateRoute.vCpus")
+struct VCpusConversionTests {
+
+    @Test("A whole-core NanoCpus value converts verbatim")
+    func wholeCoreVerbatim() {
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 4_000_000_000) == 4)
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 1_000_000_000) == 1)
+    }
+
+    @Test("A fractional NanoCpus value floors, never rounding up past the requested cap")
+    func fractionalFloors() {
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 1_500_000_000) == 1)
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 2_900_000_000) == 2)
+    }
+
+    @Test("Sub-1-core values floor to the minimum of 1 vCPU")
+    func subOneFloorsToMinimumOne() {
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 500_000_000) == 1)
+        #expect(ContainerCreateRoute.vCpus(fromNanoCpus: 10_000_000) == 1)
+    }
+}
+
+@Suite("ContainerCreateRoute.validateCpuLimits")
+struct CpuLimitsValidationTests {
+
+    @Test("NanoCpus and CpuPeriod together are rejected, matching moby")
+    func conflictingNanoCpusAndPeriod() {
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000,"CpuPeriod":100000}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "Conflicting options: Nano CPUs and CPU Period cannot both be set")
+    }
+
+    @Test("NanoCpus and CpuQuota together are rejected, matching moby")
+    func conflictingNanoCpusAndQuota() {
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000,"CpuQuota":50000}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "Conflicting options: Nano CPUs and CPU Quota cannot both be set")
+    }
+
+    @Test("A negative NanoCpus is rejected as out of range")
+    func negativeNanoCpusRejected() {
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":-1}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) != nil)
+    }
+
+    @Test("A NanoCpus value beyond the host's core count is rejected as out of range")
+    func excessiveNanoCpusRejected() {
+        let hostCores = ProcessInfo.processInfo.activeProcessorCount
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":\#((hostCores + 1) * 1_000_000_000)}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "range of CPUs is from 0.01 to \(hostCores).00, as there are only \(hostCores) CPUs available")
+    }
+
+    @Test("A NanoCpus value within the host's core count is accepted")
+    func validNanoCpusAccepted() {
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == nil)
+    }
+
+    @Test("A negative CpuShares is rejected, matching moby")
+    func negativeCpuSharesRejected() {
+        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"CpuShares":-5}"#.utf8))
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "invalid CPU shares (-5): value must be a positive integer")
+    }
+
+    @Test("No HostConfig is valid")
+    func nilHostConfigIsValid() {
+        #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: nil) == nil)
+    }
+}
+
+@Suite("ContainerCreateRoute — CPU limit validation")
+struct CpuLimitRouteValidationTests {
+
+    @Test("Conflicting NanoCpus and CpuPeriod are rejected with 400 before any image work")
+    func conflictingCpuOptionsReturn400() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=bad-cpu",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"whatever:latest","HostConfig":{"NanoCpus":1000000000,"CpuPeriod":100000}}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("A negative CpuShares is rejected with 400 before any image work")
+    func negativeCpuSharesReturns400() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=bad-shares",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"whatever:latest","HostConfig":{"CpuShares":-1}}"#)
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("A valid NanoCpus passes validation, failing later only at the image check")
+    func validNanoCpusPassesValidation() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=good-cpu",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"NanoCpus":1500000000}}"#)
+            ) { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -374,40 +374,44 @@ struct VCpusConversionTests {
 @Suite("ContainerCreateRoute.validateCpuLimits")
 struct CpuLimitsValidationTests {
 
+    private func decodeHostConfig(_ json: String) -> HostConfig {
+        try! JSONDecoder().decode(HostConfig.self, from: Data(json.utf8))
+    }
+
     @Test("NanoCpus and CpuPeriod together are rejected, matching moby")
     func conflictingNanoCpusAndPeriod() {
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000,"CpuPeriod":100000}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"NanoCpus":1000000000,"CpuPeriod":100000}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "Conflicting options: Nano CPUs and CPU Period cannot both be set")
     }
 
     @Test("NanoCpus and CpuQuota together are rejected, matching moby")
     func conflictingNanoCpusAndQuota() {
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000,"CpuQuota":50000}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"NanoCpus":1000000000,"CpuQuota":50000}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "Conflicting options: Nano CPUs and CPU Quota cannot both be set")
     }
 
     @Test("A negative NanoCpus is rejected as out of range")
     func negativeNanoCpusRejected() {
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":-1}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"NanoCpus":-1}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) != nil)
     }
 
     @Test("A NanoCpus value beyond the host's core count is rejected as out of range")
     func excessiveNanoCpusRejected() {
         let hostCores = ProcessInfo.processInfo.activeProcessorCount
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":\#((hostCores + 1) * 1_000_000_000)}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"NanoCpus":\#((hostCores + 1) * 1_000_000_000)}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "range of CPUs is from 0.01 to \(hostCores).00, as there are only \(hostCores) CPUs available")
     }
 
     @Test("A NanoCpus value within the host's core count is accepted")
     func validNanoCpusAccepted() {
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"NanoCpus":1000000000}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"NanoCpus":1000000000}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == nil)
     }
 
     @Test("A negative CpuShares is rejected, matching moby")
     func negativeCpuSharesRejected() {
-        let hostConfig = try! JSONDecoder().decode(HostConfig.self, from: Data(#"{"CpuShares":-5}"#.utf8))
+        let hostConfig = decodeHostConfig(#"{"CpuShares":-5}"#)
         #expect(ContainerCreateRoute.validateCpuLimits(hostConfig: hostConfig) == "invalid CPU shares (-5): value must be a positive integer")
     }
 


### PR DESCRIPTION
## Summary

Honor `docker run --cpus` (`HostConfig.NanoCpus`), which socktainer decoded and silently dropped, by mapping it onto Apple `container`'s `ContainerConfiguration.resources.cpus`.

## Related Issue

Closes #274

## The mismatch this PR navigates

Docker's `--cpus` is a **fractional CFS quota** throttling a shared kernel. Apple Container runs each container in its **own lightweight VM**, and `resources.cpus` is a **whole vCPU count** provisioned to that VM (default 4) — there's no shared kernel to throttle. The mapping is therefore lossy by construction: a fractional `--cpus` floors to the nearest whole core, minimum 1 (`1.5→1`, `2.9→2`, `0.5→1`). Flooring, not rounding — `--cpus` is a cap, and flooring never grants more compute than requested.

## Changes — following moby v28.5.2 (`daemon_unix.go` cpu subsystem checks)

- `NanoCpus` → `resources.cpus`, only overriding when `NanoCpus > 0` (matches the existing `Memory` mapping — `0`/absent leaves Apple's default in place).
- **Validated early, before any image work**, replicating moby's exact checks and error text:
  - `NanoCpus` + `CpuPeriod` set → `400` "Conflicting options: Nano CPUs and CPU Period cannot both be set"
  - `NanoCpus` + `CpuQuota` set → `400` "Conflicting options: Nano CPUs and CPU Quota cannot both be set"
  - `NanoCpus` outside `[0, hostCores × 1e9]` → `400` "range of CPUs is from 0.01 to N.00, as there are only N CPUs available" (host core count via `ProcessInfo.processInfo.activeProcessorCount`, mirroring moby's `runtime.NumCPU()`)
  - `CpuShares < 0` → `400` "invalid CPU shares (...): value must be a positive integer"

## Not mapped (by design, still moby-compliant)

- **`CpuShares`** (relative weighting) — no absolute-allocation equivalent under a per-VM whole-core model. Validated but not applied.
- **`CpuPeriod`/`CpuQuota`** — CFS tunables moby treats as alternatives to `NanoCpus`; incompatible with whole-vCPU provisioning.
- **`CpuCount`/`CpuPercent`** — Windows-only in moby, discarded on Linux — ignoring them here **is** the compliant behavior, not a gap.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (443 tests)
- [x] New unit tests: pure-function suites for `vCpus(fromNanoCpus:)` (flooring behavior, min-1 clamp) and `validateCpuLimits(hostConfig:)` (all four moby-parity checks), plus route-level tests asserting `400` on conflicting options / negative shares and pass-through (→ `404` image check) for a valid `NanoCpus`.
- [x] Same testability caveat as prior HostConfig PRs: the pure conversion/validation helpers and route-level 400s are unit-tested; the actual apply-to-VM isn't (`ContainerClient` isn't dependency-injected into the route), so end-to-end vCPU allocation is manual/runtime-verified, not unit-tested.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
