### PR TITLE
fix(containers): report last-known network attachment for stopped containers

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -27,9 +27,11 @@ extension ContainerInspectRoute {
     /// back to the persisted `configuration.networks` keeps that parity,
     /// though the IP/gateway are unknown without a live sandbox.
     private static func networkEndpoints(for container: ContainerSnapshot) -> [String: ContainerEndpointSettings] {
+        // uniquingKeysWith rather than uniqueKeysWithValues: nothing in Attachment's array-based
+        // storage guarantees distinct .network names, and a duplicate would otherwise trap.
         if !container.networks.isEmpty {
             return Dictionary(
-                uniqueKeysWithValues: container.networks.map { attachment in
+                container.networks.map { attachment in
                     (
                         attachment.network,
                         ContainerEndpointSettings(
@@ -48,11 +50,12 @@ extension ContainerInspectRoute {
                             DriverOpts: nil
                         )
                     )
-                }
+                },
+                uniquingKeysWith: { first, _ in first }
             )
         }
         return Dictionary(
-            uniqueKeysWithValues: container.configuration.networks.map { attachment in
+            container.configuration.networks.map { attachment in
                 (
                     attachment.network,
                     ContainerEndpointSettings(
@@ -71,7 +74,8 @@ extension ContainerInspectRoute {
                         DriverOpts: nil
                     )
                 )
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
     }
 

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -20,6 +20,61 @@ extension ContainerInspectRoute {
         }
     }
 
+    /// Apple Container only reports live network attachments while a
+    /// container is running (`container.networks` is hardcoded to `[]` once
+    /// stopped), whereas Docker's `NetworkSettings.Networks` reflects the
+    /// container's configured attachments regardless of run state. Falling
+    /// back to the persisted `configuration.networks` keeps that parity,
+    /// though the IP/gateway are unknown without a live sandbox.
+    private static func networkEndpoints(for container: ContainerSnapshot) -> [String: ContainerEndpointSettings] {
+        if !container.networks.isEmpty {
+            return Dictionary(
+                uniqueKeysWithValues: container.networks.map { attachment in
+                    (
+                        attachment.network,
+                        ContainerEndpointSettings(
+                            IPAMConfig: nil,
+                            Links: nil,
+                            Aliases: nil,
+                            NetworkID: attachment.network,
+                            EndpointID: nil,
+                            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
+                            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
+                            IPPrefixLen: nil,
+                            IPv6Gateway: nil,
+                            GlobalIPv6Address: nil,
+                            GlobalIPv6PrefixLen: nil,
+                            MacAddress: nil,
+                            DriverOpts: nil
+                        )
+                    )
+                }
+            )
+        }
+        return Dictionary(
+            uniqueKeysWithValues: container.configuration.networks.map { attachment in
+                (
+                    attachment.network,
+                    ContainerEndpointSettings(
+                        IPAMConfig: nil,
+                        Links: nil,
+                        Aliases: nil,
+                        NetworkID: attachment.network,
+                        EndpointID: nil,
+                        Gateway: nil,
+                        IPAddress: nil,
+                        IPPrefixLen: nil,
+                        IPv6Gateway: nil,
+                        GlobalIPv6Address: nil,
+                        GlobalIPv6PrefixLen: nil,
+                        MacAddress: nil,
+                        DriverOpts: nil
+                    )
+                )
+            }
+        )
+    }
+
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> RESTContainerInspect {
         { req in
             guard let id = req.parameters.get("id") else {
@@ -65,7 +120,7 @@ extension ContainerInspectRoute {
                 Volumes: nil,  // Could be derived from mounts if needed
                 WorkingDir: container.configuration.initProcess.workingDirectory.isEmpty ? nil : container.configuration.initProcess.workingDirectory,
                 Entrypoint: [container.configuration.initProcess.executable],
-                NetworkDisabled: container.networks.isEmpty,
+                NetworkDisabled: container.configuration.networks.isEmpty,
                 MacAddress: nil,  // no mechanism to derive this value
                 OnBuild: nil,  // no mechanism to derive this value
                 Labels: {
@@ -115,6 +170,7 @@ extension ContainerInspectRoute {
             let hostConfig: HostConfig = HostConfig()
 
             // Enhanced network settings with proper port mapping
+            let networkEndpoints = Self.networkEndpoints(for: container)
             let networkSettings = ContainerNetworkSettings(
                 Bridge: nil,
                 SandboxID: nil,
@@ -123,46 +179,8 @@ extension ContainerInspectRoute {
                         bindings.map { PortBinding(HostIp: $0.hostAddress.description, HostPort: "\($0.hostPort)") }
                     },
                 SandboxKey: nil,
-                Networks: Dictionary(
-                    uniqueKeysWithValues: container.networks.map { attachment in
-                        let endpoint = ContainerEndpointSettings(
-                            IPAMConfig: nil,
-                            Links: nil,
-                            Aliases: nil,
-                            NetworkID: attachment.network,
-                            EndpointID: nil,
-                            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-                            IPPrefixLen: nil,
-                            IPv6Gateway: nil,
-                            GlobalIPv6Address: nil,
-                            GlobalIPv6PrefixLen: nil,
-                            MacAddress: nil,
-                            DriverOpts: nil
-                        )
-                        return (attachment.network, endpoint)
-                    }
-                ),
-                EndpointsConfig: Dictionary(
-                    uniqueKeysWithValues: container.networks.map { attachment in
-                        let endpoint = ContainerEndpointSettings(
-                            IPAMConfig: nil,
-                            Links: nil,
-                            Aliases: nil,
-                            NetworkID: attachment.network,
-                            EndpointID: nil,
-                            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-                            IPPrefixLen: nil,
-                            IPv6Gateway: nil,
-                            GlobalIPv6Address: nil,
-                            GlobalIPv6PrefixLen: nil,
-                            MacAddress: nil,
-                            DriverOpts: nil
-                        )
-                        return (attachment.network, endpoint)
-                    }
-                )
+                Networks: networkEndpoints,
+                EndpointsConfig: networkEndpoints
             )
 
             let createdAt = AppleContainerTimestampResolver.containerCreationDate(container)

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -20,6 +20,24 @@ extension ContainerInspectRoute {
         }
     }
 
+    private static func endpointSettings(networkID: String, gateway: String? = nil, ipAddress: String? = nil) -> ContainerEndpointSettings {
+        ContainerEndpointSettings(
+            IPAMConfig: nil,
+            Links: nil,
+            Aliases: nil,
+            NetworkID: networkID,
+            EndpointID: nil,
+            Gateway: gateway,
+            IPAddress: ipAddress,
+            IPPrefixLen: nil,
+            IPv6Gateway: nil,
+            GlobalIPv6Address: nil,
+            GlobalIPv6PrefixLen: nil,
+            MacAddress: nil,
+            DriverOpts: nil
+        )
+    }
+
     /// Apple Container only reports live network attachments while a
     /// container is running (`container.networks` is hardcoded to `[]` once
     /// stopped), whereas Docker's `NetworkSettings.Networks` reflects the
@@ -34,20 +52,10 @@ extension ContainerInspectRoute {
                 container.networks.map { attachment in
                     (
                         attachment.network,
-                        ContainerEndpointSettings(
-                            IPAMConfig: nil,
-                            Links: nil,
-                            Aliases: nil,
-                            NetworkID: attachment.network,
-                            EndpointID: nil,
-                            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-                            IPPrefixLen: nil,
-                            IPv6Gateway: nil,
-                            GlobalIPv6Address: nil,
-                            GlobalIPv6PrefixLen: nil,
-                            MacAddress: nil,
-                            DriverOpts: nil
+                        endpointSettings(
+                            networkID: attachment.network,
+                            gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
+                            ipAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address))
                         )
                     )
                 },
@@ -56,24 +64,7 @@ extension ContainerInspectRoute {
         }
         return Dictionary(
             container.configuration.networks.map { attachment in
-                (
-                    attachment.network,
-                    ContainerEndpointSettings(
-                        IPAMConfig: nil,
-                        Links: nil,
-                        Aliases: nil,
-                        NetworkID: attachment.network,
-                        EndpointID: nil,
-                        Gateway: nil,
-                        IPAddress: nil,
-                        IPPrefixLen: nil,
-                        IPv6Gateway: nil,
-                        GlobalIPv6Address: nil,
-                        GlobalIPv6PrefixLen: nil,
-                        MacAddress: nil,
-                        DriverOpts: nil
-                    )
-                )
+                (attachment.network, endpointSettings(networkID: attachment.network))
             },
             uniquingKeysWith: { first, _ in first }
         )

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -1,0 +1,134 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationExtras
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression tests for issue #279: a stopped container that was correctly
+/// attached to a named network reported `NetworkSettings.Networks: {}` on
+/// inspect. Apple Container only tracks live attachments (`container.networks`
+/// is `[]` once stopped) — this asserts the route falls back to the persisted
+/// `configuration.networks` so Docker clients still see the attachment.
+private struct MockContainerClient: ClientContainerProtocol {
+    let containers: [ContainerSnapshot]
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { containers }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { containers.first { $0.id == id } }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+private func makeSnapshot(
+    id: String,
+    status: RuntimeStatus,
+    configuredNetworks: [AttachmentConfiguration],
+    liveNetworks: [ContainerResource.Attachment]
+) -> ContainerSnapshot {
+    let processConfig = ProcessConfiguration(
+        executable: "/bin/sh",
+        arguments: [],
+        environment: [],
+        workingDirectory: "/",
+        terminal: false,
+        user: .id(uid: 0, gid: 0)
+    )
+    let imageDesc = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+    )
+    var config = ContainerConfiguration(id: id, image: imageDesc, process: processConfig)
+    config.networks = configuredNetworks
+    return ContainerSnapshot(
+        configuration: config,
+        status: status,
+        networks: liveNetworks,
+        startedDate: status == .running ? Date(timeIntervalSinceNow: -30) : nil
+    )
+}
+
+@Suite("ContainerInspectRoute network settings")
+struct ContainerInspectRouteNetworkSettingsTests {
+
+    private func withRoute(
+        container: ContainerSnapshot,
+        test: @escaping (Application) async throws -> Void
+    ) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+
+            let client = MockContainerClient(containers: [container])
+            try app.register(collection: ContainerInspectRoute(client: client))
+            try await test(app)
+        }
+    }
+
+    @Test("A stopped container still reports its configured network attachment")
+    func stoppedContainerReportsConfiguredNetwork() async throws {
+        let container = makeSnapshot(
+            id: "c1",
+            status: .stopped,
+            configuredNetworks: [AttachmentConfiguration(network: "mynet", options: AttachmentOptions(hostname: "c1"))],
+            liveNetworks: []
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                #expect(inspect.NetworkSettings.Networks?.keys.contains("mynet") == true)
+                #expect(inspect.Config.NetworkDisabled == false)
+            }
+        }
+    }
+
+    @Test("A running container reports its live network attachment with IP info")
+    func runningContainerReportsLiveNetwork() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "mynet",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        let container = makeSnapshot(
+            id: "c1",
+            status: .running,
+            configuredNetworks: [AttachmentConfiguration(network: "mynet", options: AttachmentOptions(hostname: "c1"))],
+            liveNetworks: [attachment]
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                #expect(inspect.NetworkSettings.Networks?["mynet"]?.IPAddress == "192.168.64.5")
+            }
+        }
+    }
+
+    @Test("No configured networks at all is reported as network-disabled")
+    func noNetworksIsDisabled() async throws {
+        let container = makeSnapshot(id: "c1", status: .stopped, configuredNetworks: [], liveNetworks: [])
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                #expect(inspect.NetworkSettings.Networks?.isEmpty ?? true)
+                #expect(inspect.Config.NetworkDisabled == true)
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -120,6 +120,49 @@ struct ContainerInspectRouteNetworkSettingsTests {
         }
     }
 
+    @Test("Duplicate configured network names do not crash inspect")
+    func duplicateConfiguredNetworkNamesDoNotCrash() async throws {
+        let container = makeSnapshot(
+            id: "c1",
+            status: .stopped,
+            configuredNetworks: [
+                AttachmentConfiguration(network: "dup", options: AttachmentOptions(hostname: "c1")),
+                AttachmentConfiguration(network: "dup", options: AttachmentOptions(hostname: "c1")),
+            ],
+            liveNetworks: []
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                #expect(inspect.NetworkSettings.Networks?.keys.contains("dup") == true)
+            }
+        }
+    }
+
+    @Test("Duplicate live network names do not crash inspect")
+    func duplicateLiveNetworkNamesDoNotCrash() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "dup",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        let container = makeSnapshot(
+            id: "c1",
+            status: .running,
+            configuredNetworks: [AttachmentConfiguration(network: "dup", options: AttachmentOptions(hostname: "c1"))],
+            liveNetworks: [attachment, attachment]
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                #expect(inspect.NetworkSettings.Networks?.keys.contains("dup") == true)
+            }
+        }
+    }
+
     @Test("No configured networks at all is reported as network-disabled")
     func noNetworksIsDisabled() async throws {
         let container = makeSnapshot(id: "c1", status: .stopped, configuredNetworks: [], liveNetworks: [])


### PR DESCRIPTION
## Summary
- `docker inspect` on a stopped container reported `NetworkSettings.Networks: {}` even when it had a correctly-working network attachment while running — Apple Container only tracks attachments as live runtime state (`ContainersService.swift` hardcodes `networks: []` for any non-running snapshot), unlike Docker which retains endpoint info after exit.
- `ContainerInspectRoute` now falls back to the persisted `configuration.networks` (create-time desired attachments) when the live snapshot is empty, so a stopped container still reports which network(s) it's attached to (name only — IP/gateway require a live sandbox). `Config.NetworkDisabled` had the same live-vs-configured bug and is fixed the same way.
- Originally filed as #279 ("container ends up with zero network attachments"), which looked like a create-time attachment bug. Investigation (see issue comment) showed the attachment was never actually lost — it's an inspect-time reporting gap that only shows up once a container has exited. Confirmed causally: stopping a verified-attached running container flips its reported Networks to `{}` immediately.

## Test plan
- [x] New unit tests (`ContainerInspectRouteTests.swift`): stopped container with configured network reports it; running container reports live IP; no configured networks reports `NetworkDisabled: true`.
- [x] `make test` — 449 tests pass.
- [x] `make fmt` — clean.
- [x] Verified against a real `supabase start` run: previously-`{}` exited containers (`supabase_storage_supabase`, `supabase_kong_supabase`, `supabase_db_supabase`, `supabase_vector_supabase`) now report their `supabase_network_supabase` attachment; still-running containers (`supabase_pg_meta_supabase`) unaffected.

Refs #279. Note: this fixes the inspect-reporting gap only — it does not address the underlying `EHOSTUNREACH` connectivity failure that caused those containers to exit in the first place (separate, still-open investigation).