### PR TITLE
fix(exec): reject an exec create with no command instead of crashing the daemon

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -69,7 +69,9 @@ actor ExecManager {
 
 // Request & Response DTOs
 struct CreateExecRequest: Content {
-    let Cmd: [String]
+    // Optional so that a missing/null Cmd yields Docker's "No exec command
+    // specified" 400 rather than a generic decoding error.
+    let Cmd: [String]?
     let AttachStdin: Bool?
     let AttachStdout: Bool?
     let AttachStderr: Bool?
@@ -164,6 +166,15 @@ struct ExecRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
+            let body = try req.content.decode(CreateExecRequest.self)
+
+            // Docker rejects an exec with no command at create time, before even
+            // resolving the container. Without this guard the empty Cmd is stored
+            // and startExec's config.cmd.first! traps, taking down the whole daemon.
+            guard let cmd = body.Cmd, !cmd.isEmpty else {
+                throw Abort(.badRequest, reason: "No exec command specified")
+            }
+
             guard let container = try await client.getContainer(id: containerId) else {
                 throw Abort(.notFound, reason: "Container not found")
             }
@@ -174,8 +185,6 @@ struct ExecRoute: RouteCollection {
                 throw Abort(.conflict, reason: "Container is not running")
             }
 
-            let body = try req.content.decode(CreateExecRequest.self)
-
             // there is an error if we provides attachStderr with terminal true
             var attachStderr = body.AttachStderr ?? true
             if body.Tty ?? false {
@@ -184,7 +193,7 @@ struct ExecRoute: RouteCollection {
 
             let config = ExecManager.ExecConfig(
                 containerId: containerId,
-                cmd: body.Cmd,
+                cmd: cmd,
                 attachStdin: body.AttachStdin ?? false,
                 attachStdout: body.AttachStdout ?? true,
                 attachStderr: attachStderr,

--- a/Tests/socktainerTests/Routes/ExecCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ExecCreateRouteTests.swift
@@ -1,0 +1,100 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// POST /containers/{id}/exec must reject an empty Cmd at create time, as
+/// Docker does. Without the guard the empty command is stored and the later
+/// exec start force-unwraps `cmd.first!`, crashing the whole daemon.
+@Suite("ExecRoute — create Cmd validation")
+struct ExecCreateRouteTests {
+
+    @Test(
+        "Empty or missing Cmd returns 400 with Docker's message",
+        arguments: [#"{"Cmd":[]}"#, "{}"])
+    func emptyCmdReturns400(payload: String) async throws {
+        try await withRunningContainerApp { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/running-ctr/exec",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: payload)
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("No exec command specified"))
+            }
+        }
+    }
+
+    @Test("Non-empty Cmd still creates the exec instance")
+    func nonEmptyCmdCreates() async throws {
+        try await withRunningContainerApp { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/running-ctr/exec",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Cmd":["echo","hi"]}"#)
+            ) { res async throws in
+                #expect(res.status == .created)
+                let created = try JSONDecoder().decode(CreateExecResponse.self, from: Data(buffer: res.body))
+                #expect(!created.Id.isEmpty)
+                // The stored config carries the command through to exec start.
+                let stored = await ExecManager.shared.get(id: created.Id)
+                #expect(stored?.cmd == ["echo", "hi"])
+                await ExecManager.shared.remove(id: created.Id)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func withRunningContainerApp(
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+        try app.register(collection: ExecRoute(client: RunningContainerMock()))
+        try await test(app)
+    }
+}
+
+/// Mock whose getContainer always returns a running snapshot, so createExec
+/// reaches the request-body validation.
+private struct RunningContainerMock: ClientContainerProtocol {
+    private var snapshot: ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let config = ContainerConfiguration(id: "running-ctr", image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: .running, networks: [])
+    }
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## Summary

`POST /containers/{id}/exec` accepted `{"Cmd": []}` and returned 201 with an exec id. The empty command was stored as-is, and the subsequent `POST /exec/{id}/start` hit `config.cmd.first!` — a force-unwrap on an empty array — which traps and takes down the entire daemon. Every connected Docker client loses its socket until socktainer is restarted.

Docker validates this at create time and returns `400 Bad Request — "No exec command specified"`. This change adds the same guard in `createExec`, the single choke point through which every exec config is stored, so an empty `Cmd` can never reach the force-unwraps in exec start. Matching moby exactly: the check runs before the container is resolved (moby 400s an empty Cmd even for an unknown container), and a missing or null `Cmd` gets the same message instead of a generic decode error.

## Related Issue

None — found while auditing exec routes for Docker Engine API parity.

## Reproduction

Before (any raw API client can kill the daemon):

```console
$ EXEC_ID=$(curl -s --unix-socket ~/.socktainer/socktainer.sock \
    -X POST http://localhost/v1.51/containers/web/exec \
    -H 'Content-Type: application/json' -d '{"Cmd":[]}' | jq -r .Id)   # 201 — accepted
$ curl -s --unix-socket ~/.socktainer/socktainer.sock \
    -X POST http://localhost/v1.51/exec/$EXEC_ID/start \
    -H 'Content-Type: application/json' -d '{}'
curl: (52) Empty reply from server
$ docker ps
Cannot connect to the Docker daemon at unix://...   # daemon crashed
```

After:

```console
$ curl -s --unix-socket ~/.socktainer/socktainer.sock \
    -X POST http://localhost/v1.51/containers/web/exec \
    -H 'Content-Type: application/json' -d '{"Cmd":[]}'
{"error":true,"reason":"No exec command specified"}   # 400, daemon unaffected
```

## Changes

- `createExec` rejects an empty `Cmd` with `400 "No exec command specified"` before resolving the container, matching moby's validation order
- `CreateExecRequest.Cmd` is now optional so a missing/null `Cmd` yields the same Docker error message instead of a generic decoding error
- New unit tests in `Tests/socktainerTests/Routes/ExecCreateRouteTests.swift`: `{"Cmd":[]}` and `{}` → 400 with the moby message; a valid `Cmd` still returns 201 and stores the command intact. The empty-Cmd test fails against the previous implementation (201 with an exec id), confirming it reproduces the bug.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))