### PR TITLE
fix(containers): require force to remove a running container (409 Conflict)

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -10,12 +10,18 @@ struct ContainerDeleteRoute: RouteCollection {
 
 }
 
+struct ContainerDeleteQuery: Content {
+    var force: Bool?
+}
+
 extension ContainerDeleteRoute {
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> HTTPStatus {
         { req in
             guard let id = req.parameters.get("id") else {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
+
+            let force = try req.query.decode(ContainerDeleteQuery.self).force ?? false
 
             let snapshot = try? await client.getContainer(id: id)
             let cached = await ContainerInfoCache.shared.get(id: id)
@@ -42,6 +48,16 @@ extension ContainerDeleteRoute {
 
             do {
                 let container = try await client.getContainer(id: id)
+
+                // Docker Engine API: removing a running container requires force=true.
+                // Checked before any side effect (healthcheck stop, DNS cleanup) so a
+                // rejected delete leaves the container fully intact. A container still
+                // shutting down (.stopping) counts as running, as it does in moby.
+                if let container, container.status == .running || container.status == .stopping, !force {
+                    throw Abort(
+                        .conflict,
+                        reason: "cannot remove container \"\(id)\": container is running: stop the container before removing or force remove")
+                }
 
                 if let healthManager = req.application.storage[HealthCheckManagerKey.self] {
                     if container == nil {

--- a/Tests/socktainerTests/Routes/ContainerDeleteForceTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerDeleteForceTests.swift
@@ -1,0 +1,128 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// DELETE /containers/{id} must follow the Docker Engine API force contract:
+/// removing a running container without `force=true` is a 409 Conflict, and
+/// only `force=true` stops the container before deleting it.
+@Suite("ContainerDeleteRoute — force query parameter")
+struct ContainerDeleteForceTests {
+
+    @Test(
+        "Deleting a live container without force returns 409 and performs no action",
+        arguments: [RuntimeStatus.running, RuntimeStatus.stopping])
+    func liveWithoutForceConflicts(status: RuntimeStatus) async throws {
+        let log = CallLog()
+        let mock = RecordingDeleteMock(snapshot: Self.snapshot(id: "live-ctr", status: status), log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/live-ctr") { res async in
+                #expect(res.status == .conflict)
+                #expect(res.body.string.contains("stop the container before removing or force remove"))
+            }
+        }
+
+        let calls = await log.calls
+        #expect(!calls.contains("stop"), "A rejected delete must not stop the container")
+        #expect(!calls.contains("delete"), "A rejected delete must not remove the container")
+    }
+
+    @Test(
+        "Deleting a running container with force set stops then deletes it",
+        arguments: ["force=1", "force=true"])
+    func runningWithForceStopsAndDeletes(forceParam: String) async throws {
+        let log = CallLog()
+        let mock = RecordingDeleteMock(snapshot: Self.snapshot(id: "running-ctr", status: .running), log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/running-ctr?\(forceParam)") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["stop", "delete"], "force must stop the running container, then delete it")
+    }
+
+    @Test("Deleting a stopped container without force succeeds")
+    func stoppedWithoutForceDeletes() async throws {
+        let log = CallLog()
+        let mock = RecordingDeleteMock(snapshot: Self.snapshot(id: "stopped-ctr", status: .stopped), log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/stopped-ctr") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["delete"], "A stopped container is deleted directly, without a stop call")
+    }
+
+    private static func snapshot(id: String, status: RuntimeStatus) -> ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let config = ContainerConfiguration(id: id, image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: status, networks: [])
+    }
+}
+
+// MARK: - Mocks
+
+private actor CallLog {
+    var calls: [String] = []
+    func add(_ call: String) { calls.append(call) }
+}
+
+/// Mock that returns a fixed snapshot and records stop/delete calls in order.
+private struct RecordingDeleteMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    let log: CallLog
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws { await log.add("stop") }
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws { await log.add("delete") }
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## Summary

`DELETE /containers/{id}` ignored the `force` query parameter entirely: a plain `docker rm` of a running container silently stopped and removed it. The Docker Engine API only allows that with `force=true`; without it the daemon must refuse with 409 Conflict so users don't lose a running workload to a typo'd `docker rm`.

This change decodes `force` and returns 409 for a running container unless `force=true` is set. A container still shutting down (`.stopping`) counts as running, as it does in moby. The conflict is checked before any side effect (healthcheck loop stop, DNS alias cleanup), so a rejected delete leaves the container fully intact. `force=true` keeps today's stop-then-delete behavior, and deleting a stopped container is unchanged.

## Related Issue

None — found while auditing container routes for Docker Engine API parity.

## Reproduction

Before:

```console
$ docker run -d --name web nginx:alpine
$ docker rm web        # no -f — should be refused
web                    # …but the running container is stopped and deleted
```

After:

```console
$ docker rm web
Error response from daemon: cannot remove container "web": container is running: stop the container before removing or force remove
$ docker rm -f web
web
```

Matches Docker Engine behavior (`docker rm` → 409, `docker rm -f` → 204).

## Changes

- `ContainerDeleteQuery` decodes `force` (`force=1` / `force=true`, both docker CLI forms)
- Deleting a `.running` or `.stopping` container without `force` returns 409 with moby's exact message, checked before the healthcheck-stop and DNS-cleanup side effects so the rejected container is left fully intact
- New unit tests in `Tests/socktainerTests/Routes/ContainerDeleteForceTests.swift`: `.running`/`.stopping` without force → 409 and the recording mock proves no `stop`/`delete` call was made; `force=1`/`force=true` → 204 with `stop` then `delete`; stopped container → 204 with `delete` only. The 409 test fails against the previous implementation (returns 204 and records stop+delete), confirming it reproduces the bug.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))