### PR TITLE
fix(images): omit the Untagged record when deleting a dangling image

### DIFF
--- a/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
@@ -36,11 +36,21 @@ extension ImageDeleteRoute {
             // Both carry the image digest as Actor.ID with the reference in `name`
             // (matches moby's logImageEvent / LogImageEvent shape).
             //
-            // moby's imageDeleteHelper (daemon/containerd/image_delete.go) gates "untag" on
-            // `!isDanglingImage(img)` — dangling images have no real tag to untag, so only
-            // "delete" is emitted for them. Verified against moby v28.5.2 source.
+            // moby's imageDeleteHelper (daemon/containerd/image_delete.go) gates both
+            // the "untag" event and the response's {Untagged} record on
+            // `!isDanglingImage(img)` — dangling images have no real tag to untag, so
+            // only "delete" is emitted and returned for them. Verified against
+            // moby v28.5.2 source.
+            //
+            // In this stack a dangling image is stored as "untagged@<digest>" (the
+            // sentinel LocalOCILayoutClient assigns when a loaded tarball has no
+            // RepoTags — the analogue of moby's "moby-dangling@" name). "<none>" is
+            // kept for refs imported verbatim from foreign tarball annotations.
+            // A pull-by-digest ref (repo@sha256:…) is NOT dangling and keeps its
+            // Untagged record, as in moby.
+            let isDangling = result.untagged.hasPrefix("untagged@") || result.untagged.contains("<none>")
+
             if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
-                let isDangling = result.untagged.contains("<none>")
                 if !isDangling {
                     await broadcaster.broadcast(
                         DockerEvent.make(
@@ -56,9 +66,12 @@ extension ImageDeleteRoute {
             }
 
             // Build response matching Docker Engine API:
-            //   {Untagged} for the tag that was removed
+            //   {Untagged} for the tag that was removed (omitted for dangling images)
             //   {Deleted}  for the image layers freed (only when the last reference was removed)
-            var deleteResponse = [ImageDeleteResponseItem(Deleted: nil, Untagged: result.untagged)]
+            var deleteResponse: [ImageDeleteResponseItem] = []
+            if !isDangling {
+                deleteResponse.append(ImageDeleteResponseItem(Deleted: nil, Untagged: result.untagged))
+            }
             if let digest = result.deletedDigest {
                 deleteResponse.append(ImageDeleteResponseItem(Deleted: digest, Untagged: nil))
             }

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -14,8 +14,13 @@ struct ImageDeleteEventTests {
     // moby's imageDeleteHelper skips ActionUnTag when isDanglingImage(img) — dangling images
     // have no real tag to untag (Name == "<none>"). Verified against moby v28.5.2 source:
     // daemon/containerd/image_delete.go `if !isDanglingImage(img) { logImageEvent(...ActionUnTag) }`.
-    @Test("dangling image delete emits 'delete' only — no 'untag'")
-    func danglingImageDeleteEmitsDeleteOnly() async throws {
+    // Covers both dangling forms: the store's "untagged@<digest>" sentinel (what
+    // LocalOCILayoutClient assigns to a loaded tarball with no RepoTags) and a
+    // "<none>" ref imported verbatim from a foreign tarball annotation.
+    @Test(
+        "dangling image delete emits 'delete' only — no 'untag'",
+        arguments: ["untagged@sha256:abc123", "<none>@sha256:abc123"])
+    func danglingImageDeleteEmitsDeleteOnly(untaggedRef: String) async throws {
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
 
@@ -31,9 +36,9 @@ struct ImageDeleteEventTests {
             return collected
         }
 
-        // Mock returns a dangling reference ("<none>@sha256:...") with a deletedDigest —
-        // the delete event only fires when deletedDigest is non-nil, so this is required.
-        let danglingMock = DanglingImageDeleteMock()
+        // Mock returns a dangling reference with a deletedDigest — the delete
+        // event only fires when deletedDigest is non-nil, so this is required.
+        let danglingMock = DanglingImageDeleteMock(untagged: untaggedRef)
         try await withApp(configure: { _ in }) { app in
             let regexRouter = app.regexRouter(with: app.logger)
             app.setRegexRouter(regexRouter)
@@ -120,11 +125,13 @@ private func withImageRouteApp(
 }
 
 private struct DanglingImageDeleteMock: ClientImageProtocol {
+    // The dangling reference form to return: the store's "untagged@<digest>"
+    // sentinel or a verbatim "<none>" annotation. The route must skip "untag"
+    // and only emit "delete" for either.
+    let untagged: String
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
     func delete(id: String) async throws -> ImageDeletionResult {
-        // A dangling image has Name == "<none>" in Apple Container (mirrors moby).
-        // The route must skip "untag" and only emit "delete" for this case.
-        ImageDeletionResult(untagged: "<none>@sha256:abc123", digest: "sha256:abc123", deletedDigest: "sha256:abc123")
+        ImageDeletionResult(untagged: untagged, digest: "sha256:abc123", deletedDigest: "sha256:abc123")
     }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
         -> AsyncThrowingStream<String, Error>

--- a/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
+++ b/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
@@ -1,0 +1,118 @@
+import ContainerAPIClient
+import Containerization
+import ContainerizationOCI
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// DELETE /images/{name} for a dangling image must return only a {Deleted}
+/// record. moby gates the {Untagged} entry on !isDanglingImage — a dangling
+/// image has no real tag, so echoing `Untagged: "<none>…"` puts a garbage
+/// line in `docker rmi` output. The route already suppresses the "untag"
+/// event for dangling images; the response must match.
+@Suite("ImageDeleteRoute — dangling image response shape")
+struct ImageDeleteDanglingResponseTests {
+
+    @Test(
+        "Deleting a dangling image returns only the Deleted record",
+        arguments: [
+            // The sentinel LocalOCILayoutClient assigns to a loaded tarball with no RepoTags.
+            "untagged@sha256:aaa111",
+            // A ref imported verbatim from a foreign tarball's name annotation.
+            "<none>:<none>",
+        ])
+    func danglingDeleteOmitsUntagged(untaggedRef: String) async throws {
+        let result = ImageDeletionResult(
+            untagged: untaggedRef,
+            digest: "sha256:aaa111",
+            deletedDigest: "sha256:aaa111"
+        )
+
+        let items = try await Self.deleteImage(result: result, ref: "sha256:aaa111")
+        #expect(items.map(\.Deleted) == ["sha256:aaa111"])
+        #expect(items.compactMap(\.Untagged).isEmpty, "A dangling image has no tag to untag")
+    }
+
+    @Test("Deleting a pull-by-digest image keeps its Untagged record (not dangling)")
+    func digestRefKeepsUntagged() async throws {
+        let result = ImageDeletionResult(
+            untagged: "docker.io/library/alpine@sha256:ddd444",
+            digest: "sha256:ddd444",
+            deletedDigest: "sha256:ddd444"
+        )
+
+        let items = try await Self.deleteImage(result: result, ref: "alpine@sha256:ddd444")
+        #expect(items.compactMap(\.Untagged) == ["docker.io/library/alpine@sha256:ddd444"])
+    }
+
+    @Test("Deleting a tagged image still returns Untagged (and Deleted when layers are freed)")
+    func taggedDeleteKeepsUntagged() async throws {
+        let result = ImageDeletionResult(
+            untagged: "docker.io/library/alpine:latest",
+            digest: "sha256:bbb222",
+            deletedDigest: "sha256:bbb222"
+        )
+
+        let items = try await Self.deleteImage(result: result, ref: "alpine:latest")
+        #expect(items.compactMap(\.Untagged) == ["docker.io/library/alpine:latest"])
+        #expect(items.compactMap(\.Deleted) == ["sha256:bbb222"])
+    }
+
+    @Test("Untag-only delete (other tags remain) returns just the Untagged record")
+    func untagOnlyDelete() async throws {
+        let result = ImageDeletionResult(
+            untagged: "docker.io/library/alpine:extra",
+            digest: "sha256:ccc333",
+            deletedDigest: nil
+        )
+
+        let items = try await Self.deleteImage(result: result, ref: "alpine:extra")
+        #expect(items.compactMap(\.Untagged) == ["docker.io/library/alpine:extra"])
+        #expect(items.compactMap(\.Deleted).isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private static func deleteImage(result: ImageDeletionResult, ref: String) async throws -> [ImageDeleteResponseItem] {
+        var items: [ImageDeleteResponseItem] = []
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ImageDeleteRoute(client: FixedResultImageMock(result: result)))
+
+            try await app.testing().test(.DELETE, "/v1.51/images/\(ref)") { res async throws in
+                #expect(res.status == .ok)
+                items = try JSONDecoder().decode([ImageDeleteResponseItem].self, from: Data(buffer: res.body))
+            }
+        }
+        return items
+    }
+}
+
+// MARK: - Mocks
+
+/// Mock whose delete always returns a fixed ImageDeletionResult.
+private struct FixedResultImageMock: ClientImageProtocol {
+    let result: ImageDeletionResult
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws -> ImageDeletionResult { result }
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        URL(fileURLWithPath: "/dev/null")
+    }
+}


### PR DESCRIPTION
## Summary

`DELETE /images/{name}` unconditionally put an `{Untagged: …}` record in the response, even for dangling images. The docker CLI prints every record, so `docker rmi <dangling-id>` showed a garbage `Untagged: untagged@sha256:…` line — reporting an untag that never happened, with an internal store sentinel leaking as if it were a user-visible tag.

moby's `imageDeleteHelper` gates the untag record on `!isDanglingImage(img)` — deleting a dangling image returns only `{Deleted: sha256:…}`. The route already tried to apply this gate to the untag event, but the predicate only checked for `<none>`, which the live store never produces: in this stack a dangling image (e.g. `docker load` of a tarball saved from an untagged image) is stored under the `untagged@<digest>` sentinel that `LocalOCILayoutClient` assigns — the analogue of moby's `moby-dangling@` name. So the existing gate never fired in production.

This change keys the dangling check on that real sentinel (keeping `<none>` for refs imported verbatim from foreign tarball annotations) and applies it to both the untag event and the response body. A pull-by-digest ref (`repo@sha256:…`) is not dangling and keeps its `Untagged` record, as in moby. Tagged deletes are unchanged.

## Related Issue

None — found while auditing image routes for Docker Engine API parity.

## Reproduction

Before:

```console
$ docker save <untagged-image-id> -o img.tar && docker load -i img.tar
$ docker rmi untagged@sha256:8ae123…
Untagged: untagged@sha256:8ae123…   # ← garbage line, moby prints no Untagged here
Deleted: sha256:8ae123…
```

After:

```console
$ docker rmi untagged@sha256:8ae123…
Deleted: sha256:8ae123…
```

Matches Docker Engine output for dangling images.

## Changes

- The dangling predicate now matches the store's real sentinel (`untagged@<digest>`) in addition to `<none>`, and is hoisted so it gates both the `untag` event and the response's `{Untagged}` record
- Pull-by-digest refs (`repo@sha256:…`) are explicitly not treated as dangling and keep their `Untagged` record
- New unit tests in `Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift`: dangling deletes (both sentinel forms) return only `{Deleted}`; tagged, untag-only, and pull-by-digest deletes are unchanged. The dangling tests fail against the previous implementation, confirming they reproduce the bug.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))