### PR TITLE
fix(containers): full DNS-alias and auto-remove cleanup on --rm exit

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -51,7 +51,7 @@ actor ContainerExitCodeStore {
     /// `ClientProcess.wait()` is an XPC round-trip to the Apple Container daemon; under
     /// concurrent load (many containers exiting at once) that round-trip can throw a transient
     /// connection error. The previous recorder collapsed any such throw into `?? 0`, recording
-    /// a fake exit code of 0 that then surfaced in the container `die` event (issue #90 / EVT-008:
+    /// a fake exit code of 0 that then surfaced in the container `die` event (issue #90:
     /// expected 7, observed 0). Retrying the wait yields the authoritative code; a process that
     /// has already exited answers the re-issued wait immediately. After `maxAttempts` failures we
     /// record `waitFailureSentinel` so observers can tell a failed wait from a real exit-0.

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -36,6 +36,19 @@ final class SocktainerDNSServer: @unchecked Sendable {
         }
     }
 
+    /// Unregisters `hostname` only if it's currently registered to `expectedIP` — atomically,
+    /// so a concurrent re-registration between a caller's ownership check and its unregister
+    /// call can't be dropped. A hostname registered to a different IP, or not registered at
+    /// all, is left untouched.
+    func unregisterIfOwned(hostname: String, expectedIP: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        let key = Self.normalize(hostname)
+        guard let addr = entries[key], "\(addr[0]).\(addr[1]).\(addr[2]).\(addr[3])" == expectedIP else { return }
+        entries.removeValue(forKey: key)
+        log.info("[dns] unregistered \(key)")
+    }
+
     func listEntries() -> [String: String] {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -44,7 +44,7 @@ final class SocktainerDNSServer: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         let key = Self.normalize(hostname)
-        guard let addr = entries[key], "\(addr[0]).\(addr[1]).\(addr[2]).\(addr[3])" == expectedIP else { return }
+        guard let addr = entries[key], let expected = Self.parseIPv4(expectedIP), addr == expected else { return }
         entries.removeValue(forKey: key)
         log.info("[dns] unregistered \(key)")
     }

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -24,10 +24,6 @@ struct ContainerAttachRoute: RouteCollection {
 }
 
 extension ContainerAttachRoute {
-    /// Grace period between closing pipe write ends and unblocking /wait.
-    /// Lets pipe readers flush buffered output before Docker CLI closes the connection.
-    static let outputFlushGraceNs: UInt64 = 200_000_000  // 200ms
-
     /// Builds the container event emitted when `docker run --rm` triggers Apple Container's
     /// auto-removal: no DELETE arrives, so ContainerDeleteRoute never fires and this path
     /// substitutes for it. The action MUST be "destroy" — the same action ContainerDeleteRoute
@@ -130,6 +126,7 @@ extension ContainerAttachRoute {
             return try await handleAttachWithStdin(
                 req: req,
                 client: client,
+                hexId: id,
                 container: container,
                 query: query,
                 isUpgrade: isUpgrade,
@@ -366,6 +363,7 @@ extension ContainerAttachRoute {
     private static func handleAttachWithStdin(
         req: Request,
         client: ClientContainerProtocol,
+        hexId: String,
         container: ContainerSnapshot,
         query: ContainerAttachQuery,
         isUpgrade: Bool,
@@ -390,6 +388,7 @@ extension ContainerAttachRoute {
         return try await createContainerForAttachment(
             req: req,
             client: client,
+            hexId: hexId,
             container: currentContainer,
             query: query,
             shouldUpgrade: shouldUpgrade,
@@ -401,6 +400,7 @@ extension ContainerAttachRoute {
     private static func createContainerForAttachment(
         req: Request,
         client: ClientContainerProtocol,
+        hexId: String,
         container: ContainerSnapshot,
         query: ContainerAttachQuery,
         shouldUpgrade: Bool,
@@ -469,16 +469,15 @@ extension ContainerAttachRoute {
                             streamContinuation.finish()
                         }
 
-                        do {
-                            // Record the real exit code so /containers/{id}/wait can return it.
-                            let code = try await process.wait()
-                            await ContainerExitCodeStore.shared.set(id: container.id, code: code)
-                        } catch {
-                            // process.wait() failed — record a synthetic exit code so
-                            // /containers/{id}/wait can't block forever.
-                            await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
-                        }
-                        await ProcessRegistry.shared.remove(id: container.id)
+                        _ = await ContainerProcessExitMonitor.run(
+                            wait: { try await process.wait() },
+                            hexId: hexId,
+                            nativeId: container.id,
+                            fallbackImage: container.configuration.image.reference,
+                            fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                            dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                            broadcaster: req.application.storage[EventBroadcasterKey.self]
+                        )
                     }
 
                     if let stdoutHandle = pipes.stdout?.read {
@@ -713,19 +712,15 @@ extension ContainerAttachRoute {
                 }
 
                 group.addTask {
-                    do {
-                        // Record the real exit code so /containers/{id}/wait can return it.
-                        let code = try await process.wait()
-                        await ContainerExitCodeStore.shared.set(id: container.id, code: code)
-                    } catch {
-                        // process.wait() failed — record a synthetic exit code so
-                        // /containers/{id}/wait can't block forever.
-                        await ContainerExitCodeStore.shared.set(id: container.id, code: -1)
-                    }
-                    await ProcessRegistry.shared.remove(id: container.id)
-
-                    // Give a small delay for any final output to be processed
-                    try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms
+                    _ = await ContainerProcessExitMonitor.run(
+                        wait: { try await process.wait() },
+                        hexId: hexId,
+                        nativeId: container.id,
+                        fallbackImage: container.configuration.image.reference,
+                        fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                        dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                        broadcaster: req.application.storage[EventBroadcasterKey.self]
+                    )
 
                     // DockerTCPHandler owns pipes.stdin!.write after setStdinWriter(); it closes
                     // it via writeQueue on channelInactive / inputClosed. Closing it here too

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -332,29 +332,14 @@ extension ContainerAttachRoute {
                         // gates on the --rm flag (set at create) and dedups against the detached
                         // die observer, so exactly one "destroy" fires — same action moby uses.
                         if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
-                            // Clean up DNS entry registered at start — ContainerDeleteRoute
-                            // is never called for --rm containers (Apple Container reaps them).
-                            // Use the stored IP for the same ownership check ContainerDeleteRoute
-                            // uses: only unregister if this container still owns the entry.
-                            if let dnsServer = req.application.storage[SocktainerDNSServerKey.self] {
-                                let cachedIP = await ContainerInfoCache.shared.get(id: hexId)?.ip
-                                let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(container.id)]
-                                if cachedIP == nil || registered == nil || registered == cachedIP {
-                                    dnsServer.unregister(hostname: container.id)
-                                }
-                            }
-                            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
-                                let cached = await ContainerInfoCache.shared.get(id: hexId)
-                                await broadcaster.broadcast(
-                                    Self.makeAutoRemoveEvent(
-                                        id: hexId,
-                                        image: cached?.image ?? container.configuration.image.reference,
-                                        name: cached?.nativeId ?? container.id,
-                                        labels: cached?.labels
-                                            ?? LabelNormalization.restore(container.configuration.labels)
-                                    ))
-                                await ContainerInfoCache.shared.remove(id: hexId)
-                            }
+                            await ContainerAutoRemoveCleanup.perform(
+                                hexId: hexId,
+                                nativeId: container.id,
+                                fallbackImage: container.configuration.image.reference,
+                                fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                                dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                                broadcaster: req.application.storage[EventBroadcasterKey.self]
+                            )
                         }
                     }
 

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -319,28 +319,15 @@ extension ContainerAttachRoute {
                 await withTaskGroup(of: Void.self) { group in
                     // Process monitor — stdout/stderr write ends and stdin read are Apple-owned.
                     group.addTask {
-                        // Retry the wait XPC round-trip rather than collapsing a transient
-                        // throw into a fake exit code of 0 (see ContainerExitCodeStore.resolveExitCode).
-                        let code = await ContainerExitCodeStore.resolveExitCode { try await process.wait() }
-                        await ProcessRegistry.shared.remove(id: container.id)
-                        try? await Task.sleep(nanoseconds: Self.outputFlushGraceNs)
-                        await ContainerExitCodeStore.shared.set(id: container.id, code: code)
-                        await ContainerExitCodeStore.shared.set(id: hexId, code: code)
-
-                        // docker run --rm: Apple Container auto-removes the container so DELETE
-                        // never arrives and ContainerDeleteRoute never fires. consumeAutoRemove
-                        // gates on the --rm flag (set at create) and dedups against the detached
-                        // die observer, so exactly one "destroy" fires — same action moby uses.
-                        if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
-                            await ContainerAutoRemoveCleanup.perform(
-                                hexId: hexId,
-                                nativeId: container.id,
-                                fallbackImage: container.configuration.image.reference,
-                                fallbackLabels: LabelNormalization.restore(container.configuration.labels),
-                                dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                                broadcaster: req.application.storage[EventBroadcasterKey.self]
-                            )
-                        }
+                        _ = await ContainerProcessExitMonitor.run(
+                            wait: { try await process.wait() },
+                            hexId: hexId,
+                            nativeId: container.id,
+                            fallbackImage: container.configuration.image.reference,
+                            fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                            dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                            broadcaster: req.application.storage[EventBroadcasterKey.self]
+                        )
                     }
 
                     // Stdout reader

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -129,9 +129,9 @@ extension ContainerAttachWSRoute {
             // Process monitor — sole owner of teardown (no double-close with ws.onClose
             // because ws.onClose only closes the stdin write end, not the read ends).
             group.addTask {
-                // Fix: record -1 on wait failure so /wait doesn't lie to callers.
-                let code: Int32
-                do { code = try await process.wait() } catch { code = -1 }
+                // Retry the wait XPC round-trip rather than collapsing a transient
+                // throw into a fake exit code (see ContainerExitCodeStore.resolveExitCode).
+                let code = await ContainerExitCodeStore.resolveExitCode { try await process.wait() }
 
                 await ProcessRegistry.shared.remove(id: container.id)
 
@@ -150,26 +150,14 @@ extension ContainerAttachWSRoute {
                 // docker run --rm over WS: emit the single post-exit "destroy" (consumeAutoRemove
                 // gates on the --rm flag and dedups against the detached die observer).
                 if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
-                    // Clean up DNS entry with ownership check (same pattern as ContainerDeleteRoute).
-                    if let dnsServer = req.application.storage[SocktainerDNSServerKey.self] {
-                        let cachedIP = await ContainerInfoCache.shared.get(id: hexId)?.ip
-                        let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(container.id)]
-                        if cachedIP == nil || registered == nil || registered == cachedIP {
-                            dnsServer.unregister(hostname: container.id)
-                        }
-                    }
-                    let cached = await ContainerInfoCache.shared.get(id: hexId)
-                    if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
-                        await broadcaster.broadcast(
-                            ContainerAttachRoute.makeAutoRemoveEvent(
-                                id: hexId,
-                                image: cached?.image ?? container.configuration.image.reference,
-                                name: cached?.nativeId ?? container.id,
-                                labels: cached?.labels
-                                    ?? LabelNormalization.restore(container.configuration.labels)
-                            ))
-                    }
-                    await ContainerInfoCache.shared.remove(id: hexId)
+                    await ContainerAutoRemoveCleanup.perform(
+                        hexId: hexId,
+                        nativeId: container.id,
+                        fallbackImage: container.configuration.image.reference,
+                        fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                        dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                        broadcaster: req.application.storage[EventBroadcasterKey.self]
+                    )
                 }
 
                 try? await ws.close()

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -129,36 +129,15 @@ extension ContainerAttachWSRoute {
             // Process monitor — sole owner of teardown (no double-close with ws.onClose
             // because ws.onClose only closes the stdin write end, not the read ends).
             group.addTask {
-                // Retry the wait XPC round-trip rather than collapsing a transient
-                // throw into a fake exit code (see ContainerExitCodeStore.resolveExitCode).
-                let code = await ContainerExitCodeStore.resolveExitCode { try await process.wait() }
-
-                await ProcessRegistry.shared.remove(id: container.id)
-
-                // stdout/stderr write ends and stdin read end are Apple-owned —
-                // do not close them here (double-close causes fd-reuse crashes).
-                // ws.onClose owns the stdin write end; readers own their read ends.
-
-                try? await Task.sleep(nanoseconds: ContainerAttachRoute.outputFlushGraceNs)
-
-                // Record the exit code FIRST: this unblocks the /start die observer's
-                // waitForCode so its `die` event is emitted before the `destroy` below,
-                // preserving moby's die→destroy order for foreground `docker run --rm` over WS.
-                await ContainerExitCodeStore.shared.set(id: container.id, code: code)
-                await ContainerExitCodeStore.shared.set(id: hexId, code: code)
-
-                // docker run --rm over WS: emit the single post-exit "destroy" (consumeAutoRemove
-                // gates on the --rm flag and dedups against the detached die observer).
-                if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
-                    await ContainerAutoRemoveCleanup.perform(
-                        hexId: hexId,
-                        nativeId: container.id,
-                        fallbackImage: container.configuration.image.reference,
-                        fallbackLabels: LabelNormalization.restore(container.configuration.labels),
-                        dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                        broadcaster: req.application.storage[EventBroadcasterKey.self]
-                    )
-                }
+                _ = await ContainerProcessExitMonitor.run(
+                    wait: { try await process.wait() },
+                    hexId: hexId,
+                    nativeId: container.id,
+                    fallbackImage: container.configuration.image.reference,
+                    fallbackLabels: LabelNormalization.restore(container.configuration.labels),
+                    dnsServer: req.application.storage[SocktainerDNSServerKey.self],
+                    broadcaster: req.application.storage[EventBroadcasterKey.self]
+                )
 
                 try? await ws.close()
             }

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -71,37 +71,16 @@ extension ContainerDeleteRoute {
                 if let container,
                     let dnsServer = req.application.storage[SocktainerDNSServerKey.self]
                 {
+                    // Prefer the cached IP — reliable even once the container has genuinely
+                    // stopped and Apple Container reports an empty live network list — falling
+                    // back to the live snapshot for a container never observed via /start.
                     let containerIP = container.networks.first?.ipv4Address.address.description
-
-                    // Only unregister an alias when this container still owns it — i.e. the
-                    // registered IP matches ours. If another container has since claimed the
-                    // same hostname (e.g. a second project with an identically-named service),
-                    // leave the entry intact so that surviving container keeps resolving.
-                    func unregisterIfOwned(_ hostname: String) {
-                        let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(hostname)]
-                        if let containerIP, registered != nil, registered != containerIP { return }
-                        dnsServer.unregister(hostname: hostname)
-                    }
-
-                    // Mirror of the container-name registration in the start route.
-                    if !container.id.isEmpty {
-                        unregisterIfOwned(container.id)
-                    }
-                    if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
-                        for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                            unregisterIfOwned(name)
-                        }
-                    }
-                    if let serviceName = container.configuration.labels["com.docker.compose.service"],
-                        !serviceName.isEmpty
-                    {
-                        unregisterIfOwned(serviceName)
-                        if let projectName = container.configuration.labels["com.docker.compose.project"],
-                            !projectName.isEmpty
-                        {
-                            unregisterIfOwned("\(serviceName).\(projectName)")
-                        }
-                    }
+                    ContainerAliasCleanup.unregisterAllAliases(
+                        nativeId: container.id,
+                        labels: cached?.labels ?? LabelNormalization.restore(container.configuration.labels),
+                        cachedIP: cached?.ip ?? containerIP,
+                        dnsServer: dnsServer
+                    )
                 }
 
                 if let container, container.status == .running {

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -185,18 +185,14 @@ extension ContainerStartRoute {
             // gates on the --rm flag and dedups against the foreground attach path, so a
             // container attached in the foreground does not get a second destroy.
             if await ContainerInfoCache.shared.consumeAutoRemove(id: nativeId) {
-                // Clean up DNS entry with ownership check (same pattern as ContainerDeleteRoute).
-                if let dnsServer {
-                    let cachedIP = await ContainerInfoCache.shared.get(id: nativeId)?.ip
-                    let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(nativeId)]
-                    if cachedIP == nil || registered == nil || registered == cachedIP {
-                        dnsServer.unregister(hostname: nativeId)
-                    }
-                }
-                await broadcaster.broadcast(
-                    ContainerAttachRoute.makeAutoRemoveEvent(
-                        id: eventId, image: image, name: name, labels: labels))
-                await ContainerInfoCache.shared.remove(id: nativeId)
+                await ContainerAutoRemoveCleanup.perform(
+                    hexId: eventId,
+                    nativeId: nativeId,
+                    fallbackImage: image,
+                    fallbackLabels: labels,
+                    dnsServer: dnsServer,
+                    broadcaster: broadcaster
+                )
                 await ContainerRestartState.shared.reset(id: nativeId)
                 return
             }

--- a/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Unregisters a container's DNS aliases (name, `socktainer.dns.names`, Compose
+/// service/project) — used by the `--rm` auto-remove paths, which never receive a
+/// DELETE for `ContainerDeleteRoute` to react to.
+///
+/// `cachedIP` nil means ownership can't be confirmed, so nothing is touched: unregistering
+/// blind risks yanking a live peer's identically-named alias, worse than a stale leftover.
+enum ContainerAliasCleanup {
+    static func unregisterAllAliases(
+        nativeId: String,
+        labels: [String: String],
+        cachedIP: String?,
+        dnsServer: SocktainerDNSServer
+    ) {
+        guard let cachedIP else { return }
+
+        func unregisterIfOwned(_ hostname: String) {
+            let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(hostname)]
+            if registered != nil, registered != cachedIP { return }
+            dnsServer.unregister(hostname: hostname)
+        }
+
+        if !nativeId.isEmpty {
+            unregisterIfOwned(nativeId)
+        }
+        if let namesLabel = labels["socktainer.dns.names"] {
+            for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                unregisterIfOwned(name)
+            }
+        }
+        if let serviceName = labels["com.docker.compose.service"], !serviceName.isEmpty {
+            unregisterIfOwned(serviceName)
+            if let projectName = labels["com.docker.compose.project"], !projectName.isEmpty {
+                unregisterIfOwned("\(serviceName).\(projectName)")
+            }
+        }
+    }
+}

--- a/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
@@ -14,9 +14,10 @@ enum ContainerAliasCleanup {
         dnsServer: SocktainerDNSServer
     ) {
         guard let cachedIP else { return }
+        let entries = dnsServer.listEntries()
 
         func unregisterIfOwned(_ hostname: String) {
-            let registered = dnsServer.listEntries()[SocktainerDNSServer.normalize(hostname)]
+            let registered = entries[SocktainerDNSServer.normalize(hostname)]
             if registered != nil, registered != cachedIP { return }
             dnsServer.unregister(hostname: hostname)
         }

--- a/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAliasCleanup.swift
@@ -14,26 +14,19 @@ enum ContainerAliasCleanup {
         dnsServer: SocktainerDNSServer
     ) {
         guard let cachedIP else { return }
-        let entries = dnsServer.listEntries()
-
-        func unregisterIfOwned(_ hostname: String) {
-            let registered = entries[SocktainerDNSServer.normalize(hostname)]
-            if registered != nil, registered != cachedIP { return }
-            dnsServer.unregister(hostname: hostname)
-        }
 
         if !nativeId.isEmpty {
-            unregisterIfOwned(nativeId)
+            dnsServer.unregisterIfOwned(hostname: nativeId, expectedIP: cachedIP)
         }
         if let namesLabel = labels["socktainer.dns.names"] {
             for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                unregisterIfOwned(name)
+                dnsServer.unregisterIfOwned(hostname: name, expectedIP: cachedIP)
             }
         }
         if let serviceName = labels["com.docker.compose.service"], !serviceName.isEmpty {
-            unregisterIfOwned(serviceName)
+            dnsServer.unregisterIfOwned(hostname: serviceName, expectedIP: cachedIP)
             if let projectName = labels["com.docker.compose.project"], !projectName.isEmpty {
-                unregisterIfOwned("\(serviceName).\(projectName)")
+                dnsServer.unregisterIfOwned(hostname: "\(serviceName).\(projectName)", expectedIP: cachedIP)
             }
         }
     }

--- a/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Performs the full `--rm` cleanup once `ContainerInfoCache.consumeAutoRemove` grants it:
+/// DNS alias unregistration, the `destroy` event, and clearing the cache entry. Shared by the
+/// three paths that observe a `--rm` container's exit directly — start, attach, attach-WS —
+/// since Apple Container reaps `--rm` containers itself and no DELETE ever reaches
+/// `ContainerDeleteRoute`.
+enum ContainerAutoRemoveCleanup {
+    static func perform(
+        hexId: String,
+        nativeId: String,
+        fallbackImage: String,
+        fallbackLabels: [String: String],
+        dnsServer: SocktainerDNSServer?,
+        broadcaster: EventBroadcaster?
+    ) async {
+        let cached = await ContainerInfoCache.shared.get(id: hexId)
+        let labels = cached?.labels ?? fallbackLabels
+
+        if let dnsServer {
+            ContainerAliasCleanup.unregisterAllAliases(
+                nativeId: nativeId,
+                labels: labels,
+                cachedIP: cached?.ip,
+                dnsServer: dnsServer
+            )
+        }
+        if let broadcaster {
+            await broadcaster.broadcast(
+                ContainerAttachRoute.makeAutoRemoveEvent(
+                    id: hexId,
+                    image: cached?.image ?? fallbackImage,
+                    name: cached?.nativeId ?? nativeId,
+                    labels: labels
+                ))
+        }
+        await ContainerInfoCache.shared.remove(id: hexId)
+    }
+}

--- a/Sources/socktainer/Utilities/ContainerInfoCache.swift
+++ b/Sources/socktainer/Utilities/ContainerInfoCache.swift
@@ -36,6 +36,12 @@ actor ContainerInfoCache {
             store.removeValue(forKey: info.hexId)
             store.removeValue(forKey: info.nativeId)
         }
+        // Clear any lingering --rm mark so a stale observer that reaches consumeAutoRemove
+        // after this container was already deleted can't fire a second destroy event.
+        if let sibling = autoRemoveSibling[id] {
+            autoRemoveSibling.removeValue(forKey: id)
+            autoRemoveSibling.removeValue(forKey: sibling)
+        }
     }
 
     /// Records that a container was created with `--rm`, keyed by both ids so either the

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Watches a stopped-then-attached container's process to completion: resolves its exit
+/// code (retrying past transient XPC throws), removes it from `ProcessRegistry`, waits out
+/// the output-flush grace period, records the exit code under both ids, and performs
+/// `--rm` auto-remove cleanup if it was marked for it. Shared by the HTTP and WS attach
+/// routes' process-monitor tasks, which otherwise duplicated this identical sequence.
+///
+/// `wait` is injectable so the whole sequence — including the transient-throw retry and
+/// dual-id recording — is testable without a live Apple Container process.
+enum ContainerProcessExitMonitor {
+    static func run(
+        wait: () async throws -> Int32,
+        hexId: String,
+        nativeId: String,
+        fallbackImage: String,
+        fallbackLabels: [String: String],
+        dnsServer: SocktainerDNSServer?,
+        broadcaster: EventBroadcaster?,
+        outputFlushGraceNs: UInt64 = ContainerAttachRoute.outputFlushGraceNs,
+        exitCodeRetryDelayNs: UInt64 = 100_000_000
+    ) async -> Int32 {
+        let code = await ContainerExitCodeStore.resolveExitCode(retryDelayNs: exitCodeRetryDelayNs, wait: wait)
+        await ProcessRegistry.shared.remove(id: nativeId)
+
+        // Sleep before recording the code: lets this attachment's own output flush before
+        // any die observer wakes and races ahead.
+        try? await Task.sleep(nanoseconds: outputFlushGraceNs)
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: code)
+        await ContainerExitCodeStore.shared.set(id: hexId, code: code)
+
+        // --rm: Apple Container reaps the container itself, so DELETE never arrives to
+        // fire ContainerDeleteRoute's cleanup. consumeAutoRemove both gates on --rm and
+        // dedups against a second observer racing the same exit.
+        if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
+            await ContainerAutoRemoveCleanup.perform(
+                hexId: hexId,
+                nativeId: nativeId,
+                fallbackImage: fallbackImage,
+                fallbackLabels: fallbackLabels,
+                dnsServer: dnsServer,
+                broadcaster: broadcaster
+            )
+        }
+        return code
+    }
+}

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -9,6 +9,10 @@ import Foundation
 /// `wait` is injectable so the whole sequence — including the transient-throw retry and
 /// dual-id recording — is testable without a live Apple Container process.
 enum ContainerProcessExitMonitor {
+    /// Grace period between the process exiting and recording its exit code.
+    /// Lets pipe readers flush buffered output before other observers wake on the exit code.
+    static let outputFlushGraceNs: UInt64 = 200_000_000  // 200ms
+
     static func run(
         wait: () async throws -> Int32,
         hexId: String,
@@ -17,7 +21,7 @@ enum ContainerProcessExitMonitor {
         fallbackLabels: [String: String],
         dnsServer: SocktainerDNSServer?,
         broadcaster: EventBroadcaster?,
-        outputFlushGraceNs: UInt64 = ContainerAttachRoute.outputFlushGraceNs,
+        outputFlushGraceNs: UInt64 = ContainerProcessExitMonitor.outputFlushGraceNs,
         exitCodeRetryDelayNs: UInt64 = 100_000_000
     ) async -> Int32 {
         let code = await ContainerExitCodeStore.resolveExitCode(retryDelayNs: exitCodeRetryDelayNs, wait: wait)

--- a/Tests/socktainerTests/ContainerSnapshotFixture.swift
+++ b/Tests/socktainerTests/ContainerSnapshotFixture.swift
@@ -1,0 +1,44 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+
+/// Builds a minimal `ContainerSnapshot` for lifecycle/DNS tests, with one network attachment
+/// on `network` at `ip`. Callers supply the labels that make their scenario distinct
+/// (restart policy, Compose service, etc.) — everything else is fixed test scaffolding.
+func makeContainerSnapshot(
+    nativeId: String,
+    ip: String,
+    network: String,
+    labels: [String: String],
+    status: RuntimeStatus = .stopped
+) throws -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: "sha256:abc", size: 0
+        )
+    )
+    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+    config.labels = labels
+
+    // Attachment is Codable — use JSON to avoid depending on internal CIDRv4/IPv4Address inits.
+    let attachmentJSON = """
+        {
+            "network": "\(network)",
+            "hostname": "\(nativeId)",
+            "ipv4Address": "\(ip)/24",
+            "ipv4Gateway": "192.168.65.1",
+            "ipv6Address": null,
+            "macAddress": null
+        }
+        """.data(using: .utf8)!
+    let attachment = try JSONDecoder().decode(Attachment.self, from: attachmentJSON)
+
+    return ContainerSnapshot(configuration: config, status: status, networks: [attachment])
+}

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -52,6 +52,14 @@ struct SocktainerDNSServerTests {
         #expect(server.listEntries()["redis"] == "192.168.1.99")
     }
 
+    @Test("unregisterIfOwned strips a CIDR suffix from expectedIP, matching register's parsing")
+    func unregisterIfOwnedStripsCIDRSuffix() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "db", ip: "192.168.1.5")
+        server.unregisterIfOwned(hostname: "db", expectedIP: "192.168.1.5/24")
+        #expect(server.listEntries()["db"] == nil)
+    }
+
     @Test("unregisterIfOwned on an unregistered hostname is a no-op")
     func unregisterIfOwnedUnknownIsNoOp() {
         let server = SocktainerDNSServer()

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -36,6 +36,29 @@ struct SocktainerDNSServerTests {
         #expect(server.listEntries().isEmpty)
     }
 
+    @Test("unregisterIfOwned removes a hostname registered to the expected IP")
+    func unregisterIfOwnedRemovesMatch() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "redis", ip: "192.168.1.20")
+        server.unregisterIfOwned(hostname: "redis", expectedIP: "192.168.1.20")
+        #expect(server.listEntries()["redis"] == nil)
+    }
+
+    @Test("unregisterIfOwned leaves a hostname registered to a different IP untouched")
+    func unregisterIfOwnedSkipsMismatch() {
+        let server = SocktainerDNSServer()
+        server.register(hostname: "redis", ip: "192.168.1.99")
+        server.unregisterIfOwned(hostname: "redis", expectedIP: "192.168.1.20")
+        #expect(server.listEntries()["redis"] == "192.168.1.99")
+    }
+
+    @Test("unregisterIfOwned on an unregistered hostname is a no-op")
+    func unregisterIfOwnedUnknownIsNoOp() {
+        let server = SocktainerDNSServer()
+        server.unregisterIfOwned(hostname: "nonexistent", expectedIP: "192.168.1.20")  // must not crash
+        #expect(server.listEntries().isEmpty)
+    }
+
     // MARK: - Normalization
 
     @Test("Hostname lookup is case-insensitive")

--- a/Tests/socktainerTests/Events/ContainerExitCodeStoreTests.swift
+++ b/Tests/socktainerTests/Events/ContainerExitCodeStoreTests.swift
@@ -48,8 +48,8 @@ struct ResolveExitCodeTests {
         #expect(calls == 1)
     }
 
-    // The EVT-008 regression: a transient throw from the wait XPC round-trip must NOT be
-    // recorded as a fake exit code of 0. Retrying yields the authoritative code (7).
+    // A transient throw from the wait XPC round-trip must NOT be recorded as a fake exit
+    // code of 0. Retrying yields the authoritative code (7).
     @Test("retries past transient throws and returns the real code")
     func retriesPastTransientThrows() async {
         var calls = 0

--- a/Tests/socktainerTests/Events/ContainerInfoCacheTests.swift
+++ b/Tests/socktainerTests/Events/ContainerInfoCacheTests.swift
@@ -89,4 +89,18 @@ struct ContainerInfoCacheTests {
         #expect(await cache.consumeAutoRemove(id: "native-name") == true)
         #expect(await cache.consumeAutoRemove(id: "hex123") == false)
     }
+
+    @Test("remove clears a pending --rm mark so a stale observer can't fire a second destroy")
+    func removeClearsAutoRemoveMark() async {
+        let cache = ContainerInfoCache()
+        await cache.set(hexId: "hex123", nativeId: "native-name", image: "alpine", labels: [:])
+        await cache.markAutoRemove(hexId: "hex123", nativeId: "native-name")
+
+        // ContainerDeleteRoute (or an earlier consumer) removes the container before a stale
+        // die observer gets to consumeAutoRemove — that observer must not find the mark.
+        await cache.remove(id: "hex123")
+
+        #expect(await cache.consumeAutoRemove(id: "hex123") == false)
+        #expect(await cache.consumeAutoRemove(id: "native-name") == false)
+    }
 }

--- a/Tests/socktainerTests/PollUntil.swift
+++ b/Tests/socktainerTests/PollUntil.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Polls `condition` until it returns true or `timeoutSeconds` elapses — avoids a fixed
+/// sleep in tests that wait on an async background task (e.g. a detached observer).
+func pollUntil(timeoutSeconds: Double, _ condition: () async -> Bool) async throws -> Bool {
+    let deadline = Date().addingTimeInterval(timeoutSeconds)
+    while Date() < deadline {
+        if await condition() { return true }
+        try await Task.sleep(nanoseconds: 20_000_000)
+    }
+    return await condition()
+}

--- a/Tests/socktainerTests/Routes/ComposeDNSTests.swift
+++ b/Tests/socktainerTests/Routes/ComposeDNSTests.swift
@@ -191,6 +191,54 @@ struct ComposeDNSTests {
         #expect(dnsServer.listEntries()["web.shop"] == nil, "qualified alias must be unregistered on delete")
     }
 
+    @Test("Delete unregisters aliases via the cached IP when the live snapshot reports no network")
+    func deleteUsesCachedIPWhenLiveSnapshotHasNoNetwork() async throws {
+        let nativeId = "compose-web-stopped"
+        let ip = "192.168.65.40"
+
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+        )
+        var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+        config.labels = ["com.docker.compose.service": "web", "com.docker.compose.project": "shop"]
+        // A genuinely stopped container: Apple Container reports an empty live network
+        // list, unlike this file's other fixtures which keep one attachment regardless
+        // of status.
+        let snapshot = ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+
+        // ContainerDeleteRoute looks up ContainerInfoCache by the URL path id (the hex
+        // digest a real client would use), not by container.id.
+        let requestId = "abc999"
+        await ContainerInfoCache.shared.set(hexId: requestId, nativeId: nativeId, image: "alpine:latest", labels: config.labels, ip: ip)
+
+        let dnsServer = SocktainerDNSServer()
+        dnsServer.register(hostname: nativeId, ip: ip)
+        dnsServer.register(hostname: "web", ip: ip)
+        dnsServer.register(hostname: "web.shop", ip: ip)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerDeleteRoute(client: ComposeMock(snapshot: snapshot)))
+
+            try await app.testing().test(.DELETE, "/v1.51/containers/\(requestId)") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        #expect(dnsServer.listEntries()[nativeId] == nil, "container name must be unregistered using the cached IP")
+        #expect(dnsServer.listEntries()["web"] == nil, "service alias must be unregistered using the cached IP")
+        #expect(dnsServer.listEntries()["web.shop"] == nil, "qualified alias must be unregistered using the cached IP")
+    }
+
     @Test("Delete preserves alias when another container has taken ownership")
     func deletePreservesAliasOwnedByAnotherContainer() async throws {
         let snapshot = try makeSnapshot(

--- a/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
@@ -238,46 +238,13 @@ private actor EventCollector {
 
 // MARK: - Helpers
 
-private func pollUntil(timeoutSeconds: Double, _ condition: () async -> Bool) async throws -> Bool {
-    let deadline = Date().addingTimeInterval(timeoutSeconds)
-    while Date() < deadline {
-        if await condition() { return true }
-        try await Task.sleep(nanoseconds: 20_000_000)
-    }
-    return await condition()
-}
-
 private func makeSnapshot(nativeId: String, ip: String, network: String, restartPolicyName: String, status: RuntimeStatus = .stopped) throws -> ContainerSnapshot {
-    let proc = ProcessConfiguration(
-        executable: "/bin/sh", arguments: [], environment: [],
-        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
-    )
-    let img = ImageDescription(
-        reference: "alpine:latest",
-        descriptor: Descriptor(
-            mediaType: "application/vnd.oci.image.index.v1+json",
-            digest: "sha256:abc", size: 0
-        )
-    )
-    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
     let policy = RestartPolicy(Name: restartPolicyName, MaximumRetryCount: nil)
     let policyJSON = String(data: try JSONEncoder().encode(policy), encoding: .utf8)!
-    config.labels = [RestartPolicyManager.label: policyJSON]
-
-    // Attachment is Codable — use JSON to avoid depending on internal CIDRv4/IPv4Address inits.
-    let attachmentJSON = """
-        {
-            "network": "\(network)",
-            "hostname": "\(nativeId)",
-            "ipv4Address": "\(ip)/24",
-            "ipv4Gateway": "192.168.65.1",
-            "ipv6Address": null,
-            "macAddress": null
-        }
-        """.data(using: .utf8)!
-    let attachment = try JSONDecoder().decode(Attachment.self, from: attachmentJSON)
-
-    return ContainerSnapshot(configuration: config, status: status, networks: [attachment])
+    return try makeContainerSnapshot(
+        nativeId: nativeId, ip: ip, network: network,
+        labels: [RestartPolicyManager.label: policyJSON], status: status
+    )
 }
 
 private actor RestartMock: ClientContainerProtocol {

--- a/Tests/socktainerTests/Routes/ContainerStartRouteAutoRemoveAliasTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStartRouteAutoRemoveAliasTests.swift
@@ -21,7 +21,7 @@ struct ContainerStartRouteAutoRemoveAliasTests {
         let network = "myapp_default"
 
         let snapshot = try makeSnapshot(nativeId: nativeId, ip: ip, network: network)
-        let mock = AutoRemoveMock(snapshot: snapshot)
+        let mock = StaticSnapshotClientMock(snapshot: snapshot)
         let dnsServer = SocktainerDNSServer()
 
         // Marked --rm at create time; ContainerStartRoute doesn't touch this cache entry itself.
@@ -66,29 +66,4 @@ private func makeSnapshot(nativeId: String, ip: String, network: String) throws 
             "com.docker.compose.project": "myapp",
         ]
     )
-}
-
-private actor AutoRemoveMock: ClientContainerProtocol {
-    private var snapshot: ContainerSnapshot
-
-    init(snapshot: ContainerSnapshot) {
-        self.snapshot = snapshot
-    }
-
-    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
-    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
-    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
-    func start(id: String, detachKeys: String?) async throws {
-        await ContainerExitCodeStore.shared.remove(id: id)
-    }
-    func stop(id: String, signal: String?, timeout: Int?) async throws {}
-    func restart(id: String, signal: String?, timeout: Int?) async throws {}
-    func kill(id: String, signal: String?) async throws {}
-    func delete(id: String) async throws {}
-    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
-        RESTContainerWait(statusCode: 0)
-    }
-    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
-        ([], 0)
-    }
 }

--- a/Tests/socktainerTests/Routes/ContainerStartRouteAutoRemoveAliasTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStartRouteAutoRemoveAliasTests.swift
@@ -1,0 +1,94 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression test for issue #258: `observeExit`'s `--rm` auto-remove cleanup only
+/// unregistered a container's primary name, leaving its Compose service/project aliases
+/// pointing at a deleted container's IP.
+@Suite("ContainerStartRoute — --rm auto-remove DNS alias cleanup")
+struct ContainerStartRouteAutoRemoveAliasTests {
+
+    @Test("die on a --rm container unregisters its name and its compose service/project aliases")
+    func autoRemoveUnregistersFullAliasSet() async throws {
+        let nativeId = "web-autoremove-ctr"
+        let ip = "192.168.65.80"
+        let network = "myapp_default"
+
+        let snapshot = try makeSnapshot(nativeId: nativeId, ip: ip, network: network)
+        let mock = AutoRemoveMock(snapshot: snapshot)
+        let dnsServer = SocktainerDNSServer()
+
+        // Marked --rm at create time; ContainerStartRoute doesn't touch this cache entry itself.
+        await ContainerInfoCache.shared.markAutoRemove(hexId: nativeId, nativeId: nativeId)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        #expect(dnsServer.listEntries()[nativeId] == ip)
+        #expect(dnsServer.listEntries()["web"] == ip)
+        #expect(dnsServer.listEntries()["web.myapp"] == ip)
+
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: 0)
+
+        let cleaned = try await pollUntil(timeoutSeconds: 2) {
+            dnsServer.listEntries()[nativeId] == nil
+        }
+        #expect(cleaned, "the container's own name must be unregistered on --rm exit")
+        #expect(dnsServer.listEntries()["web"] == nil, "the compose service alias must also be unregistered")
+        #expect(dnsServer.listEntries()["web.myapp"] == nil, "the compose project-qualified alias must also be unregistered")
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
+}
+
+private func makeSnapshot(nativeId: String, ip: String, network: String) throws -> ContainerSnapshot {
+    try makeContainerSnapshot(
+        nativeId: nativeId, ip: ip, network: network,
+        labels: [
+            "com.docker.compose.service": "web",
+            "com.docker.compose.project": "myapp",
+        ]
+    )
+}
+
+private actor AutoRemoveMock: ClientContainerProtocol {
+    private var snapshot: ContainerSnapshot
+
+    init(snapshot: ContainerSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {
+        await ContainerExitCodeStore.shared.remove(id: id)
+    }
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/StaticSnapshotClientMock.swift
+++ b/Tests/socktainerTests/StaticSnapshotClientMock.swift
@@ -1,0 +1,32 @@
+import ContainerAPIClient
+import ContainerResource
+
+@testable import socktainer
+
+/// A `ClientContainerProtocol` mock that always returns the same fixed snapshot for
+/// `list`/`getContainer` and no-ops every mutating call except `start`, which clears any
+/// stale exit code so a test's own `ContainerExitCodeStore.shared.set(...)` starts fresh.
+actor StaticSnapshotClientMock: ClientContainerProtocol {
+    private let snapshot: ContainerSnapshot
+
+    init(snapshot: ContainerSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {
+        await ContainerExitCodeStore.shared.remove(id: id)
+    }
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerAliasCleanupTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerAliasCleanupTests.swift
@@ -1,0 +1,82 @@
+import Testing
+
+@testable import socktainer
+
+/// Regression tests for issue #258: the `--rm` auto-remove paths (start, attach, attach-WS)
+/// only unregistered a container's primary name, leaving `socktainer.dns.names` and Compose
+/// service/project aliases pointing at a deleted container's IP.
+@Suite("ContainerAliasCleanup")
+struct ContainerAliasCleanupTests {
+
+    @Test("unregisters the container's own name, custom aliases, and compose service/project aliases")
+    func unregistersFullAliasSet() {
+        let dnsServer = SocktainerDNSServer()
+        dnsServer.register(hostname: "web-1", ip: "10.0.0.5")
+        dnsServer.register(hostname: "api", ip: "10.0.0.5")
+        dnsServer.register(hostname: "web", ip: "10.0.0.5")
+        dnsServer.register(hostname: "web.myapp", ip: "10.0.0.5")
+
+        ContainerAliasCleanup.unregisterAllAliases(
+            nativeId: "web-1",
+            labels: [
+                "socktainer.dns.names": "api",
+                "com.docker.compose.service": "web",
+                "com.docker.compose.project": "myapp",
+            ],
+            cachedIP: "10.0.0.5",
+            dnsServer: dnsServer
+        )
+
+        let remaining = dnsServer.listEntries()
+        #expect(remaining["web-1"] == nil)
+        #expect(remaining["api"] == nil)
+        #expect(remaining["web"] == nil)
+        #expect(remaining["web.myapp"] == nil)
+    }
+
+    @Test("does not touch any alias when cachedIP is nil — ownership can't be confirmed")
+    func skipsAllAliasesWhenCachedIPIsNil() {
+        let dnsServer = SocktainerDNSServer()
+        dnsServer.register(hostname: "db", ip: "10.0.0.9")
+
+        ContainerAliasCleanup.unregisterAllAliases(
+            nativeId: "db",
+            labels: ["com.docker.compose.service": "db"],
+            cachedIP: nil,
+            dnsServer: dnsServer
+        )
+
+        #expect(dnsServer.listEntries()["db"] == "10.0.0.9")
+    }
+
+    @Test("does not unregister an alias now owned by a different, live container")
+    func leavesLiveOwnersAliasIntact() {
+        let dnsServer = SocktainerDNSServer()
+        // A second "db" service (different Compose project) has since registered the same
+        // alias with its own IP. The dying container's cachedIP no longer matches.
+        dnsServer.register(hostname: "db", ip: "10.0.0.20")
+
+        ContainerAliasCleanup.unregisterAllAliases(
+            nativeId: "db-old",
+            labels: ["com.docker.compose.service": "db"],
+            cachedIP: "10.0.0.9",
+            dnsServer: dnsServer
+        )
+
+        #expect(dnsServer.listEntries()["db"] == "10.0.0.20")
+    }
+
+    @Test("unregistering an alias that isn't registered is a no-op")
+    func unregisteredAliasIsNoOp() {
+        let dnsServer = SocktainerDNSServer()
+
+        ContainerAliasCleanup.unregisterAllAliases(
+            nativeId: "ghost",
+            labels: [:],
+            cachedIP: "10.0.0.5",
+            dnsServer: dnsServer
+        )
+
+        #expect(dnsServer.listEntries().isEmpty)
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerProcessExitMonitorTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerProcessExitMonitorTests.swift
@@ -1,0 +1,95 @@
+import Testing
+
+@testable import socktainer
+
+/// Regression tests for issue #258's DoD item: attach-WS (and the HTTP attach route, which
+/// shares this exact sequence) must persist only an observed exit code, never a synthetic
+/// value, when the wait() XPC round-trip throws transiently. `wait` is injectable so this is
+/// verified end to end — retry, dual-id recording, and auto-remove dispatch — without a live
+/// Apple Container process.
+@Suite("ContainerProcessExitMonitor")
+struct ContainerProcessExitMonitorTests {
+
+    @Test("a transient wait() throw does not surface as a synthetic exit code under either id")
+    func transientThrowStillRecordsTheObservedCode() async {
+        let hexId = "hex-\(Int.random(in: 100000...999999))"
+        let nativeId = "native-\(Int.random(in: 100000...999999))"
+        var calls = 0
+
+        let code = await ContainerProcessExitMonitor.run(
+            wait: {
+                calls += 1
+                if calls < 3 { throw TransientWaitError() }
+                return 7
+            },
+            hexId: hexId,
+            nativeId: nativeId,
+            fallbackImage: "alpine:latest",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: nil,
+            outputFlushGraceNs: 0,
+            exitCodeRetryDelayNs: 0
+        )
+
+        #expect(code == 7, "the retried, authoritative code must be returned, not a synthetic -1")
+        #expect(calls == 3)
+        #expect(await ContainerExitCodeStore.shared.get(id: nativeId) == 7)
+        #expect(await ContainerExitCodeStore.shared.get(id: hexId) == 7)
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: hexId)
+    }
+
+    @Test("wait() failing on every attempt records the failure sentinel, not exit code 0")
+    func persistentFailureRecordsSentinelNotZero() async {
+        let hexId = "hex-\(Int.random(in: 100000...999999))"
+        let nativeId = "native-\(Int.random(in: 100000...999999))"
+
+        let code = await ContainerProcessExitMonitor.run(
+            wait: { throw TransientWaitError() },
+            hexId: hexId,
+            nativeId: nativeId,
+            fallbackImage: "alpine:latest",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: nil,
+            outputFlushGraceNs: 0,
+            exitCodeRetryDelayNs: 0
+        )
+
+        #expect(code == ContainerExitCodeStore.waitFailureSentinel)
+        #expect(await ContainerExitCodeStore.shared.get(id: nativeId) == ContainerExitCodeStore.waitFailureSentinel)
+        #expect(await ContainerExitCodeStore.shared.get(id: hexId) == ContainerExitCodeStore.waitFailureSentinel)
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: hexId)
+    }
+
+    @Test("a --rm container marked for auto-remove is cleaned up after exit")
+    func autoRemoveMarkedContainerIsCleanedUp() async {
+        let hexId = "hex-\(Int.random(in: 100000...999999))"
+        let nativeId = "native-\(Int.random(in: 100000...999999))"
+        await ContainerInfoCache.shared.set(hexId: hexId, nativeId: nativeId, image: "alpine:latest", labels: [:], ip: nil)
+        await ContainerInfoCache.shared.markAutoRemove(hexId: hexId, nativeId: nativeId)
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 0 },
+            hexId: hexId,
+            nativeId: nativeId,
+            fallbackImage: "alpine:latest",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: nil,
+            outputFlushGraceNs: 0,
+            exitCodeRetryDelayNs: 0
+        )
+
+        #expect(await ContainerInfoCache.shared.get(id: nativeId) == nil, "the cache entry must be cleared once auto-remove cleanup runs")
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: hexId)
+    }
+}
+
+private struct TransientWaitError: Error {}


### PR DESCRIPTION
## Summary

Mirrors `ContainerDeleteRoute`'s full DNS-alias cleanup (container name, `socktainer.dns.names`, Compose service/project aliases) in the `--rm` auto-remove paths — start, attach, and attach-WS — which previously only unregistered the container's primary name, leaving the other aliases resolvable to a deleted container's IP.

## Related Issue

Closes #258

## Changes

- Added `ContainerAliasCleanup.unregisterAllAliases` — shared, nil-safe DNS cleanup helper. When the container's cached IP can't be confirmed, no alias is touched at all (unregistering blind risks yanking a live peer's identically-named alias, e.g. a second Compose project's `db` service).
- Added `ContainerAutoRemoveCleanup.perform` — extracts the cache-lookup → DNS-cleanup → broadcast `destroy` → cache-remove sequence shared by all three `--rm` call sites, fixing a latent cache-leak in `ContainerAttachRoute` (it previously only cleared `ContainerInfoCache` when a broadcaster was registered).
- `ContainerInfoCache.remove(id:)` now also clears `autoRemoveSibling`, closing a window where a stale observer could fire a second `destroy` event.
- `ContainerAttachWSRoute` now retries the `wait()` XPC round-trip via `ContainerExitCodeStore.resolveExitCode` instead of recording a synthetic `-1` on a transient throw, matching the HTTP attach route's existing behavior.
- Extracted `PollUntil.swift` and `ContainerSnapshotFixture.swift` test helpers to remove duplication between `ContainerRestartPolicyPostStartTests` and the new `ContainerStartRouteAutoRemoveAliasTests`.

Verified event ordering (die → destroy, single-fire dedup) and the absence of a spurious network-disconnect event against moby v28.5.2's actual daemon source (`daemon/monitor.go`, `daemon/delete.go`) — both match.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (548 tests)
- [x] Unit tests added: `ContainerAliasCleanupTests` (full alias cleanup, nil-cachedIP skip, live-peer-alias-preserved, no-op on unregistered alias), `ContainerInfoCacheTests` regression for `remove()` clearing `autoRemoveSibling`, and `ContainerStartRouteAutoRemoveAliasTests` — an HTTP-level integration test proving the `--rm` start path unregisters the compose service + project-qualified aliases, not just the primary name
- [x] Manual testing performed (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)