### PR TITLE
fix(containers): unregister DNS aliases on a terminal (non-restarting) stop

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -74,7 +74,7 @@ extension ContainerDeleteRoute {
                     // Prefer the cached IP — reliable even once the container has genuinely
                     // stopped and Apple Container reports an empty live network list — falling
                     // back to the live snapshot for a container never observed via /start.
-                    let containerIP = container.networks.first?.ipv4Address.address.description
+                    let containerIP = ContainerStartRoute.dnsAttachmentIP(in: container)
                     ContainerAliasCleanup.unregisterAllAliases(
                         nativeId: container.id,
                         labels: cached?.labels ?? LabelNormalization.restore(container.configuration.labels),

--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -72,7 +72,7 @@ extension ContainerRestartRoute {
                     image: snap.configuration.image.reference,
                     name: snap.id,
                     labels: LabelNormalization.restore(snap.configuration.labels),
-                    ip: snap.networks.first?.ipv4Address.address.description,
+                    ip: ContainerStartRoute.dnsAttachmentIP(in: snap),
                     refreshCache: true,
                     restartPolicy: restartPolicy,
                     generation: generation,

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -198,13 +198,29 @@ extension ContainerStartRoute {
             }
 
             let explicitlyStopped = await ContainerRestartState.shared.consumeExplicitlyStopped(id: nativeId)
-            guard let restartPolicy else { return }
-
             let nextAttemptNumber = await ContainerRestartState.shared.count(id: nativeId) + 1
-            guard
-                RestartPolicyManager.shouldRestart(
-                    policy: restartPolicy, exitCode: code, attempt: nextAttemptNumber, hasBeenManuallyStopped: explicitlyStopped)
-            else { return }
+            let willRestart =
+                restartPolicy.map {
+                    RestartPolicyManager.shouldRestart(
+                        policy: $0, exitCode: code, attempt: nextAttemptNumber, hasBeenManuallyStopped: explicitlyStopped)
+                } ?? false
+
+            // Staying stopped: moby tears down a container's network sandbox (and its DNS
+            // resolution) on every exit, not just --rm. Mirror that here, after the generation
+            // guard above so a stale, superseded observer can't unregister a live,
+            // already-restarted container's alias.
+            guard willRestart else {
+                if let dnsServer {
+                    let cached = await ContainerInfoCache.shared.get(id: nativeId)
+                    ContainerAliasCleanup.unregisterAllAliases(
+                        nativeId: nativeId,
+                        labels: cached?.labels ?? labels,
+                        cachedIP: cached?.ip,
+                        dnsServer: dnsServer
+                    )
+                }
+                return
+            }
 
             await ContainerRestartState.shared.markPendingRestart(id: nativeId)
             let backoffDelay = await ContainerRestartState.shared.nextBackoffDelayNanoseconds(

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -84,7 +84,7 @@ extension ContainerStartRoute {
             if let snap = metadataSnapshot {
                 // Store under canonical hexId so later lookups by the Docker hex ID always
                 // hit, regardless of whether /start was called by name or short ID.
-                let containerIP = startedSnapshot?.networks.first?.ipv4Address.address.description
+                let containerIP = ContainerStartRoute.dnsAttachmentIP(in: startedSnapshot)
                 await ContainerInfoCache.shared.set(
                     hexId: eventId,
                     nativeId: snap.id,
@@ -125,7 +125,7 @@ extension ContainerStartRoute {
                     image: snap.configuration.image.reference,
                     name: snap.id,
                     labels: LabelNormalization.restore(snap.configuration.labels),
-                    ip: startedSnapshot?.networks.first?.ipv4Address.address.description,
+                    ip: ContainerStartRoute.dnsAttachmentIP(in: startedSnapshot),
                     refreshCache: false,
                     restartPolicy: restartPolicy,
                     generation: generation,
@@ -257,7 +257,7 @@ extension ContainerStartRoute {
                 image: image,
                 name: name,
                 labels: labels,
-                ip: restartedSnapshot?.networks.first?.ipv4Address.address.description,
+                ip: ContainerStartRoute.dnsAttachmentIP(in: restartedSnapshot),
                 refreshCache: restartedSnapshot != nil,
                 restartPolicy: restartPolicy,
                 generation: generation,
@@ -343,10 +343,7 @@ extension ContainerStartRoute {
             // as sidecarNetwork. On reserved networks (default/bridge/host/none) there is no
             // forwarder so any registration would be unreachable; skip entirely if none of the
             // container's attachments qualify, rather than falling back to the first attachment.
-            let reservedNetworks: Set<String> = ["default", "bridge", "host", "none"]
-            if let dnsAttachment = snapshot.networks.first(where: { !$0.network.isEmpty && !reservedNetworks.contains($0.network) }) {
-                let ip = dnsAttachment.ipv4Address.address.description
-
+            if let ip = ContainerStartRoute.dnsAttachmentIP(in: snapshot) {
                 if !snapshot.id.isEmpty {
                     dnsServer.register(hostname: snapshot.id, ip: ip)
                     logger.info("[dns] registered container name '\(snapshot.id)' → \(ip)")
@@ -419,5 +416,39 @@ extension ContainerStartRoute {
         if roleLabel == NetworkDNSManager.dnsRole { return nil }
         let reserved: Set<String> = ["default", "bridge", "host", "none"]
         return configuredNetworks.first { !$0.isEmpty && !reserved.contains($0) }
+    }
+
+    /// The IP DNS aliases are registered under — the first non-reserved network
+    /// attachment. Every cache/cleanup site (ContainerInfoCache.ip, ContainerDeleteRoute)
+    /// must derive its IP the same way, or unregisterIfOwned's ownership check silently
+    /// fails to match on multi-network containers.
+    static func dnsAttachmentIP(in snapshot: ContainerSnapshot?) -> String? {
+        let reservedNetworks: Set<String> = ["default", "bridge", "host", "none"]
+        return snapshot?.networks.first { !$0.network.isEmpty && !reservedNetworks.contains($0.network) }?
+            .ipv4Address.address.description
+    }
+
+    /// Re-registers a resumed container's DNS aliases (name, `socktainer.dns.names`,
+    /// Compose service/project) — called once per still-running container when
+    /// Socktainer starts, since SocktainerDNSServer's registry is in-memory and lost
+    /// across daemon restarts. Uses dnsAttachmentIP so a container whose first network
+    /// attachment happens to be reserved (e.g. bridge) still gets re-registered on its
+    /// named network, instead of being skipped entirely.
+    static func registerDNSAliasesOnResume(container: ContainerSnapshot, dnsServer: SocktainerDNSServer, logger: Logger) {
+        guard let ip = ContainerStartRoute.dnsAttachmentIP(in: container) else { return }
+
+        dnsServer.register(hostname: container.id, ip: ip)
+        if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
+            for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
+                dnsServer.register(hostname: name, ip: ip)
+            }
+        }
+        if let serviceName = container.configuration.labels["com.docker.compose.service"], !serviceName.isEmpty {
+            dnsServer.register(hostname: serviceName, ip: ip)
+            if let projectName = container.configuration.labels["com.docker.compose.project"], !projectName.isEmpty {
+                dnsServer.register(hostname: "\(serviceName).\(projectName)", ip: ip)
+            }
+        }
+        logger.info("[dns] re-registered '\(container.id)' → \(ip) on resume")
     }
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -212,35 +212,12 @@ func configure(_ app: Application) async throws {
     // restarted (not re-created) via docker start cannot be resolved by peers.
     let resumeClient = ContainerClient()
     if let runningContainers = try? await resumeClient.list() {
-        let reservedNetworks: Set<String> = ["default", "bridge", "host", "none"]
         for container in runningContainers where container.status == .running {
             // Skip DNS-sidecar containers — they are internal infrastructure.
             guard container.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole
             else { continue }
 
-            // Re-register DNS entries for containers on named networks.
-            if let firstAttachment = container.networks.first,
-                !reservedNetworks.contains(firstAttachment.network)
-            {
-                let ip = firstAttachment.ipv4Address.address.description
-                dnsServer.register(hostname: container.id, ip: ip)
-                if let namesLabel = container.configuration.labels["socktainer.dns.names"] {
-                    for name in namesLabel.split(separator: ",").map(String.init) where !name.isEmpty {
-                        dnsServer.register(hostname: name, ip: ip)
-                    }
-                }
-                if let serviceName = container.configuration.labels["com.docker.compose.service"],
-                    !serviceName.isEmpty
-                {
-                    dnsServer.register(hostname: serviceName, ip: ip)
-                    if let projectName = container.configuration.labels["com.docker.compose.project"],
-                        !projectName.isEmpty
-                    {
-                        dnsServer.register(hostname: "\(serviceName).\(projectName)", ip: ip)
-                    }
-                }
-                app.logger.info("[dns] re-registered '\(container.id)' → \(ip) on resume")
-            }
+            ContainerStartRoute.registerDNSAliasesOnResume(container: container, dnsServer: dnsServer, logger: app.logger)
 
             // Resume healthcheck loop if the container has one.
             guard let json = container.configuration.labels[HealthCheckManager.healthcheckLabel],

--- a/Tests/socktainerTests/ContainerSnapshotFixture.swift
+++ b/Tests/socktainerTests/ContainerSnapshotFixture.swift
@@ -3,13 +3,12 @@ import ContainerResource
 import ContainerizationOCI
 import Foundation
 
-/// Builds a minimal `ContainerSnapshot` for lifecycle/DNS tests, with one network attachment
-/// on `network` at `ip`. Callers supply the labels that make their scenario distinct
+/// Builds a minimal `ContainerSnapshot` for lifecycle/DNS tests, attached to each of
+/// `networks` in order. Callers supply the labels that make their scenario distinct
 /// (restart policy, Compose service, etc.) — everything else is fixed test scaffolding.
 func makeContainerSnapshot(
     nativeId: String,
-    ip: String,
-    network: String,
+    networks: [(network: String, ip: String)],
     labels: [String: String],
     status: RuntimeStatus = .stopped
 ) throws -> ContainerSnapshot {
@@ -28,17 +27,30 @@ func makeContainerSnapshot(
     config.labels = labels
 
     // Attachment is Codable — use JSON to avoid depending on internal CIDRv4/IPv4Address inits.
-    let attachmentJSON = """
-        {
-            "network": "\(network)",
-            "hostname": "\(nativeId)",
-            "ipv4Address": "\(ip)/24",
-            "ipv4Gateway": "192.168.65.1",
-            "ipv6Address": null,
-            "macAddress": null
-        }
-        """.data(using: .utf8)!
-    let attachment = try JSONDecoder().decode(Attachment.self, from: attachmentJSON)
+    let attachments = try networks.map { entry -> Attachment in
+        let attachmentJSON = """
+            {
+                "network": "\(entry.network)",
+                "hostname": "\(nativeId)",
+                "ipv4Address": "\(entry.ip)/24",
+                "ipv4Gateway": "192.168.65.1",
+                "ipv6Address": null,
+                "macAddress": null
+            }
+            """.data(using: .utf8)!
+        return try JSONDecoder().decode(Attachment.self, from: attachmentJSON)
+    }
 
-    return ContainerSnapshot(configuration: config, status: status, networks: [attachment])
+    return ContainerSnapshot(configuration: config, status: status, networks: attachments)
+}
+
+/// Single-network convenience for the common case — see `makeContainerSnapshot(nativeId:networks:labels:status:)`.
+func makeContainerSnapshot(
+    nativeId: String,
+    ip: String,
+    network: String,
+    labels: [String: String],
+    status: RuntimeStatus = .stopped
+) throws -> ContainerSnapshot {
+    try makeContainerSnapshot(nativeId: nativeId, networks: [(network: network, ip: ip)], labels: labels, status: status)
 }

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -3,6 +3,7 @@ import ContainerResource
 import ContainerizationOCI
 import Darwin
 import Foundation
+import Logging
 import SocktainerDNSImage
 import Testing
 
@@ -494,5 +495,87 @@ struct SidecarNetworkTests {
             roleLabel: NetworkDNSManager.dnsRole
         )
         #expect(result == nil, "a DNS sidecar must not ensure another sidecar for its own network")
+    }
+}
+
+// MARK: - ContainerStartRoute.dnsAttachmentIP (cache/cleanup IP must match the registered IP)
+
+@Suite("ContainerStartRoute.dnsAttachmentIP")
+struct DNSAttachmentIPTests {
+
+    @Test("Skips a reserved first attachment and returns the named network's IP")
+    func skipsReservedFirstAttachment() throws {
+        let snapshot = try makeContainerSnapshot(
+            nativeId: "web-1",
+            networks: [(network: "bridge", ip: "192.168.65.10"), (network: "stackdemo_default", ip: "192.168.65.20")],
+            labels: [:]
+        )
+        let result = ContainerStartRoute.dnsAttachmentIP(in: snapshot)
+        #expect(result == "192.168.65.20", "must match the IP dnsServer.register(hostname:ip:) is actually called with")
+    }
+
+    @Test("A single named network returns its own IP")
+    func singleNamedNetwork() throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web-1", ip: "192.168.65.20", network: "stackdemo_default", labels: [:])
+        #expect(ContainerStartRoute.dnsAttachmentIP(in: snapshot) == "192.168.65.20")
+    }
+
+    @Test("Only reserved networks returns nil")
+    func onlyReservedNetworksReturnsNil() throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web-1", ip: "192.168.65.10", network: "bridge", labels: [:])
+        #expect(ContainerStartRoute.dnsAttachmentIP(in: snapshot) == nil)
+    }
+
+    @Test("Nil snapshot returns nil")
+    func nilSnapshotReturnsNil() {
+        #expect(ContainerStartRoute.dnsAttachmentIP(in: nil) == nil)
+    }
+}
+
+// MARK: - ContainerStartRoute.registerDNSAliasesOnResume (daemon-restart re-registration)
+
+@Suite("ContainerStartRoute.registerDNSAliasesOnResume")
+struct RegisterDNSAliasesOnResumeTests {
+
+    @Test("Re-registers on a named network even when the first attachment is reserved")
+    func reRegistersPastReservedFirstAttachment() throws {
+        let container = try makeContainerSnapshot(
+            nativeId: "web-1",
+            networks: [(network: "bridge", ip: "192.168.65.10"), (network: "stackdemo_default", ip: "192.168.65.20")],
+            labels: [:]
+        )
+        let dnsServer = SocktainerDNSServer()
+        ContainerStartRoute.registerDNSAliasesOnResume(container: container, dnsServer: dnsServer, logger: Logger(label: "test"))
+        #expect(dnsServer.listEntries()["web-1"] == "192.168.65.20")
+    }
+
+    @Test("A container on only reserved networks is not registered")
+    func onlyReservedNetworksSkipsRegistration() throws {
+        let container = try makeContainerSnapshot(nativeId: "web-1", ip: "192.168.65.10", network: "bridge", labels: [:])
+        let dnsServer = SocktainerDNSServer()
+        ContainerStartRoute.registerDNSAliasesOnResume(container: container, dnsServer: dnsServer, logger: Logger(label: "test"))
+        #expect(dnsServer.listEntries().isEmpty)
+    }
+
+    @Test("Also registers socktainer.dns.names and Compose service/project aliases")
+    func registersAllAliases() throws {
+        let container = try makeContainerSnapshot(
+            nativeId: "db-1",
+            ip: "192.168.65.20",
+            network: "stackdemo_default",
+            labels: [
+                "socktainer.dns.names": "postgres,pg",
+                "com.docker.compose.service": "db",
+                "com.docker.compose.project": "stackdemo",
+            ]
+        )
+        let dnsServer = SocktainerDNSServer()
+        ContainerStartRoute.registerDNSAliasesOnResume(container: container, dnsServer: dnsServer, logger: Logger(label: "test"))
+        let entries = dnsServer.listEntries()
+        #expect(entries["db-1"] == "192.168.65.20")
+        #expect(entries["postgres"] == "192.168.65.20")
+        #expect(entries["pg"] == "192.168.65.20")
+        #expect(entries["db"] == "192.168.65.20")
+        #expect(entries["db.stackdemo"] == "192.168.65.20")
     }
 }

--- a/Tests/socktainerTests/Routes/ContainerStartRouteStopDNSCleanupTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStartRouteStopDNSCleanupTests.swift
@@ -1,0 +1,121 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Regression tests for a moby-conformance gap found while auditing issue #258: moby tears
+/// down a container's network sandbox (and its DNS resolution) on every exit via
+/// `daemon.Cleanup`, not just `--rm`. Socktainer previously only unregistered DNS aliases on
+/// `--rm` auto-remove or explicit delete, so a plain `docker stop` left a stale, resolvable
+/// DNS entry pointing at a dead container's IP indefinitely.
+@Suite("ContainerStartRoute — DNS cleanup on a terminal (non-restarting) stop")
+struct ContainerStartRouteStopDNSCleanupTests {
+
+    @Test("a container with no restart policy unregisters its DNS alias on exit")
+    func plainStopUnregistersDNS() async throws {
+        let nativeId = "stop-dns-plain-ctr"
+        let ip = "192.168.65.90"
+        let network = "myapp_default"
+
+        let snapshot = try makeContainerSnapshot(nativeId: nativeId, ip: ip, network: network, labels: [:])
+        let mock = TerminalStopMock(snapshot: snapshot)
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        #expect(dnsServer.listEntries()[nativeId] == ip)
+
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: 0)
+
+        let cleaned = try await pollUntil(timeoutSeconds: 2) {
+            dnsServer.listEntries()[nativeId] == nil
+        }
+        #expect(cleaned, "a container with no restart policy must unregister its DNS alias once it exits")
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
+
+    @Test("on-failure declining to restart on a clean exit unregisters its DNS alias")
+    func onFailureDecliningToRestartUnregistersDNS() async throws {
+        let nativeId = "stop-dns-on-failure-ctr"
+        let ip = "192.168.65.91"
+        let network = "myapp_default"
+
+        let policy = RestartPolicy(Name: "on-failure", MaximumRetryCount: nil)
+        let policyJSON = String(data: try JSONEncoder().encode(policy), encoding: .utf8)!
+        let snapshot = try makeContainerSnapshot(
+            nativeId: nativeId, ip: ip, network: network,
+            labels: [RestartPolicyManager.label: policyJSON]
+        )
+        let mock = TerminalStopMock(snapshot: snapshot)
+        let dnsServer = SocktainerDNSServer()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[SocktainerDNSServerKey.self] = dnsServer
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        #expect(dnsServer.listEntries()[nativeId] == ip)
+
+        // on-failure never restarts on a clean (code 0) exit.
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: 0)
+
+        let cleaned = try await pollUntil(timeoutSeconds: 2) {
+            dnsServer.listEntries()[nativeId] == nil
+        }
+        #expect(cleaned, "on-failure declining to restart on a clean exit must unregister its DNS alias")
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
+}
+
+private actor TerminalStopMock: ClientContainerProtocol {
+    private var snapshot: ContainerSnapshot
+
+    init(snapshot: ContainerSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {
+        await ContainerExitCodeStore.shared.remove(id: id)
+    }
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerStartRouteStopDNSCleanupTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStartRouteStopDNSCleanupTests.swift
@@ -23,7 +23,7 @@ struct ContainerStartRouteStopDNSCleanupTests {
         let network = "myapp_default"
 
         let snapshot = try makeContainerSnapshot(nativeId: nativeId, ip: ip, network: network, labels: [:])
-        let mock = TerminalStopMock(snapshot: snapshot)
+        let mock = StaticSnapshotClientMock(snapshot: snapshot)
         let dnsServer = SocktainerDNSServer()
 
         try await withApp(configure: { _ in }) { app in
@@ -64,7 +64,7 @@ struct ContainerStartRouteStopDNSCleanupTests {
             nativeId: nativeId, ip: ip, network: network,
             labels: [RestartPolicyManager.label: policyJSON]
         )
-        let mock = TerminalStopMock(snapshot: snapshot)
+        let mock = StaticSnapshotClientMock(snapshot: snapshot)
         let dnsServer = SocktainerDNSServer()
 
         try await withApp(configure: { _ in }) { app in
@@ -92,30 +92,5 @@ struct ContainerStartRouteStopDNSCleanupTests {
 
         await ContainerRestartState.shared.reset(id: nativeId)
         await ContainerExitCodeStore.shared.remove(id: nativeId)
-    }
-}
-
-private actor TerminalStopMock: ClientContainerProtocol {
-    private var snapshot: ContainerSnapshot
-
-    init(snapshot: ContainerSnapshot) {
-        self.snapshot = snapshot
-    }
-
-    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
-    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
-    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
-    func start(id: String, detachKeys: String?) async throws {
-        await ContainerExitCodeStore.shared.remove(id: id)
-    }
-    func stop(id: String, signal: String?, timeout: Int?) async throws {}
-    func restart(id: String, signal: String?, timeout: Int?) async throws {}
-    func kill(id: String, signal: String?) async throws {}
-    func delete(id: String) async throws {}
-    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
-        RESTContainerWait(statusCode: 0)
-    }
-    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
-        ([], 0)
     }
 }


### PR DESCRIPTION
## Summary

moby tears down a container's network sandbox (and its DNS resolution) on *every* exit via `daemon.Cleanup`→`releaseNetwork`, not just `--rm` (confirmed against moby v28.5.2 source: `daemon/monitor.go`, `daemon/container_operations.go`). Socktainer only unregistered DNS aliases on `--rm` auto-remove or explicit delete, so a plain `docker stop` (no `--rm`) left a stale, resolvable DNS entry pointing at a dead container's IP indefinitely — confirmed live against a running daemon before and after this fix.

**Stacked on #290** — this branch builds on `fix/lifecycle-dns-cleanup`, so the diff includes that PR's commit (`d66e41e`) until it merges. Only the last commit (`dcf976c`) is new here.

## Related Issue

Follow-up to #258, found while auditing that fix's behavior against moby's actual daemon source.

## Changes

- Unified `ContainerStartRoute.observeExit`'s two "declining to restart" return paths (no restart policy at all, or the policy declines to restart this exit) into a single `willRestart` check.
- On the non-restarting branch, unregisters DNS aliases via the existing `ContainerAliasCleanup` helper (from #290) — placed *after* the `isCurrent(generation:)` guard so a stale/superseded observer can never unregister a live, already-restarted container's alias.
- A restart-bound exit's DNS gap is deliberately left untouched: it's transient and self-heals once the container restarts, matching moby's own behavior (which also tears down DNS before a restart-policy restart completes).

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (550 tests)
- [x] Unit tests added: a container with no restart policy unregisters its DNS alias on exit; `on-failure` declining to restart on a clean exit unregisters its DNS alias
- [x] Manual testing: reproduced the bug live pre-fix (started a named-network container, confirmed DNS resolution, `docker stop`, confirmed the entry stayed resolvable indefinitely with no unregister). Re-verified post-fix: `docker stop` now triggers unregistration within ~1s and the DNS query correctly returns NXDOMAIN.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)