### PR TITLE
fix(events): carry the canonical container id in stop/restart events

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -42,8 +42,11 @@ extension ContainerRestartRoute {
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+            // Carry the canonical 64-char Docker id, not the raw request
+            // reference (name or short id), so clients can correlate this
+            // event with start/kill/die (same pattern as those routes).
             let event = DockerEvent.simpleEvent(
-                id: id,
+                id: snapshot.map { DockerContainerID.hexId(for: $0) } ?? id,
                 type: "container",
                 status: "restart",
                 image: snapshot?.configuration.image.reference ?? "",

--- a/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
@@ -38,8 +38,11 @@ extension ContainerStopRoute {
             }
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
+            // Carry the canonical 64-char Docker id, not the raw request
+            // reference (name or short id), so clients can correlate this
+            // event with start/kill/die (same pattern as those routes).
             let event = DockerEvent.simpleEvent(
-                id: id,
+                id: snapshot.map { DockerContainerID.hexId(for: $0) } ?? id,
                 type: "container",
                 status: "stop",
                 image: snapshot?.configuration.image.reference ?? "",

--- a/Tests/socktainerTests/Events/StopRestartEventIdTests.swift
+++ b/Tests/socktainerTests/Events/StopRestartEventIdTests.swift
@@ -1,0 +1,125 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// stop/restart events must carry the canonical 64-char Docker id in
+/// Actor.ID, like start/kill/die do — not the raw request reference
+/// (container name or short id) the client happened to use. Clients such
+/// as testcontainers correlate lifecycle events by that id.
+@Suite("Stop/Restart events — canonical container id")
+struct StopRestartEventIdTests {
+
+    @Test("stop event carries the 64-char hex id, not the request reference")
+    func stopEventUsesHexId() async throws {
+        let snapshot = Self.snapshot(nativeId: "sockt-evtid-native")
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "stop" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerStopRoute(client: FixedSnapshotMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/sockt-evtid-native/stop") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let event = await Self.withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["name"] == "sockt-evtid-native")
+    }
+
+    @Test("restart event carries the 64-char hex id, not the request reference")
+    func restartEventUsesHexId() async throws {
+        let snapshot = Self.snapshot(nativeId: "sockt-evtid-native")
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "restart" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerRestartRoute(client: FixedSnapshotMock(snapshot: snapshot)))
+
+            try await app.testing().test(.POST, "/v1.51/containers/sockt-evtid-native/restart") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let event = await Self.withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["name"] == "sockt-evtid-native")
+    }
+
+    // MARK: - Helpers
+
+    private static func snapshot(nativeId: String) -> ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: .running, networks: [])
+    }
+
+    private static func withTimeout(_ task: Task<DockerEvent?, Never>, seconds: UInt64 = 5) async -> DockerEvent? {
+        let timeoutTask = Task<DockerEvent?, Never> {
+            try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+            task.cancel()
+            return nil
+        }
+        let value = await task.value
+        timeoutTask.cancel()
+        return value
+    }
+}
+
+// MARK: - Mocks
+
+/// Mock whose getContainer resolves any reference to a fixed snapshot.
+private struct FixedSnapshotMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## Summary

The `stop` and `restart` events carried the raw request reference (whatever the client typed — a name, or a 12-char short id) as the event id. The sibling lifecycle emitters (`start`, `kill`, `create`, `die`, and the delete route's `destroy`) already normalize to the canonical 64-char Docker id via `DockerContainerID.hexId`.

Clients that correlate lifecycle events by container id (`docker events --filter container=<id>`, testcontainers wait strategies) never matched a name-keyed `stop` event against the `start` event of the same container.

Both routes already fetch the container snapshot; this change derives the event id from it with the exact pattern the sibling routes use, falling back to the request reference only when the snapshot is unavailable.

## Related Issue

None — found while auditing container routes for Docker Engine API parity.

## Reproduction

Before:

```console
$ docker events --format '{{.Action}} {{.Actor.ID}}' &
$ docker run -d --name web nginx:alpine
start 09e397da4917…(64-char id)
$ docker stop web
stop web                      # ← raw name, doesn't match the start event
```

After:

```console
$ docker stop web
stop 09e397da4917…(64-char id)  # ← same id as start/die
```

## Changes

- `ContainerStopRoute` / `ContainerRestartRoute` derive the event id from the already-fetched snapshot via `DockerContainerID.hexId`, falling back to the request reference only when the snapshot is unavailable — no extra I/O added
- The `name` attribute still carries the native name, as in moby
- New unit tests in `Tests/socktainerTests/Events/StopRestartEventIdTests.swift`: `POST /containers/<name>/stop` and `/restart` broadcast events whose `Actor.ID` equals `DockerContainerID.hexId(for: snapshot)`, not the raw name. Both tests fail against the previous implementation (`Actor.ID == "<name>"`), confirming they reproduce the bug.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))