### PR TITLE
fix(ports): treat PortBinding HostPort "0" as auto-allocate

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -867,14 +867,16 @@ func convertPortBindings(from portBindings: [String: [PortBinding]]) throws -> [
             // Use default values if not specified
             let hostAddress = binding.HostIp?.isEmpty == false ? binding.HostIp! : "0.0.0.0"
 
-            // If HostPort is empty/nil, find an available port
+            // If HostPort is empty/nil/"0", find an available port. Docker
+            // Engine treats HostPort "0" the same as "" (auto-allocate an
+            // ephemeral port); Testcontainers relies on that semantics.
             let hostPort: UInt16
-            if let hostPortString = binding.HostPort, !hostPortString.isEmpty {
-                if let parsedPort = UInt16(hostPortString) {
-                    hostPort = parsedPort
-                } else {
-                    hostPort = UInt16(try findAvailablePort())
-                }
+            if let hostPortString = binding.HostPort,
+                !hostPortString.isEmpty,
+                let parsedPort = UInt16(hostPortString),
+                parsedPort != 0
+            {
+                hostPort = parsedPort
             } else {
                 hostPort = UInt16(try findAvailablePort())
             }

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -583,3 +583,28 @@ struct RestartPolicyValidationTests {
         }
     }
 }
+
+@Suite("ContainerCreateRoute — port binding conversion")
+struct ConvertPortBindingsTests {
+    @Test("an explicit HostPort is published verbatim")
+    func explicitHostPortIsKept() throws {
+        let ports = try convertPortBindings(from: ["5432/tcp": [PortBinding(HostIp: nil, HostPort: "15432")]])
+        #expect(ports.count == 1)
+        #expect(ports[0].hostPort == 15432)
+        #expect(ports[0].containerPort == 5432)
+    }
+
+    @Test(#"HostPort "0" auto-allocates an ephemeral port like Docker, never publishes literal port 0"#)
+    func hostPortZeroAutoAllocates() throws {
+        let ports = try convertPortBindings(from: ["5432/tcp": [PortBinding(HostIp: nil, HostPort: "0")]])
+        #expect(ports.count == 1)
+        #expect(ports[0].hostPort != 0)
+    }
+
+    @Test("an empty HostPort auto-allocates an ephemeral port")
+    func emptyHostPortAutoAllocates() throws {
+        let ports = try convertPortBindings(from: ["5432/tcp": [PortBinding(HostIp: nil, HostPort: "")]])
+        #expect(ports.count == 1)
+        #expect(ports[0].hostPort != 0)
+    }
+}


### PR DESCRIPTION
## Problem

Docker Engine treats a port binding whose `HostPort` is `"0"` the same as an empty string: allocate an ephemeral host port. `convertPortBindings` currently parses `"0"` as a literal `UInt16` and publishes host port 0, so clients that request ephemeral ports with an explicit `"0"` get an unusable binding.

Testcontainers is the prominent real-world caller: testcontainers-go sends `PortBindings: {"5432/tcp": [{"HostPort": "0"}]}` for every container it starts, then dials the mapped port from `docker inspect` and fails its wait strategy with `dial tcp [::1]:0`. Repro on macOS 27 / Apple Container 1.1.0 with any testcontainers-go module; `docker inspect` shows `"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"0"}]` for the created container while a plain `docker run -p 5432` (empty `HostPort`) correctly gets an ephemeral port.

## Fix

One line in `convertPortBindings`: only accept a parsed `HostPort` when it is non-zero, otherwise fall through to the existing `findAvailablePort()` path — exactly the empty-string behavior.

## Testing

Added a small `ConvertPortBindingsTests` suite covering the three shapes: explicit port kept verbatim, `"0"` auto-allocates (fails without this fix), empty string auto-allocates.

Verified end to end: with this fix (built against Apple Container 1.1.0), a full testcontainers-go v0.42 integration suite (multiple Go packages sharing `postgres:16-alpine` containers, `TESTCONTAINERS_RYUK_DISABLED=true`) runs green against socktainer, and `docker compose up` port publishing keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYy4FLrdajbp4ybpP2chXU