### PR TITLE
fix: Docker-API compatibility for docker-py clients (arch, error shape, ImageNotFound)

### DIFF
--- a/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageInspectRoute.swift
@@ -140,7 +140,11 @@ extension ImageInspectRoute {
             do {
                 image = try await ClientImage.get(reference: refOrId, containerSystemConfig: systemConfig)
             } catch {
-                throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
+                // Docker phrasing ("No such image: <ref>") is load-bearing: docker-py
+                // only maps a 404 to ImageNotFound when the message contains
+                // "no such image"; otherwise callers' `except ImageNotFound` (which
+                // triggers an auto-pull, e.g. MiniStack's Lambda RIE image) is skipped.
+                throw Abort(.notFound, reason: "No such image: \(refOrId)")
             }
 
             let containers = includeManifests ? try await ContainerClient().list() : []
@@ -322,7 +326,7 @@ extension ImageInspectRoute {
                 throw Abort(.notFound, reason: "Image '\(refOrId)' does not provide platform '\(requestedPlatform.description)'")
             }
 
-            throw Abort(.notFound, reason: "Image '\(refOrId)' not found")
+            throw Abort(.notFound, reason: "No such image: \(refOrId)")
         }
     }
 }

--- a/Sources/socktainer/Routes/Server/InfoRoute.swift
+++ b/Sources/socktainer/Routes/Server/InfoRoute.swift
@@ -77,7 +77,7 @@ struct InfoRoute: RouteCollection {
                 KernelVersion: try await kernelNameProvider(),
                 OSVersion: currentPlatform().osVersion ?? nil,
                 OSType: currentPlatform().os,
-                Architecture: currentPlatform().architecture,
+                Architecture: dockerInfoArchitecture(currentPlatform().architecture),
                 NCPU: hostCPUCoreCount(),
                 MemTotal: Int64(hostPhysicalMemory()),
                 HttpProxy: ProcessInfo.processInfo.environment["HTTP_PROXY"] ?? nil,

--- a/Sources/socktainer/Utilities/DockerErrorMiddleware.swift
+++ b/Sources/socktainer/Utilities/DockerErrorMiddleware.swift
@@ -25,6 +25,12 @@ struct DockerErrorMiddleware: AsyncMiddleware {
                 return Self.ensureMessageField(in: response)
             }
             return response
+        } catch is CancellationError {
+            // Vapor's default error handling rethrows CancellationError so request
+            // cancellation propagates and downstream cleanup runs. This middleware is
+            // outermost, so it must preserve that behaviour rather than turn a
+            // cancellation into a 500.
+            throw CancellationError()
         } catch {
             let status: HTTPResponseStatus
             let reason: String
@@ -45,7 +51,9 @@ struct DockerErrorMiddleware: AsyncMiddleware {
     /// `{"message": ...}`.
     static func ensureMessageField(in response: Response) -> Response {
         guard let bodyData = response.body.data, !bodyData.isEmpty else {
-            return response
+            // An error status with no body still lacks `message` — the exact shape that
+            // breaks docker-py. Synthesise a Docker error so `message` is always present.
+            return makeDockerError(status: response.status, message: "error", headers: response.headers)
         }
         guard
             let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]

--- a/Sources/socktainer/Utilities/DockerErrorMiddleware.swift
+++ b/Sources/socktainer/Utilities/DockerErrorMiddleware.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Vapor
+
+/// Docker clients expect API error bodies shaped like Moby's: `{"message": "..."}`.
+/// Vapor's default `AbortError` rendering uses `{"error": true, "reason": "..."}`,
+/// which has no `message` key. The docker-py SDK's
+/// `create_api_error_from_http_exception` does `response.json()['message']` and only
+/// guards `ValueError` (non-JSON) — a missing `message` key raises
+/// `KeyError('message')`. That masks the real HTTP error: e.g. a clean 404
+/// `ImageNotFound` (which callers catch to trigger an image pull) surfaces instead as
+/// `KeyError('message')` and escapes the `except ImageNotFound` handler. MiniStack's
+/// Lambda docker-executor hits exactly this on first use of an RIE base image
+/// ("spawn error: 'message'"), so no Lambda can cold-start.
+///
+/// This middleware is installed outermost (at `.beginning`) and makes every error
+/// response Docker-compatible by ensuring a `message` field is present, preserving
+/// the original `error`/`reason` fields for any existing consumers.
+struct DockerErrorMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        do {
+            let response = try await next.respond(to: request)
+            // A downstream error middleware may already have rendered the error as a
+            // Response. Ensure error-status JSON bodies carry a `message` field.
+            if response.status.code >= 400 {
+                return Self.ensureMessageField(in: response)
+            }
+            return response
+        } catch {
+            let status: HTTPResponseStatus
+            let reason: String
+            if let abort = error as? AbortError {
+                status = abort.status
+                reason = abort.reason
+            } else {
+                status = .internalServerError
+                reason = String(describing: error)
+            }
+            request.logger.debug("DockerErrorMiddleware: rendering \(status.code) as Docker error: \(reason)")
+            return Self.makeDockerError(status: status, message: reason)
+        }
+    }
+
+    /// Rewrites an already-rendered error response so its JSON body includes a
+    /// `message` field. Non-JSON bodies are wrapped so clients always get
+    /// `{"message": ...}`.
+    static func ensureMessageField(in response: Response) -> Response {
+        guard let bodyData = response.body.data, !bodyData.isEmpty else {
+            return response
+        }
+        guard
+            let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        else {
+            let text = response.body.string ?? "error"
+            return makeDockerError(status: response.status, message: text, headers: response.headers)
+        }
+        if json["message"] != nil {
+            return response  // already Docker-compatible
+        }
+        let message = (json["reason"] as? String) ?? "error"
+        var merged = json
+        merged["message"] = message
+        let newResponse = Response(status: response.status)
+        newResponse.headers = response.headers
+        if let data = try? JSONSerialization.data(withJSONObject: merged) {
+            newResponse.headers.replaceOrAdd(name: .contentType, value: "application/json")
+            newResponse.body = .init(data: data)
+        }
+        return newResponse
+    }
+
+    static func makeDockerError(
+        status: HTTPResponseStatus,
+        message: String,
+        headers: HTTPHeaders = HTTPHeaders()
+    ) -> Response {
+        let response = Response(status: status)
+        response.headers = headers
+        response.headers.replaceOrAdd(name: .contentType, value: "application/json")
+        let payload: [String: Any] = ["message": message, "error": true, "reason": message]
+        if let data = try? JSONSerialization.data(withJSONObject: payload) {
+            response.body = .init(data: data)
+        } else {
+            response.body = .init(string: "{\"message\":\"\(message)\"}")
+        }
+        return response
+    }
+}

--- a/Sources/socktainer/Utilities/PlatformUtility.swift
+++ b/Sources/socktainer/Utilities/PlatformUtility.swift
@@ -10,6 +10,19 @@ public func currentPlatform() -> Platform {
     Platform.current
 }
 
+/// Docker's `GET /info` reports `Architecture` in the `uname -m` convention
+/// (`aarch64`, `x86_64`), not the OCI/GOARCH convention (`arm64`, `amd64`) that
+/// `Platform.current.architecture` returns. Clients that key off `/info`
+/// Architecture (e.g. MiniStack's Lambda arch detection) reject `arm64`. Map to the
+/// Docker/uname value so socktainer matches real Docker on Apple Silicon.
+public func dockerInfoArchitecture(_ ociArchitecture: String) -> String {
+    switch ociArchitecture {
+    case "arm64", "aarch64": return "aarch64"
+    case "amd64", "x86_64": return "x86_64"
+    default: return ociArchitecture
+    }
+}
+
 public func platformOrThrow(_ platformString: String) throws -> Platform {
     let trimmed = platformString.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -14,6 +14,11 @@ func configure(_ app: Application) async throws {
     // cap, yielding 413 "Payload Too Large". Raise it well above any real request.
     app.routes.defaultMaxBodySize = "64mb"
 
+    // Make error responses Docker-compatible (`{"message": ...}`) so SDKs like
+    // docker-py don't crash on their `response.json()['message']` lookup. Installed
+    // outermost so it wraps all routing/error handling. See DockerErrorMiddleware.
+    app.middleware.use(DockerErrorMiddleware(), at: .beginning)
+
     // Define app support path early since it's needed by multiple services
     let folderPath = ("\(NSHomeDirectory())/Library/Application Support/com.apple.container")
     let appleContainerAppSupportUrl = URL(fileURLWithPath: folderPath)


### PR DESCRIPTION
## Summary

Three focused Docker-API compatibility fixes so that clients using the official
`docker-py` SDK (here, [MiniStack](https://github.com/ministackorg)'s Lambda
docker-executor) work against socktainer on Apple Silicon. Each fix was found while
getting a real workload (MiniStack spawning AWS Lambda RIE containers through a
bind-mounted socket) to progress; they are independent and individually useful.

### 1. `GET /info` reports OCI arch instead of Docker's `uname` arch
`/info` returned `Architecture: "arm64"` (OCI/GOARCH), but real Docker reports the
`uname -m` value `aarch64` (and `x86_64`). Clients that key off `/info` Architecture
break on the OCI form — MiniStack's Lambda arch detection fails outright with
`Unsupported Docker Engine architecture: arm64`. Now mapped to `aarch64`/`x86_64` in
the `/info` response only (image-pull platform selection is unchanged).

### 2. Error responses lack a `message` field, crashing docker-py
Vapor renders `AbortError` as `{"error":true,"reason":...}` with no `message` key.
docker-py's `create_api_error_from_http_exception` does `response.json()['message']`
and only guards `ValueError`, so **any** error status raises `KeyError('message')` on
the client — masking the real error and escaping typed handlers like
`except ImageNotFound:`. A new outermost `DockerErrorMiddleware` ensures every error
body carries a `message` field (existing `error`/`reason` preserved).

### 3. Image-inspect 404 doesn't use Docker's "No such image" phrasing
docker-py only maps a 404 to `ImageNotFound` (vs generic `NotFound`) when the message
contains the substring `no such image`. The inspect 404 said `Image '<ref>' not found`,
so callers' `except ImageNotFound: pull()` never fired (breaking auto-pull of missing
images). Now returns Docker's exact `No such image: <ref>`.

## Impact

With all three, socktainer successfully serves docker-py: MiniStack creates Lambda
functions, pulls `public.ecr.aws/lambda/nodejs:22`, and cold-starts nested Lambda
containers through a bind-mounted socket. (A separate, unrelated limitation — `docker cp`
into a *created-but-not-started* container, where Apple `container` has no rootfs yet —
is out of scope for this PR.)

## Test plan

- [ ] `swift build -c release`
- [ ] `curl --unix-socket … /info` → `Architecture` is `aarch64` on Apple Silicon
- [ ] `curl --unix-socket … /v1.51/images/does/not:exist/json` → body contains both
      `message` and the text `No such image:`, HTTP 404
- [ ] docker-py: `client.images.get("missing:tag")` raises `ImageNotFound` (not `KeyError`)
