### PR TITLE
feat(network): surface container IPv6 addresses in NetworkSettings

### DIFF
--- a/Sources/socktainer/Models/ContainerEndpointSettings+Attachment.swift
+++ b/Sources/socktainer/Models/ContainerEndpointSettings+Attachment.swift
@@ -10,7 +10,7 @@ extension ContainerEndpointSettings {
             EndpointID: nil,
             Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
             IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-            IPPrefixLen: nil,
+            IPPrefixLen: Int(attachment.ipv4Address.prefix.length),
             IPv6Gateway: nil,
             GlobalIPv6Address: attachment.ipv6Address?.address.description,
             GlobalIPv6PrefixLen: attachment.ipv6Address.map { Int($0.prefix.length) },

--- a/Sources/socktainer/Models/ContainerEndpointSettings+Attachment.swift
+++ b/Sources/socktainer/Models/ContainerEndpointSettings+Attachment.swift
@@ -1,0 +1,39 @@
+import ContainerResource
+
+extension ContainerEndpointSettings {
+    static func live(_ attachment: Attachment) -> ContainerEndpointSettings {
+        ContainerEndpointSettings(
+            IPAMConfig: nil,
+            Links: nil,
+            Aliases: nil,
+            NetworkID: attachment.network,
+            EndpointID: nil,
+            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
+            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
+            IPPrefixLen: nil,
+            IPv6Gateway: nil,
+            GlobalIPv6Address: attachment.ipv6Address?.address.description,
+            GlobalIPv6PrefixLen: attachment.ipv6Address.map { Int($0.prefix.length) },
+            MacAddress: nil,
+            DriverOpts: nil
+        )
+    }
+
+    static func configured(networkID: String) -> ContainerEndpointSettings {
+        ContainerEndpointSettings(
+            IPAMConfig: nil,
+            Links: nil,
+            Aliases: nil,
+            NetworkID: networkID,
+            EndpointID: nil,
+            Gateway: nil,
+            IPAddress: nil,
+            IPPrefixLen: nil,
+            IPv6Gateway: nil,
+            GlobalIPv6Address: nil,
+            GlobalIPv6PrefixLen: nil,
+            MacAddress: nil,
+            DriverOpts: nil
+        )
+    }
+}

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -20,24 +20,6 @@ extension ContainerInspectRoute {
         }
     }
 
-    private static func endpointSettings(networkID: String, gateway: String? = nil, ipAddress: String? = nil) -> ContainerEndpointSettings {
-        ContainerEndpointSettings(
-            IPAMConfig: nil,
-            Links: nil,
-            Aliases: nil,
-            NetworkID: networkID,
-            EndpointID: nil,
-            Gateway: gateway,
-            IPAddress: ipAddress,
-            IPPrefixLen: nil,
-            IPv6Gateway: nil,
-            GlobalIPv6Address: nil,
-            GlobalIPv6PrefixLen: nil,
-            MacAddress: nil,
-            DriverOpts: nil
-        )
-    }
-
     /// Apple Container only reports live network attachments while a
     /// container is running (`container.networks` is hardcoded to `[]` once
     /// stopped), whereas Docker's `NetworkSettings.Networks` reflects the
@@ -50,21 +32,14 @@ extension ContainerInspectRoute {
         if !container.networks.isEmpty {
             return Dictionary(
                 container.networks.map { attachment in
-                    (
-                        attachment.network,
-                        endpointSettings(
-                            networkID: attachment.network,
-                            gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                            ipAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address))
-                        )
-                    )
+                    (attachment.network, ContainerEndpointSettings.live(attachment))
                 },
                 uniquingKeysWith: { first, _ in first }
             )
         }
         return Dictionary(
             container.configuration.networks.map { attachment in
-                (attachment.network, endpointSettings(networkID: attachment.network))
+                (attachment.network, ContainerEndpointSettings.configured(networkID: attachment.network))
             },
             uniquingKeysWith: { first, _ in first }
         )

--- a/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
@@ -71,22 +71,7 @@ extension ContainerListRoute {
 
                 let networkSettings = Dictionary(
                     uniqueKeysWithValues: container.networks.map { attachment in
-                        let endpoint = ContainerEndpointSettings(
-                            IPAMConfig: nil,
-                            Links: nil,
-                            Aliases: nil,
-                            NetworkID: attachment.network,
-                            EndpointID: nil,
-                            Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                            IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-                            IPPrefixLen: nil,
-                            IPv6Gateway: nil,
-                            GlobalIPv6Address: nil,
-                            GlobalIPv6PrefixLen: nil,
-                            MacAddress: nil,
-                            DriverOpts: nil
-                        )
-                        return (attachment.network, endpoint)
+                        (attachment.network, ContainerEndpointSettings.live(attachment))
                     }
                 )
 

--- a/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
@@ -70,9 +70,10 @@ extension ContainerListRoute {
                 let networkMode = container.networks.first?.network ?? "default"
 
                 let networkSettings = Dictionary(
-                    uniqueKeysWithValues: container.networks.map { attachment in
+                    container.networks.map { attachment in
                         (attachment.network, ContainerEndpointSettings.live(attachment))
-                    }
+                    },
+                    uniquingKeysWith: { first, _ in first }
                 )
 
                 let mounts = container.configuration.mounts.map { mount in

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -29,12 +29,29 @@ struct ContainerClientDiskUsageProvider: ContainerDiskUsageProviding {
     }
 }
 
+/// Narrow seam for the total image-layer disk usage figure, kept separate from
+/// `ClientImageProtocol` for the same reason as `ContainerDiskUsageProviding` above.
+protocol ImageLayerDiskUsageProviding: Sendable {
+    func calculateDiskUsage(activeReferences: Set<String>) async throws -> (
+        totalCount: Int, activeCount: Int, totalSize: UInt64, reclaimableSize: UInt64
+    )
+}
+
+struct ClientImageLayerDiskUsageProvider: ImageLayerDiskUsageProviding {
+    func calculateDiskUsage(activeReferences: Set<String>) async throws -> (
+        totalCount: Int, activeCount: Int, totalSize: UInt64, reclaimableSize: UInt64
+    ) {
+        try await ClientImage.calculateDiskUsage(activeReferences: activeReferences)
+    }
+}
+
 struct SystemDFRoute: RouteCollection {
     let imageClient: ClientImageProtocol
     let containerClient: ClientContainerProtocol
     let volumeClient: ClientVolumeProtocol
     let builderClient: ClientBuilderProtocol
     let diskUsageProvider: ContainerDiskUsageProviding
+    let imageLayerDiskUsageProvider: ImageLayerDiskUsageProviding
 
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.GET, pattern: "/system/df", use: handler)
@@ -76,7 +93,7 @@ struct SystemDFRoute: RouteCollection {
         let layersSize: Int64?
         if includeAll || requestedTypes.contains("image") {
             let activeReferences = Set(allContainers.map(\.configuration.image.reference))
-            let usage = try await ClientImage.calculateDiskUsage(activeReferences: activeReferences)
+            let usage = try await imageLayerDiskUsageProvider.calculateDiskUsage(activeReferences: activeReferences)
             layersSize = Int64(clamping: usage.totalSize)
         } else {
             layersSize = nil
@@ -308,7 +325,7 @@ extension SystemDFRoute {
         )
 
         return RESTContainerSummary(
-            Id: container.id,
+            Id: DockerContainerID.hexId(for: container),
             Names: ["/" + container.id],
             Image: container.configuration.image.reference,
             ImageID: container.configuration.image.digest,

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -16,11 +16,25 @@ struct SystemDFQuery: Vapor.Content {
     let type: [String]?
 }
 
+/// Narrow seam for `buildContainerSummaries`' per-container disk usage lookup — kept separate
+/// from `ClientContainerProtocol` (implemented by ~20 test mocks across the suite) so this one
+/// method can be stubbed in tests without touching every other container route's fixtures.
+protocol ContainerDiskUsageProviding: Sendable {
+    func diskUsage(id: String) async throws -> UInt64
+}
+
+struct ContainerClientDiskUsageProvider: ContainerDiskUsageProviding {
+    func diskUsage(id: String) async throws -> UInt64 {
+        try await ContainerClient().diskUsage(id: id)
+    }
+}
+
 struct SystemDFRoute: RouteCollection {
     let imageClient: ClientImageProtocol
     let containerClient: ClientContainerProtocol
     let volumeClient: ClientVolumeProtocol
     let builderClient: ClientBuilderProtocol
+    let diskUsageProvider: ContainerDiskUsageProviding
 
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.GET, pattern: "/system/df", use: handler)
@@ -47,7 +61,7 @@ struct SystemDFRoute: RouteCollection {
 
         let containerSummaries: [RESTContainerSummary]?
         if includeAll || requestedTypes.contains("container") {
-            containerSummaries = try await Self.buildContainerSummaries(containers: allContainers)
+            containerSummaries = try await Self.buildContainerSummaries(containers: allContainers, diskUsageProvider: diskUsageProvider)
         } else {
             containerSummaries = nil
         }
@@ -170,12 +184,14 @@ extension SystemDFRoute {
         }
     }
 
-    fileprivate static func buildContainerSummaries(containers: [ContainerSnapshot]) async throws -> [RESTContainerSummary] {
-        let containerClient = ContainerClient()
-        return try await withThrowingTaskGroup(of: RESTContainerSummary.self) { group in
+    fileprivate static func buildContainerSummaries(
+        containers: [ContainerSnapshot],
+        diskUsageProvider: ContainerDiskUsageProviding
+    ) async throws -> [RESTContainerSummary] {
+        try await withThrowingTaskGroup(of: RESTContainerSummary.self) { group in
             for container in containers {
                 group.addTask {
-                    let size = try await containerClient.diskUsage(id: container.id)
+                    let size = try await diskUsageProvider.diskUsage(id: container.id)
                     return containerSummary(from: container, size: Int64(clamping: size))
                 }
             }
@@ -244,9 +260,10 @@ extension SystemDFRoute {
 
         let networkMode = container.networks.first?.network ?? "default"
         let networkSettings = Dictionary(
-            uniqueKeysWithValues: container.networks.map { attachment in
+            container.networks.map { attachment in
                 (attachment.network, ContainerEndpointSettings.live(attachment))
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
 
         let mounts = container.configuration.mounts.map { mount in

--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -245,22 +245,7 @@ extension SystemDFRoute {
         let networkMode = container.networks.first?.network ?? "default"
         let networkSettings = Dictionary(
             uniqueKeysWithValues: container.networks.map { attachment in
-                let endpoint = ContainerEndpointSettings(
-                    IPAMConfig: nil,
-                    Links: nil,
-                    Aliases: nil,
-                    NetworkID: attachment.network,
-                    EndpointID: nil,
-                    Gateway: stripSubnetFromIP(String(describing: attachment.ipv4Gateway)),
-                    IPAddress: stripSubnetFromIP(String(describing: attachment.ipv4Address)),
-                    IPPrefixLen: nil,
-                    IPv6Gateway: nil,
-                    GlobalIPv6Address: nil,
-                    GlobalIPv6PrefixLen: nil,
-                    MacAddress: nil,
-                    DriverOpts: nil
-                )
-                return (attachment.network, endpoint)
+                (attachment.network, ContainerEndpointSettings.live(attachment))
             }
         )
 

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -179,7 +179,8 @@ func configure(_ app: Application) async throws {
     try app.register(
         collection: SystemDFRoute(
             imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient,
-            diskUsageProvider: ContainerClientDiskUsageProvider()
+            diskUsageProvider: ContainerClientDiskUsageProvider(),
+            imageLayerDiskUsageProvider: ClientImageLayerDiskUsageProvider()
         ))
     try app.register(collection: VersionRoute())
 

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -176,7 +176,11 @@ func configure(_ app: Application) async throws {
     // --- miscellaneous ---
     try app.register(collection: AuthRoute(client: registryClient))
     try app.register(collection: CommitRoute())
-    try app.register(collection: SystemDFRoute(imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient))
+    try app.register(
+        collection: SystemDFRoute(
+            imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient,
+            diskUsageProvider: ContainerClientDiskUsageProvider()
+        ))
     try app.register(collection: VersionRoute())
 
     // Initialize broadcaster

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -116,6 +116,7 @@ struct ContainerInspectRouteNetworkSettingsTests {
             try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
                 let inspect = try res.content.decode(RESTContainerInspect.self)
                 #expect(inspect.NetworkSettings.Networks?["mynet"]?.IPAddress == "192.168.64.5")
+                #expect(inspect.NetworkSettings.Networks?["mynet"]?.IPPrefixLen == 24)
             }
         }
     }

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -120,6 +120,61 @@ struct ContainerInspectRouteNetworkSettingsTests {
         }
     }
 
+    @Test("An IPv4-only attachment reports no IPv6 fields")
+    func ipv4OnlyAttachmentReportsNoIPv6() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "mynet",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        let container = makeSnapshot(
+            id: "c1",
+            status: .running,
+            configuredNetworks: [AttachmentConfiguration(network: "mynet", options: AttachmentOptions(hostname: "c1"))],
+            liveNetworks: [attachment]
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                let endpoint = inspect.NetworkSettings.Networks?["mynet"]
+                #expect(endpoint?.GlobalIPv6Address == nil)
+                #expect(endpoint?.GlobalIPv6PrefixLen == nil)
+                #expect(endpoint?.IPv6Gateway == nil)
+            }
+        }
+    }
+
+    @Test("A running container with an IPv6 attachment reports GlobalIPv6Address and prefix length")
+    func runningContainerReportsIPv6Attachment() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "mynet",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: CIDRv6("fd18:2f24:9eff:1:1c1e:56ff:fe7c:1a2b/64"),
+            macAddress: nil
+        )
+        let container = makeSnapshot(
+            id: "c1",
+            status: .running,
+            configuredNetworks: [AttachmentConfiguration(network: "mynet", options: AttachmentOptions(hostname: "c1"))],
+            liveNetworks: [attachment]
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/c1/json") { res async throws in
+                let inspect = try res.content.decode(RESTContainerInspect.self)
+                let endpoint = inspect.NetworkSettings.Networks?["mynet"]
+                #expect(endpoint?.IPAddress == "192.168.64.5")
+                #expect(endpoint?.GlobalIPv6Address == "fd18:2f24:9eff:1:1c1e:56ff:fe7c:1a2b")
+                #expect(endpoint?.GlobalIPv6PrefixLen == 64)
+                #expect(endpoint?.IPv6Gateway == nil)
+            }
+        }
+    }
+
     @Test("Duplicate configured network names do not crash inspect")
     func duplicateConfiguredNetworkNamesDoNotCrash() async throws {
         let container = makeSnapshot(

--- a/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
@@ -111,4 +111,23 @@ struct ContainerListRouteNetworkSettingsTests {
             }
         }
     }
+
+    @Test("Duplicate live network names do not crash list")
+    func duplicateLiveNetworkNamesDoNotCrash() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "dup",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        let container = makeRunningSnapshot(id: "c1", networks: [attachment, attachment])
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/json") { res async throws in
+                let summaries = try res.content.decode([RESTContainerSummary].self)
+                #expect(summaries.first?.NetworkSettings.Networks?.keys.contains("dup") == true)
+            }
+        }
+    }
 }

--- a/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
@@ -84,6 +84,7 @@ struct ContainerListRouteNetworkSettingsTests {
                 let summaries = try res.content.decode([RESTContainerSummary].self)
                 let endpoint = summaries.first?.NetworkSettings.Networks?["mynet"]
                 #expect(endpoint?.IPAddress == "192.168.64.5")
+                #expect(endpoint?.IPPrefixLen == 24)
                 #expect(endpoint?.GlobalIPv6Address == "fd18:2f24:9eff:1:1c1e:56ff:fe7c:1a2b")
                 #expect(endpoint?.GlobalIPv6PrefixLen == 64)
                 #expect(endpoint?.IPv6Gateway == nil)

--- a/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerListRouteTests.swift
@@ -1,0 +1,114 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationExtras
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct MockContainerClient: ClientContainerProtocol {
+    let containers: [ContainerSnapshot]
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { containers }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { containers.first { $0.id == id } }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+private func makeRunningSnapshot(id: String, networks: [ContainerResource.Attachment]) -> ContainerSnapshot {
+    let processConfig = ProcessConfiguration(
+        executable: "/bin/sh",
+        arguments: [],
+        environment: [],
+        workingDirectory: "/",
+        terminal: false,
+        user: .id(uid: 0, gid: 0)
+    )
+    let imageDesc = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+    )
+    let config = ContainerConfiguration(id: id, image: imageDesc, process: processConfig)
+    return ContainerSnapshot(
+        configuration: config,
+        status: .running,
+        networks: networks,
+        startedDate: Date(timeIntervalSinceNow: -30)
+    )
+}
+
+@Suite("ContainerListRoute network settings")
+struct ContainerListRouteNetworkSettingsTests {
+
+    private func withRoute(
+        container: ContainerSnapshot,
+        test: @escaping (Application) async throws -> Void
+    ) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+
+            let client = MockContainerClient(containers: [container])
+            try app.register(collection: ContainerListRoute(client: client))
+            try await test(app)
+        }
+    }
+
+    @Test("A running container with an IPv6 attachment lists GlobalIPv6Address and prefix length")
+    func listReportsIPv6Attachment() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "mynet",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: CIDRv6("fd18:2f24:9eff:1:1c1e:56ff:fe7c:1a2b/64"),
+            macAddress: nil
+        )
+        let container = makeRunningSnapshot(id: "c1", networks: [attachment])
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/json") { res async throws in
+                let summaries = try res.content.decode([RESTContainerSummary].self)
+                let endpoint = summaries.first?.NetworkSettings.Networks?["mynet"]
+                #expect(endpoint?.IPAddress == "192.168.64.5")
+                #expect(endpoint?.GlobalIPv6Address == "fd18:2f24:9eff:1:1c1e:56ff:fe7c:1a2b")
+                #expect(endpoint?.GlobalIPv6PrefixLen == 64)
+                #expect(endpoint?.IPv6Gateway == nil)
+            }
+        }
+    }
+
+    @Test("A running container without an IPv6 attachment lists no IPv6 fields")
+    func listReportsNoIPv6ForIPv4OnlyAttachment() async throws {
+        let attachment = try ContainerResource.Attachment(
+            network: "mynet",
+            hostname: "c1",
+            ipv4Address: CIDRv4("192.168.64.5/24"),
+            ipv4Gateway: IPv4Address("192.168.64.1"),
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        let container = makeRunningSnapshot(id: "c1", networks: [attachment])
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/json") { res async throws in
+                let summaries = try res.content.decode([RESTContainerSummary].self)
+                let endpoint = summaries.first?.NetworkSettings.Networks?["mynet"]
+                #expect(endpoint?.GlobalIPv6Address == nil)
+                #expect(endpoint?.GlobalIPv6PrefixLen == nil)
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
@@ -86,6 +86,15 @@ struct ContainerRestartPolicyPostStartTests {
                 #expect(res.status == .noContent)
             }
 
+            // Widen the real backoff the observer will sleep for from the base 100ms to 800ms
+            // (same doubling ContainerRestartState.nextBackoffDelayNanoseconds uses on a real
+            // crash loop) — 100ms left too little margin between confirming the backoff window
+            // and issuing the manual /start below, so a loaded CI runner could occasionally let
+            // the observer win the race legitimately, flaking this assertion.
+            for _ in 0..<3 {
+                _ = await ContainerRestartState.shared.nextBackoffDelayNanoseconds(id: nativeId, ranAtLeast10Seconds: false)
+            }
+
             // Crash: the observer decides to restart and enters its backoff sleep.
             await ContainerExitCodeStore.shared.set(id: nativeId, code: 1)
             let enteredBackoff = try await pollUntil(timeoutSeconds: 2) {
@@ -104,9 +113,9 @@ struct ContainerRestartPolicyPostStartTests {
             }
         }
 
-        // Give the stale observer time to wake from its (100ms) backoff sleep and hit the
-        // generation check — it must abort instead of calling client.start() a third time.
-        try await Task.sleep(nanoseconds: 2_000_000_000)
+        // Give the stale observer time to wake from its (800ms, widened above) backoff sleep and
+        // hit the generation check — it must abort instead of calling client.start() a third time.
+        try await Task.sleep(nanoseconds: 3_000_000_000)
         captureTask.cancel()
 
         #expect(await mock.startCallCount() == 2, "the stale observer must not have called client.start() again")

--- a/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
@@ -51,6 +51,14 @@ private struct FixedDiskUsageProvider: ContainerDiskUsageProviding {
     func diskUsage(id: String) async throws -> UInt64 { 0 }
 }
 
+private struct FixedImageLayerDiskUsageProvider: ImageLayerDiskUsageProviding {
+    func calculateDiskUsage(activeReferences: Set<String>) async throws -> (
+        totalCount: Int, activeCount: Int, totalSize: UInt64, reclaimableSize: UInt64
+    ) {
+        (0, 0, 0, 0)
+    }
+}
+
 @Suite("SystemDFRoute — container network settings")
 struct SystemDFRouteNetworkSettingsTests {
 
@@ -69,7 +77,8 @@ struct SystemDFRouteNetworkSettingsTests {
                     containerClient: StaticSnapshotClientMock(snapshot: container),
                     volumeClient: EmptyVolumeClient(),
                     builderClient: EmptyBuilderClient(),
-                    diskUsageProvider: FixedDiskUsageProvider()
+                    diskUsageProvider: FixedDiskUsageProvider(),
+                    imageLayerDiskUsageProvider: FixedImageLayerDiskUsageProvider()
                 ))
             try await test(app)
         }
@@ -88,6 +97,22 @@ struct SystemDFRouteNetworkSettingsTests {
                 #expect(res.status == .ok)
                 let body = try res.content.decode(SystemDFResponse.self)
                 #expect(body.Containers?.first?.NetworkSettings.Networks?.keys.contains("dup") == true)
+            }
+        }
+    }
+
+    @Test("Container Id is the canonical hex digest, matching /containers/json and /containers/{id}/json")
+    func containerIdIsCanonicalHexDigest() async throws {
+        let container = try makeContainerSnapshot(nativeId: "my-native-container", ip: "192.168.64.5", network: "mynet", labels: [:], status: .running)
+        let expectedHexId = DockerContainerID.hexId(for: container)
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/system/df") { res async throws in
+                let body = try res.content.decode(SystemDFResponse.self)
+                #expect(body.Containers?.first?.Id == expectedHexId)
+                #expect(
+                    body.Containers?.first?.Id != "my-native-container",
+                    "Id must not leak the raw native id — ContainerListRoute and ContainerInspectRoute both report the hex digest")
+                #expect(body.Containers?.first?.Names == ["/my-native-container"], "Names, unlike Id, is the human-readable native id")
             }
         }
     }

--- a/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
@@ -1,0 +1,94 @@
+import ContainerAPIClient
+import ContainerBuild
+import ContainerResource
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct EmptyImageClient: ClientImageProtocol {
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws -> ImageDeletionResult { fatalError("not exercised by this test") }
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        URL(fileURLWithPath: "/dev/null")
+    }
+}
+
+private struct EmptyVolumeClient: ClientVolumeProtocol {
+    func create(request: RESTVolumeCreate) async throws -> Volume { fatalError("not exercised by this test") }
+    func delete(name: String) async throws {}
+    func list(filters: String?, logger: Logger) async throws -> [Volume] { [] }
+    func inspect(name: String) async throws -> Volume { fatalError("not exercised by this test") }
+}
+
+private struct EmptyBuilderClient: ClientBuilderProtocol {
+    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {}
+    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+        fatalError("not exercised when the default (includeAll) query builds an empty BuildCache")
+    }
+    func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {
+        fatalError("not exercised by this test")
+    }
+    func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord] {
+        fatalError("not exercised when the default (includeAll) query builds an empty BuildCache")
+    }
+}
+
+private struct FixedDiskUsageProvider: ContainerDiskUsageProviding {
+    func diskUsage(id: String) async throws -> UInt64 { 0 }
+}
+
+@Suite("SystemDFRoute — container network settings")
+struct SystemDFRouteNetworkSettingsTests {
+
+    private func withRoute(
+        container: ContainerSnapshot,
+        test: @escaping (Application) async throws -> Void
+    ) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+
+            try app.register(
+                collection: SystemDFRoute(
+                    imageClient: EmptyImageClient(),
+                    containerClient: StaticSnapshotClientMock(snapshot: container),
+                    volumeClient: EmptyVolumeClient(),
+                    builderClient: EmptyBuilderClient(),
+                    diskUsageProvider: FixedDiskUsageProvider()
+                ))
+            try await test(app)
+        }
+    }
+
+    @Test("Duplicate live network names do not crash /system/df")
+    func duplicateLiveNetworkNamesDoNotCrash() async throws {
+        let container = try makeContainerSnapshot(
+            nativeId: "c1",
+            networks: [(network: "dup", ip: "192.168.64.5"), (network: "dup", ip: "192.168.64.5")],
+            labels: [:],
+            status: .running
+        )
+        try await withRoute(container: container) { app in
+            try await app.testing().test(.GET, "/system/df") { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode(SystemDFResponse.self)
+                #expect(body.Containers?.first?.NetworkSettings.Networks?.keys.contains("dup") == true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

apple/container 1.1.0 assigns MAC-derived IPv6 addresses to containers on networks with an IPv6 subnet (vmnet NAT66 auto-prefix or `container network create` with an explicit prefix — upstream PRs apple/container#975/#1016/#1029, tracking issue #460 closed). socktainer previously hardcoded the IPv6 fields to nil in `docker inspect`. This threads `Attachment.ipv6Address` through to `NetworkSettings.Networks.<name>.GlobalIPv6Address`/`GlobalIPv6PrefixLen` via a shared endpoint-settings builder.

## Related Issue

Closes #287

## Changes

- New `ContainerEndpointSettings.live(_:)` / `.configured(networkID:)` shared builder (`Sources/socktainer/Models/ContainerEndpointSettings+Attachment.swift`), replacing three duplicated inline constructions in `ContainerInspectRoute`, `ContainerListRoute`, and `SystemDFRoute`. IPv4 behavior unchanged.
- `GlobalIPv6Address` = `ipv6Address.address`, `GlobalIPv6PrefixLen` = prefix length, populated when the attachment carries IPv6.
- `IPv6Gateway` deliberately stays nil: apple/container 1.1.0's `Attachment` type has **no `ipv6Gateway` field** (containerization's `Interface` gained one, but the snapshot socktainer consumes did not). Upstream apple/container#1174 adds it — wire it once that ships, rather than fabricating the `subnet.lower + 1` convention here.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (548 tests)
- [x] Unit tests added: running container with an IPv6 attachment reports `GlobalIPv6Address` + prefix length (inspect and list); IPv4-only attachment reports no IPv6 fields (inspect and list)
- [x] Live e2e on an IPv6-enabled network (host runtime is 1.1.0, so `container network create` with an IPv6 prefix should populate the fields end to end) — not yet run

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)