### PR TITLE
fix(containers): apply the image's default USER when none is requested

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -205,13 +205,6 @@ extension ContainerCreateRoute {
 
             let imageConfig = try await img.config(for: requestedPlatform).config
 
-            let defaultUser: ProcessConfiguration.User = {
-                if let u = imageConfig?.user {
-                    return .raw(userString: u)
-                }
-                return .id(uid: 0, gid: 0)
-            }()
-
             let workingDirectory = imageConfig?.workingDir ?? "/"
 
             let imageConfigEnvironment = imageConfig?.env ?? []
@@ -308,13 +301,7 @@ extension ContainerCreateRoute {
             // Use working directory from request if provided and not empty, otherwise from image config
             let finalWorkingDirectory = (body.WorkingDir?.isEmpty == false) ? body.WorkingDir! : workingDirectory
 
-            // Handle user from request if provided
-            let finalUser: ProcessConfiguration.User = {
-                if let requestUser = body.User {
-                    return .raw(userString: requestUser)
-                }
-                return defaultUser
-            }()
+            let finalUser = ContainerCreateRoute.resolveUser(requestUser: body.User, imageUser: imageConfig?.user)
 
             // Ensure we have a valid executable
             guard let executable = commandLine.first, !executable.isEmpty else {
@@ -715,6 +702,19 @@ extension ContainerCreateRoute {
         if let net = endpointsConfigKeys.first(where: { !$0.isEmpty && !reservedModes.contains($0) }) { return net }
         if let mode = networkMode, !mode.isEmpty, !reservedModes.contains(mode) { return mode }
         return nil
+    }
+
+    /// Resolves the process user, preferring an explicit request override over the image
+    /// default. The Docker CLI always sends a `User` field — an empty string means
+    /// "not set", not "run as the empty-string user" — so it's treated the same as `nil`.
+    static func resolveUser(requestUser: String?, imageUser: String?) -> ProcessConfiguration.User {
+        if let requestUser, !requestUser.isEmpty {
+            return .raw(userString: requestUser)
+        }
+        if let imageUser, !imageUser.isEmpty {
+            return .raw(userString: imageUser)
+        }
+        return .id(uid: 0, gid: 0)
     }
 
     /// Mirrors moby's ShmSize handling: a positive request is used verbatim; 0 or omitted

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -289,6 +289,40 @@ struct ShmSizeBytesTests {
     }
 }
 
+@Suite("ContainerCreateRoute.resolveUser")
+struct ResolveUserTests {
+
+    @Test("An empty request User falls back to the image default, not root")
+    func emptyRequestUserFallsBackToImageDefault() {
+        let user = ContainerCreateRoute.resolveUser(requestUser: "", imageUser: "curl_user")
+        #expect(user == .raw(userString: "curl_user"))
+    }
+
+    @Test("A nil request User falls back to the image default")
+    func nilRequestUserFallsBackToImageDefault() {
+        let user = ContainerCreateRoute.resolveUser(requestUser: nil, imageUser: "curl_user")
+        #expect(user == .raw(userString: "curl_user"))
+    }
+
+    @Test("An explicit request User overrides the image default")
+    func explicitRequestUserOverridesImageDefault() {
+        let user = ContainerCreateRoute.resolveUser(requestUser: "1000:1000", imageUser: "curl_user")
+        #expect(user == .raw(userString: "1000:1000"))
+    }
+
+    @Test("No request User and no image default resolves to root")
+    func noUserAnywhereResolvesToRoot() {
+        let user = ContainerCreateRoute.resolveUser(requestUser: nil, imageUser: nil)
+        #expect(user == .id(uid: 0, gid: 0))
+    }
+
+    @Test("An empty image User is treated the same as no image default")
+    func emptyImageUserResolvesToRoot() {
+        let user = ContainerCreateRoute.resolveUser(requestUser: nil, imageUser: "")
+        #expect(user == .id(uid: 0, gid: 0))
+    }
+}
+
 @Suite("ContainerCreateRoute — ShmSize validation")
 struct ShmSizeValidationTests {
 


### PR DESCRIPTION
## Summary

Docker CLI always sends a `User` field in the create payload — an empty string when `--user` isn't passed, not an omitted key. `ContainerCreateRoute` treated any non-nil `body.User` as an explicit override, so the empty string silently discarded the image's own `USER` and the container resolved to root regardless of what the image declared.

## Related Issue

Closes #297

## Changes

- Extracted user resolution into a static, unit-testable `resolveUser(requestUser:imageUser:)` (matching the file's existing pattern for `shmSizeBytes`/`firstNamedNetwork`), treating an empty request or image user the same as absent — same class of guard the code already has for `StopSignal`.
- Named-user resolution inside the guest (`ContainerizationOS.User.getExecUser`, `RuntimeService`) and the attach-bootstrap path were both verified correct during investigation — the bug was purely in this one empty-string check.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (549 tests)
- [x] Unit tests added: empty request `User` falls back to image default (the regression case); nil request `User` falls back to image default; explicit request `User` overrides image default; no user anywhere resolves to root; empty image `User` treated as absent
- [x] Manual testing: `curlimages/curl` (image sets `USER curl_user`) now runs as `uid=100(curl_user)` with no `--user` flag; `--user 1000:1000` still correctly overrides to `uid=1000`

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)