### PR TITLE
fix(containers): honor limit and sort container list newest-first

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerListRoute.swift
@@ -4,6 +4,7 @@ import Vapor
 
 struct ContainerListQuery: Content {
     var all: Bool?
+    var limit: Int?
     var filters: String?
 }
 
@@ -19,7 +20,11 @@ extension ContainerListRoute {
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> [RESTContainerSummary] {
         { req in
             let query = try req.query.decode(ContainerListQuery.self)
-            let showAll = query.all ?? false
+            let limit = query.limit ?? 0
+            // Docker Engine API: limit returns "this number of most recently
+            // created containers, including non-running ones", so a positive
+            // limit implies the all behavior.
+            let showAll = (query.all ?? false) || limit > 0
 
             let parsedFilters = try DockerContainerFilterUtility.parseContainerFilters(filtersParam: query.filters, logger: req.logger)
             let containers = try await client.list(showAll: showAll, filters: parsedFilters)
@@ -39,8 +44,20 @@ extension ContainerListRoute {
                 filteredContainers.append(container)
             }
 
+            // moby returns list responses newest-first regardless of limit.
+            // Creation dates are resolved once per container here (the resolver
+            // touches the filesystem) and reused for the summary's Created field.
+            var decorated = filteredContainers.map {
+                (container: $0, created: AppleContainerTimestampResolver.containerCreationDate($0))
+            }
+            decorated.sort { ($0.created ?? .distantPast) > ($1.created ?? .distantPast) }
+            // A positive limit keeps only the N most recently created containers.
+            if limit > 0 {
+                decorated = Array(decorated.prefix(limit))
+            }
+
             var summaries: [RESTContainerSummary] = []
-            for container in filteredContainers {
+            for (container, createdDate) in decorated {
                 let ports = container.configuration.publishedPorts.map { port in
                     ContainerPort(
                         IP: port.hostAddress.description,
@@ -112,9 +129,7 @@ extension ContainerListRoute {
                     )
                 }
 
-                let createdTimestamp = AppleContainerTimestampResolver.unixTimestampSeconds(
-                    AppleContainerTimestampResolver.containerCreationDate(container)
-                )
+                let createdTimestamp = AppleContainerTimestampResolver.unixTimestampSeconds(createdDate)
 
                 let mobyState = container.status.mobyState
                 // Build human-readable status matching Docker's "Up X seconds/minutes/hours" format

--- a/Tests/socktainerTests/Routes/ContainerListLimitTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerListLimitTests.swift
@@ -1,0 +1,151 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// GET /containers/json must honor the `limit` query parameter: return the N
+/// most recently created containers, newest first, including non-running ones
+/// (a positive limit implies `all`), per the Docker Engine API.
+@Suite("ContainerListRoute — limit query parameter")
+struct ContainerListLimitTests {
+
+    @Test("limit=1 returns only the most recently created container")
+    func limitOneReturnsNewest() async throws {
+        let newest = Self.snapshot(id: "newest", createdAt: 300)
+        let mock = ListMock(containers: [
+            Self.snapshot(id: "oldest", createdAt: 100),
+            newest,
+            Self.snapshot(id: "middle", createdAt: 200),
+        ])
+
+        let summaries = try await Self.list(mock: mock, path: "/v1.51/containers/json?limit=1")
+        #expect(summaries.map(\.Id) == [DockerContainerID.hexId(for: newest)])
+    }
+
+    @Test("limit=2 returns the two newest containers, newest first")
+    func limitTwoReturnsNewestPairOrdered() async throws {
+        let newest = Self.snapshot(id: "newest", createdAt: 300)
+        let middle = Self.snapshot(id: "middle", createdAt: 200)
+        let mock = ListMock(containers: [
+            Self.snapshot(id: "oldest", createdAt: 100),
+            newest,
+            middle,
+        ])
+
+        let summaries = try await Self.list(mock: mock, path: "/v1.51/containers/json?limit=2")
+        #expect(summaries.map(\.Id) == [DockerContainerID.hexId(for: newest), DockerContainerID.hexId(for: middle)])
+    }
+
+    @Test("A positive limit implies all=true so stopped containers are included")
+    func limitImpliesAll() async throws {
+        let stoppedNew = Self.snapshot(id: "stopped-new", createdAt: 300, status: .stopped)
+        let mock = ListMock(containers: [
+            stoppedNew,
+            Self.snapshot(id: "running-old", createdAt: 100),
+        ])
+
+        let summaries = try await Self.list(mock: mock, path: "/v1.51/containers/json?limit=1")
+        #expect(summaries.map(\.Id) == [DockerContainerID.hexId(for: stoppedNew)])
+        #expect(await mock.log.showAllValues == [true], "limit must request non-running containers from the client")
+    }
+
+    @Test("Without limit the full list is returned, newest first")
+    func noLimitReturnsAllNewestFirst() async throws {
+        let older = Self.snapshot(id: "older", createdAt: 100)
+        let newer = Self.snapshot(id: "newer", createdAt: 200)
+        let mock = ListMock(containers: [older, newer])
+
+        let summaries = try await Self.list(mock: mock, path: "/v1.51/containers/json?all=1")
+        #expect(summaries.map(\.Id) == [DockerContainerID.hexId(for: newer), DockerContainerID.hexId(for: older)])
+    }
+
+    @Test("limit=0 and negative limit neither truncate nor imply all", arguments: ["limit=0", "limit=-1"])
+    func nonPositiveLimitIsIgnored(limitParam: String) async throws {
+        let mock = ListMock(containers: [
+            Self.snapshot(id: "a", createdAt: 100),
+            Self.snapshot(id: "b", createdAt: 200),
+        ])
+
+        let summaries = try await Self.list(mock: mock, path: "/v1.51/containers/json?\(limitParam)")
+        #expect(summaries.count == 2)
+        #expect(await mock.log.showAllValues == [false], "A non-positive limit must not imply all")
+    }
+
+    // MARK: - Helpers
+
+    private static func list(mock: ListMock, path: String) async throws -> [RESTContainerSummary] {
+        var result: [RESTContainerSummary] = []
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: ContainerListRoute(client: mock))
+
+            try await app.testing().test(.GET, path) { res async throws in
+                #expect(res.status == .ok)
+                result = try JSONDecoder().decode([RESTContainerSummary].self, from: Data(buffer: res.body))
+            }
+        }
+        return result
+    }
+
+    /// Creation dates are injected via the legacy creation-timestamp label,
+    /// which AppleContainerTimestampResolver falls back to when no container
+    /// bundle exists on disk (as is the case for these synthetic ids).
+    private static func snapshot(id shortId: String, createdAt: TimeInterval, status: RuntimeStatus = .running) -> ContainerSnapshot {
+        // Prefix the id so no real container bundle can exist on the test
+        // machine — the resolver would prefer the bundle's filesystem date
+        // over the injected label.
+        let id = "socktainer-test-limit-\(shortId)"
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        var config = ContainerConfiguration(id: id, image: img, process: proc)
+        config.labels = [AppleContainerTimestampResolver.legacyCreationTimestampLabel: String(createdAt)]
+        return ContainerSnapshot(configuration: config, status: status, networks: [])
+    }
+}
+
+// MARK: - Mocks
+
+private actor ShowAllLog {
+    var showAllValues: [Bool] = []
+    func record(_ value: Bool) { showAllValues.append(value) }
+}
+
+/// Mock that returns a fixed container list and records the showAll argument.
+private struct ListMock: ClientContainerProtocol {
+    let containers: [ContainerSnapshot]
+    let log = ShowAllLog()
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] {
+        await log.record(showAll)
+        return containers
+    }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { containers.first { $0.id == id } }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## Summary

`GET /containers/json` ignored the `limit` query parameter: `docker ps -n 1` returned every container instead of the single most recently created one.

Per the Docker Engine API, `limit` returns "this number of most recently created containers, including non-running ones" — so this change makes a positive `limit` imply the `all` behavior and truncates the (filtered) list to N. Since moby sorts every list response newest-first (not just limited ones), the sort is applied unconditionally, so `docker ps` ordering now matches Docker too. `limit=0` and negative values are ignored exactly as moby ignores them (docker CLI never sends its `--last` default of -1). Creation dates are resolved once per container and reused for the summary's `Created` field, replacing a redundant second resolution that existed before this change.

## Related Issue

None — found while auditing container routes for Docker Engine API parity.

## Reproduction

Before:

```console
$ docker run -d --name c1 alpine sleep 300
$ docker run -d --name c2 alpine sleep 300
$ docker run -d --name c3 alpine sleep 300
$ docker ps -n 1
CONTAINER ID   IMAGE    ...   NAMES
...            alpine   ...   c1
...            alpine   ...   c2
...            alpine   ...   c3     # all three — limit ignored
```

After:

```console
$ docker ps -n 1
CONTAINER ID   IMAGE    ...   NAMES
...            alpine   ...   c3     # only the most recently created
```

## Changes

- `ContainerListQuery` gains `limit: Int?`; a positive value implies `all=true` (limit must include non-running containers)
- The filtered container list is now always sorted newest-first by creation date (matching moby's unconditional ordering), then truncated to `limit` when positive
- Creation dates are resolved once during the sort and reused when building each summary's `Created` field, instead of being resolved a second time
- New unit tests in `Tests/socktainerTests/Routes/ContainerListLimitTests.swift`: `limit=1`/`limit=2` return the newest container(s) in order; a stopped newest container is still returned with `limit=1` and the mock confirms the client was queried with `showAll=true`; no `limit` returns the full list, newest first; `limit=0`/`limit=-1` neither truncate nor imply `all`. The limit-truncation tests fail against the previous implementation (full list returned), confirming they reproduce the bug.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))