### PR TITLE
fix(networks): OR multiple values for the same network filter key

### DIFF
--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -70,6 +70,15 @@ struct ClientNetworkService: ClientNetworkProtocol {
             }
         }
 
+        return Self.applyFilters(allNetworks, filters: filters, logger: logger)
+    }
+
+    /// Applies Docker network list/prune filters. Multiple values for the same
+    /// key OR together (a network matches if it matches any value); different
+    /// keys AND together — the same OR/AND combination moby's filters.Args
+    /// implements. `label` is the exception: every label filter must match,
+    /// as in moby.
+    static func applyFilters(_ allNetworks: [RESTNetworkSummary], filters: String?, logger: Logger) -> [RESTNetworkSummary] {
         guard let filters = filters, let data = filters.data(using: .utf8) else { return allNetworks }
         guard let filtersDict = try? JSONDecoder().decode([String: [String]].self, from: data) else { return allNetworks }
         // If filtersDict contains only unknown keys, return []
@@ -87,11 +96,15 @@ struct ClientNetworkService: ClientNetworkProtocol {
                     excludedReason = "dangling mismatch"
                 }
             }
-            if let driverArr = filtersDict["driver"], let driver = driverArr.first {
-                if network.Driver.caseInsensitiveCompare(driver) != ComparisonResult.orderedSame { excludedReason = "driver mismatch" }
+            if let driverArr = filtersDict["driver"], !driverArr.isEmpty {
+                if !driverArr.contains(where: { network.Driver.caseInsensitiveCompare($0) == .orderedSame }) {
+                    excludedReason = "driver mismatch"
+                }
             }
-            if let idArr = filtersDict["id"], let id = idArr.first {
-                if !network.Id.localizedCaseInsensitiveContains(id) { excludedReason = "id mismatch" }
+            if let idArr = filtersDict["id"], !idArr.isEmpty {
+                if !idArr.contains(where: { network.Id.localizedCaseInsensitiveContains($0) }) {
+                    excludedReason = "id mismatch"
+                }
             }
             if let labels = filtersDict["label"] {
                 for label in labels {
@@ -109,16 +122,21 @@ struct ClientNetworkService: ClientNetworkProtocol {
                     }
                 }
             }
-            if let nameArr = filtersDict["name"], let name = nameArr.first {
-                if !network.Name.localizedCaseInsensitiveContains(name) { excludedReason = "name mismatch" }
+            if let nameArr = filtersDict["name"], !nameArr.isEmpty {
+                if !nameArr.contains(where: { network.Name.localizedCaseInsensitiveContains($0) }) {
+                    excludedReason = "name mismatch"
+                }
             }
-            if let scopeArr = filtersDict["scope"], let scope = scopeArr.first {
-                if !network.Scope.localizedCaseInsensitiveContains(scope) { excludedReason = "scope mismatch" }
+            if let scopeArr = filtersDict["scope"], !scopeArr.isEmpty {
+                if !scopeArr.contains(where: { network.Scope.localizedCaseInsensitiveContains($0) }) {
+                    excludedReason = "scope mismatch"
+                }
             }
-            if let typeArr = filtersDict["type"], let type = typeArr.first {
+            if let typeArr = filtersDict["type"], !typeArr.isEmpty {
                 let isCustom = network.Driver != "bridge" && network.Driver != "host" && network.Driver != "null"
-                if type == "custom" && !isCustom { excludedReason = "type custom mismatch" }
-                if type == "builtin" && isCustom { excludedReason = "type builtin mismatch" }
+                if !typeArr.contains(where: { ($0 == "custom" && isCustom) || ($0 == "builtin" && !isCustom) }) {
+                    excludedReason = "type mismatch"
+                }
             }
             if let reason = excludedReason {
                 logger.debug("Excluding network \(network.Name) (ID: \(network.Id)) due to: \(reason)")

--- a/Sources/socktainer/Utilities/DockerFilterUtility.swift
+++ b/Sources/socktainer/Utilities/DockerFilterUtility.swift
@@ -12,8 +12,11 @@ struct DockerNetworkFilterUtility {
             if let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
                 filters = decoded
 
-                // Validate keys
-                let allowedKeys: Set<String> = ["name", "id", "label", "dangling"]
+                // Validate keys — the full set moby accepts for network list
+                // (docker network ls -f): dangling, driver, id, label, name,
+                // scope, type. Must stay in sync with the knownKeys handled by
+                // ClientNetworkService.applyFilters.
+                let allowedKeys: Set<String> = ["dangling", "driver", "id", "label", "name", "scope", "type"]
                 let filterKeys = Set(filters.keys)
                 if !filterKeys.isSubset(of: allowedKeys) {
                     logger.warning("Invalid filter key(s) found: \(filterKeys.subtracting(allowedKeys))")

--- a/Tests/socktainerTests/Network/NetworkFilterOrSemanticsTests.swift
+++ b/Tests/socktainerTests/Network/NetworkFilterOrSemanticsTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Logging
+import Testing
+
+@testable import socktainer
+
+/// Docker filter semantics: multiple values for the same filter key OR
+/// together (a network matches if it matches any value); different keys AND
+/// together. The previous implementation honored only the first value of
+/// name/id/driver/scope/type, silently dropping the rest — so
+/// `docker network ls -f name=a -f name=b` returned only `a`.
+@Suite("ClientNetworkService.applyFilters — OR semantics for repeated keys")
+struct NetworkFilterOrSemanticsTests {
+
+    private let logger = Logger(label: "test")
+
+    @Test("Two name values return networks matching either name")
+    func nameFilterOrsValues() {
+        let networks = [Self.network(name: "alpha"), Self.network(name: "beta"), Self.network(name: "gamma")]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"name":["alpha","beta"]}"#, logger: logger)
+        #expect(result.map(\.Name).sorted() == ["alpha", "beta"])
+    }
+
+    @Test("Two id values return networks matching either id")
+    func idFilterOrsValues() {
+        let networks = [Self.network(id: "id-one"), Self.network(id: "id-two"), Self.network(id: "id-three")]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"id":["id-one","id-two"]}"#, logger: logger)
+        #expect(result.map(\.Id).sorted() == ["id-one", "id-two"])
+    }
+
+    @Test("Two driver values return networks matching either driver")
+    func driverFilterOrsValues() {
+        let networks = [Self.network(name: "n1", driver: "nat"), Self.network(name: "n2", driver: "bridge"), Self.network(name: "n3", driver: "host")]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"driver":["nat","bridge"]}"#, logger: logger)
+        #expect(result.map(\.Name).sorted() == ["n1", "n2"])
+    }
+
+    @Test("type=custom plus type=builtin matches every network")
+    func typeFilterOrsValues() {
+        let networks = [Self.network(name: "custom-net", driver: "nat"), Self.network(name: "builtin-net", driver: "bridge")]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"type":["custom","builtin"]}"#, logger: logger)
+        #expect(result.count == 2)
+    }
+
+    @Test("Different keys still AND together")
+    func differentKeysStillAnd() {
+        let networks = [
+            Self.network(name: "alpha", driver: "nat"),
+            Self.network(name: "alpha-bridge", driver: "bridge"),
+            Self.network(name: "beta", driver: "nat"),
+        ]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"name":["alpha"],"driver":["nat"]}"#, logger: logger)
+        #expect(result.map(\.Name) == ["alpha"])
+    }
+
+    @Test("Single-value filters behave as before")
+    func singleValueUnchanged() {
+        let networks = [Self.network(name: "alpha"), Self.network(name: "beta")]
+        let result = ClientNetworkService.applyFilters(networks, filters: #"{"name":["alpha"]}"#, logger: logger)
+        #expect(result.map(\.Name) == ["alpha"])
+    }
+
+    @Test("Route-level parser accepts every moby network-ls filter key")
+    func parserAcceptsAllMobyKeys() throws {
+        // driver/scope/type were rejected with 400 before, so the OR fix for
+        // those keys was unreachable through the HTTP routes.
+        let filters = #"{"driver":["nat"],"scope":["local"],"type":["custom"],"name":["n"],"id":["i"],"label":["k=v"],"dangling":["true"]}"#
+        let parsed = try DockerNetworkFilterUtility.parseNetworkFilters(filtersParam: filters, defaultDangling: false, logger: logger)
+        #expect(Set(parsed.keys) == ["dangling", "driver", "id", "label", "name", "scope", "type"])
+    }
+
+    @Test("Route-level parser still rejects unknown filter keys")
+    func parserRejectsUnknownKeys() {
+        #expect(throws: (any Error).self) {
+            try DockerNetworkFilterUtility.parseNetworkFilters(filtersParam: #"{"bogus":["x"]}"#, defaultDangling: false, logger: logger)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func network(name: String = "net", id: String = "net-id", driver: String = "nat") -> RESTNetworkSummary {
+        RESTNetworkSummary(
+            Name: name, Id: id, Created: "", Scope: "local", Driver: driver,
+            EnableIPv4: true, EnableIPv6: false, Internal: false, Attachable: false, Ingress: false,
+            IPAM: NetworkIPAM(Driver: "", Config: []), Options: [:], Containers: nil,
+            ConfigFrom: nil, Labels: [:], Subnet: nil, Gateway: nil)
+    }
+}


### PR DESCRIPTION
## Summary

The network list/prune filters honored only the first value of `name`, `id`, `driver`, `scope`, and `type`, silently dropping the rest. Docker's filter semantics OR multiple values for the same key (a network matches if it matches any value) and AND across different keys — so `docker network ls -f name=a -f name=b` must return networks matching `a` or `b`, but socktainer returned only `a`.

The route-level allowlist also rejected `driver`/`scope`/`type` with 400 before the filter logic even ran, while moby accepts all seven network list filter keys — so `docker network ls -f driver=nat` failed outright. This extends the allowlist to match moby's set.

This is the network-side sibling of #257, which fixed the same class of bug for volume label filters.

## Related Issue

None — found while auditing network routes for Docker Engine API parity.

## Reproduction

Before:

```console
$ docker network create net-alpha && docker network create net-beta
$ docker network ls -f name=net-alpha -f name=net-beta
NETWORK ID     NAME        DRIVER    SCOPE
1a2b3c4d5e6f   net-alpha   nat       local     # net-beta missing — second value dropped
$ docker network ls -f driver=nat
Error response from daemon: Invalid filter key(s) found: ["driver"]
```

After:

```console
$ docker network ls -f name=net-alpha -f name=net-beta
NETWORK ID     NAME        DRIVER    SCOPE
1a2b3c4d5e6f   net-alpha   nat       local
7g8h9i0j1k2l   net-beta    nat       local
$ docker network ls -f driver=nat
NETWORK ID     NAME        DRIVER    SCOPE
1a2b3c4d5e6f   net-alpha   nat       local
7g8h9i0j1k2l   net-beta    nat       local
```

## Changes

- The filter block is extracted from `ClientNetworkService.list` into a testable `static func applyFilters`, with the `.first` checks for `name`/`id`/`driver`/`scope`/`type` replaced by `contains(where:)` so repeated values OR together. `label` keeps its AND semantics and `dangling` its single boolean value, both as in moby
- `DockerNetworkFilterUtility`'s route-level allowlist is extended from `name`/`id`/`label`/`dangling` to moby's full network-ls set (adds `driver`/`scope`/`type`), kept in sync with the keys `applyFilters` handles
- New unit tests in `Tests/socktainerTests/Network/NetworkFilterOrSemanticsTests.swift`: repeated `name`/`id`/`driver` values match either value; `type=custom` + `type=builtin` matches every network; different keys still AND together; single-value filters are unchanged; the route parser accepts all seven filter keys and still rejects unknown ones. The repeated-value cases return only the first value's matches against the previous implementation, confirming they reproduce the bug

## Notes

- An invalid `type` value (e.g. `type=bogus`) now matches nothing instead of everything; `POST /networks/prune` shares these filters, so repeated values widen the prune selection accordingly (the old drop-all-but-first behavior was the bug)

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [ ] Manual testing performed (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))