### PR TITLE
fix(builder): grant CAP_SYS_ADMIN so BuildKit can mount build contexts

### DIFF
--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -217,39 +217,70 @@ struct ClientBuilderService: ClientBuilderProtocol {
         let imageDesc = ImageDescription(reference: builderImage, descriptor: image.descriptor)
 
         let imageConfig = try await image.config(for: builderPlatform).config
-        let processConfig = ProcessConfiguration(
-            executable: "/usr/local/bin/container-builder-shim",
-            arguments: ["--debug", "--vsock", useRosetta ? nil : "--enable-qemu"].compactMap { $0 },
-            environment: imageConfig?.env ?? [],
-            workingDirectory: "/",
-            terminal: false,
-            user: .id(uid: 0, gid: 0)
-        )
-
-        var config = ContainerConfiguration(id: builderContainerId, image: imageDesc, process: processConfig)
-        config.resources = try Parser.resources(cpus: builderCPUs, memory: builderMemory, defaultCPUs: BuildConfig.defaultCPUs, defaultMemory: BuildConfig.defaultMemory)
-        config.labels = [ResourceLabelKeys.role: ResourceRoleValues.builder]
-        config.mounts = [
-            Filesystem.tmpfs(destination: "/run", options: []),
-            Filesystem.virtiofs(source: exportsMount.path, destination: "/var/lib/container-builder-shim/exports", options: []),
-        ]
-        config.rosetta = useRosetta
 
         guard let defaultNetwork = try await networkClient.builtin else {
             throw ContainerizationError(.invalidState, message: "default network is not present")
         }
-        let networkStatus = defaultNetwork.status
+        let nameserver = IPv4Address(defaultNetwork.status.ipv4Subnet.lower.value + 1).description
 
-        config.networks = [
-            AttachmentConfiguration(network: defaultNetwork.id, options: AttachmentOptions(hostname: builderContainerId))
-        ]
-        let nameserver = IPv4Address(networkStatus.ipv4Subnet.lower.value + 1).description
-        config.dns = ContainerConfiguration.DNSConfiguration(nameservers: [nameserver], domain: nil, searchDomains: [], options: [])
+        let config = try Self.builderContainerConfiguration(
+            builderContainerId: builderContainerId,
+            imageDescription: imageDesc,
+            imageEnv: imageConfig?.env,
+            useRosetta: useRosetta,
+            builderCPUs: builderCPUs,
+            builderMemory: builderMemory,
+            exportsMountPath: exportsMount.path,
+            networkId: defaultNetwork.id,
+            nameserver: nameserver
+        )
 
         let kernel = try await ClientKernel.getDefaultKernel(for: .current)
         try await containerClient.create(configuration: config, options: .default, kernel: kernel)
         try await startBuildKit(containerId: builderContainerId)
         return try await containerClient.get(id: builderContainerId)
+    }
+
+    /// Pure construction of the BuildKit guest's ContainerConfiguration — no real service
+    /// calls, so it's directly unit-testable without a live daemon. Kept separate from
+    /// `createAndStartBuilder` (which resolves the image/network inputs this needs).
+    static func builderContainerConfiguration(
+        builderContainerId: String,
+        imageDescription: ImageDescription,
+        imageEnv: [String]?,
+        useRosetta: Bool,
+        builderCPUs: Int64,
+        builderMemory: String,
+        exportsMountPath: String,
+        networkId: String,
+        nameserver: String
+    ) throws -> ContainerConfiguration {
+        let processConfig = ProcessConfiguration(
+            executable: "/usr/local/bin/container-builder-shim",
+            arguments: ["--debug", "--vsock", useRosetta ? nil : "--enable-qemu"].compactMap { $0 },
+            environment: imageEnv ?? [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0)
+        )
+
+        var config = ContainerConfiguration(id: builderContainerId, image: imageDescription, process: processConfig)
+        config.resources = try Parser.resources(cpus: builderCPUs, memory: builderMemory, defaultCPUs: BuildConfig.defaultCPUs, defaultMemory: BuildConfig.defaultMemory)
+        config.labels = [ResourceLabelKeys.role: ResourceRoleValues.builder]
+        config.mounts = [
+            Filesystem.tmpfs(destination: "/run", options: []),
+            Filesystem.virtiofs(source: exportsMountPath, destination: "/var/lib/container-builder-shim/exports", options: []),
+        ]
+        // BuildKit's runc-native snapshotter rbind-mounts a snapshot to read the build
+        // context/Dockerfile, which needs CAP_SYS_ADMIN — root alone doesn't grant it.
+        // Matches apple/container's own builder bootstrap (BuilderStart.swift).
+        config.capAdd = ["ALL"]
+        config.rosetta = useRosetta
+        config.networks = [
+            AttachmentConfiguration(network: networkId, options: AttachmentOptions(hostname: builderContainerId))
+        ]
+        config.dns = ContainerConfiguration.DNSConfiguration(nameservers: [nameserver], domain: nil, searchDomains: [], options: [])
+        return config
     }
 
     private func startBuildKit(containerId: String) async throws {

--- a/Tests/socktainerTests/Clients/ClientBuilderServiceTests.swift
+++ b/Tests/socktainerTests/Clients/ClientBuilderServiceTests.swift
@@ -1,0 +1,53 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Testing
+
+@testable import socktainer
+
+@Suite("ClientBuilderService.builderContainerConfiguration")
+struct ClientBuilderServiceConfigurationTests {
+
+    private func makeImageDescription() -> ImageDescription {
+        ImageDescription(
+            reference: "ghcr.io/apple/container-builder-shim/builder:0.12.0",
+            descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+        )
+    }
+
+    @Test("Grants CAP_SYS_ADMIN so BuildKit's runc-native snapshotter can rbind-mount build contexts")
+    func grantsCapSysAdmin() throws {
+        let config = try ClientBuilderService.builderContainerConfiguration(
+            builderContainerId: "buildkit",
+            imageDescription: makeImageDescription(),
+            imageEnv: nil,
+            useRosetta: false,
+            builderCPUs: 2,
+            builderMemory: "2048MB",
+            exportsMountPath: "/tmp/exports",
+            networkId: "default",
+            nameserver: "192.168.65.1"
+        )
+        #expect(config.capAdd == ["ALL"], "BuildKit's runc-native snapshotter needs CAP_SYS_ADMIN to rbind-mount build contexts — root alone is not sufficient (issue #260)")
+    }
+
+    @Test("Threads the builder id, network, and nameserver through to the resulting configuration")
+    func threadsCoreIdentity() throws {
+        let config = try ClientBuilderService.builderContainerConfiguration(
+            builderContainerId: "buildkit",
+            imageDescription: makeImageDescription(),
+            imageEnv: ["PATH=/usr/bin"],
+            useRosetta: true,
+            builderCPUs: 4,
+            builderMemory: "4096MB",
+            exportsMountPath: "/tmp/exports",
+            networkId: "mynet",
+            nameserver: "192.168.65.1"
+        )
+        #expect(config.id == "buildkit")
+        #expect(config.initProcess.environment == ["PATH=/usr/bin"])
+        #expect(config.rosetta == true)
+        #expect(config.networks.first?.network == "mynet")
+        #expect(config.dns?.nameservers == ["192.168.65.1"])
+    }
+}


### PR DESCRIPTION
## Summary

`docker compose build` / `docker build` fail against socktainer with:

```
failed to mount /tmp/buildkit-mount...: mount source:
"/var/lib/buildkit/runc-native/snapshots/snapshots/N", ...,
fstype: bind, ..., err: operation not permitted
```

BuildKit's `runc-native` snapshotter rbind-mounts a snapshot to read the build context/Dockerfile, which requires `CAP_SYS_ADMIN` — root (uid 0) alone does not grant it, since Linux gates `mount(2)` on the capability, not the uid. Apple Containerization's default OCI capability set excludes `sysAdmin`, and `ClientBuilderService` never added it back when creating the BuildKit guest container.

Apple's own `container` CLI hits this exact same problem in its builder bootstrap and already works around it (`BuilderStart.swift` sets `config.capAdd = ["ALL"]`); socktainer's reimplementation of the same builder-container creation never carried that line over.

Closes #260

## Changes

- Add `config.capAdd = ["ALL"]` when creating the BuildKit guest container, matching apple/container's own precedent.
- Extract the pure `ContainerConfiguration`-construction logic out of `createAndStartBuilder` into `builderContainerConfiguration`, so the capability grant (and the rest of the builder container's config) is unit-testable without a live daemon.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (590 tests)
- [x] Unit tests added: `builderContainerConfiguration` grants `CAP_SYS_ADMIN` (`capAdd == ["ALL"]`), and correctly threads the builder id/network/nameserver through — verified the first test traps on `config.capAdd → []` without the fix, and passes with it
- [x] Manual/live testing: reproduced the exact failure end-to-end (POST to `/build` with a busybox `Dockerfile`, matching issue #260's `docker compose build` repro) against the real daemon — got the identical `runc-native/snapshots` EPERM signature. Removed the stale `buildkit` container, rebuilt with the fix, re-ran the same build: succeeded.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)