### PR TITLE
fix(build): default Docker API versions so bare swift build binaries negotiate correctly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let buildGitCommit = ProcessInfo.processInfo.environment["BUILD_GIT_COMMIT"] ?? "unspecified"
 let buildVersion = ProcessInfo.processInfo.environment["BUILD_VERSION"] ?? "unspecified"
 let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
-let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "unspecified"
-let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "unspecified"
+let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "v1.32"
+let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "v1.51"
 let appleContainerVersion = "1.1.0"
 let appleContainerizationVersion = "0.35.0"
 

--- a/Tests/socktainerTests/Utilities/BuildInfoApiVersionTests.swift
+++ b/Tests/socktainerTests/Utilities/BuildInfoApiVersionTests.swift
@@ -1,0 +1,17 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("Docker Engine API version build info")
+struct BuildInfoApiVersionTests {
+
+    @Test("min API version is a valid Docker version string even without Makefile env vars")
+    func minApiVersionIsAlwaysValid() {
+        #expect(getDockerEngineApiMinVersion().wholeMatch(of: /v\d+\.\d+/) != nil)
+    }
+
+    @Test("max API version is a valid Docker version string even without Makefile env vars")
+    func maxApiVersionIsAlwaysValid() {
+        #expect(getDockerEngineApiMaxVersion().wholeMatch(of: /v\d+\.\d+/) != nil)
+    }
+}


### PR DESCRIPTION
## Summary
Homebrew (and any direct `swift build`) bypasses the Makefile env exports, baking `ApiVersion`/`MinAPIVersion` `"unspecified"` into `GET /version` and breaking client version negotiation (reported with PyCharm and `brew install socktainer --HEAD`). The Docker API bounds are facts about the source, not the build environment, so `Package.swift` now carries real defaults; the Makefile exports still override with identical values.

## Related Issue
Fixes #197

## Changes
- `Package.swift`: `DOCKER_ENGINE_API_MIN_VERSION`/`MAX_VERSION` fall back to `v1.32`/`v1.51` instead of `"unspecified"`
- `Tests/socktainerTests/Utilities/BuildInfoApiVersionTests.swift`: regression tests asserting both versions are always valid Docker version strings — red on a bare `swift test` without the fix, green with it

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed: `env -u DOCKER_ENGINE_API_MIN_VERSION -u DOCKER_ENGINE_API_MAX_VERSION swift test --filter BuildInfoApiVersionTests` fails before the fix, passes after

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))