### PR TITLE
fix(exec): don't close the exec start stream before the exit code is recorded

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -65,6 +65,18 @@ actor ExecManager {
     func exitCode(id: String) -> Int32? {
         exitCodes[id]
     }
+
+    // The Docker client reads the exit code with a single GET /exec/{id}/json
+    // right after the start stream closes, so the stream must not close before
+    // the exit code is recorded. Exit-code recording is bounded by the wait
+    // tasks' XPC-stall fallback, so this poll always resolves.
+    func waitForExitCode(id: String, timeoutNanoseconds: UInt64 = 12_000_000_000, pollNanoseconds: UInt64 = 25_000_000) async -> Int32? {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while exitCodes[id] == nil && DispatchTime.now().uptimeNanoseconds < deadline {
+            try? await Task.sleep(nanoseconds: pollNanoseconds)
+        }
+        return exitCodes[id]
+    }
 }
 
 // Request & Response DTOs
@@ -552,6 +564,10 @@ struct ExecRoute: RouteCollection {
 
                     // Keep the exec entry so the client's follow-up
                     // `GET /exec/{id}/json` can read the recorded exit code.
+                    // Pipe EOF can precede the wait() task recording the exit
+                    // code; closing the stream first makes the client's inspect
+                    // read ExitCode nil and report 0 for a failing command.
+                    _ = await ExecManager.shared.waitForExitCode(id: execId)
                     streamContinuation.finish()
                 }
             }

--- a/Tests/socktainerTests/Routes/ExecExitCodeWaitTests.swift
+++ b/Tests/socktainerTests/Routes/ExecExitCodeWaitTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("ExecManager.waitForExitCode")
+struct ExecExitCodeWaitTests {
+
+    private func makeStartedExec() async -> String {
+        let execId = await ExecManager.shared.create(
+            config: ExecManager.ExecConfig(
+                containerId: "devcontainer-lifecycle",
+                cmd: ["sh", "-c", "exit 42"],
+                attachStdin: false,
+                attachStdout: true,
+                attachStderr: true,
+                tty: false,
+                detach: false,
+                env: [],
+                user: nil,
+                workingDir: nil
+            )
+        )
+        _ = await ExecManager.shared.markStarted(id: execId)
+        return execId
+    }
+
+    @Test("returns immediately when the exit code is already recorded")
+    func alreadyRecorded() async {
+        let execId = await makeStartedExec()
+        await ExecManager.shared.setExitCode(id: execId, code: 42)
+
+        let code = await ExecManager.shared.waitForExitCode(id: execId)
+
+        #expect(code == 42)
+        await ExecManager.shared.remove(id: execId)
+    }
+
+    @Test("blocks until a late exit code lands instead of returning nil at pipe EOF")
+    func waitsForLateExitCode() async throws {
+        let execId = await makeStartedExec()
+
+        Task {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            await ExecManager.shared.setExitCode(id: execId, code: 42)
+        }
+
+        let code = await ExecManager.shared.waitForExitCode(id: execId)
+
+        #expect(code == 42)
+        await ExecManager.shared.remove(id: execId)
+    }
+
+    @Test("gives up after the timeout when no exit code is ever recorded")
+    func timesOutWhenNeverRecorded() async {
+        let execId = await makeStartedExec()
+
+        let code = await ExecManager.shared.waitForExitCode(id: execId, timeoutNanoseconds: 100_000_000)
+
+        #expect(code == nil)
+        await ExecManager.shared.remove(id: execId)
+    }
+}


### PR DESCRIPTION
## Summary
`docker exec` without `-i` uses the HTTP streaming path, which finished the response stream at pipe EOF while `process.wait()` recorded the exit code on an independent task. The Docker CLI reads the exit code with a single `GET /exec/{id}/json` immediately after the stream closes — when `wait()` lagged EOF under load, the inspect saw `ExitCode: null` and a failing command was reported as exit `0`. Devcontainer/CI tooling that gates on exec exit codes silently treats failed setup commands as successful.

This holds the stream close until the exit code is recorded, mirroring the ordering the TCP-upgrade path already had. The wait stays bounded: the recording tasks fall back to a sentinel after their existing XPC-stall timeout, so a hung `wait()` cannot block the stream indefinitely.

## Related Issue
Found by live integration testing (probe DEV-005: `docker exec dev sh -c 'exit 42'` intermittently returned 0 under suite load).

## Changes
- `ExecRoutes.swift`: new `ExecManager.waitForExitCode(id:timeoutNanoseconds:pollNanoseconds:)`; the HTTP streaming path awaits it before `streamContinuation.finish()`
- `Tests/socktainerTests/Routes/ExecExitCodeWaitTests.swift`: covers immediate return when already recorded, blocking until a late exit code lands, and the timeout path

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed: 20/20 correct exit codes on repeated `docker exec ... 'exit 42'` against a live daemon, plus a full 95-test integration sweep with the previously-flaky exec exit-code test passing under load

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))