### PR TITLE
fix(dns): hide sidecars from the Docker API, adopt them across restarts, right-size their VMs

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -100,9 +100,17 @@ struct ClientContainerService: ClientContainerProtocol {
     private let containerClient = ContainerClient()
 
     func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] {
-        let allContainers = try await containerClient.list()
+        let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
         let running = showAll ? allContainers : allContainers.filter { $0.status == .running }
         return Self.applyFilters(running, filters: filters, allContainers: allContainers)
+    }
+
+    static func withoutDNSSidecars(_ snapshots: [ContainerSnapshot]) -> [ContainerSnapshot] {
+        snapshots.filter { !isDNSSidecar($0) }
+    }
+
+    static func isDNSSidecar(_ snapshot: ContainerSnapshot) -> Bool {
+        snapshot.configuration.labels[NetworkDNSManager.roleLabel] == NetworkDNSManager.dnsRole
     }
 
     /// Applies parsed Docker container filters to a snapshot list.
@@ -222,12 +230,13 @@ struct ClientContainerService: ClientContainerProtocol {
     func getContainer(id: String) async throws -> ContainerSnapshot? {
         let id = ContainerNameUtility.sanitize(id)
         do {
-            return try await containerClient.get(id: id)
+            let snapshot = try await containerClient.get(id: id)
+            return Self.isDNSSidecar(snapshot) ? nil : snapshot
         } catch let error as ContainerizationError where error.code == .notFound {
             // The reference may be a Docker-shaped hex ID, or a truncated
             // prefix of one fed back from `docker ps` output; resolve it
             // against the derived IDs of all containers.
-            let allContainers = try await containerClient.list()
+            let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
             let entries = allContainers.map { (nativeId: $0.id, hexId: DockerContainerID.hexId(for: $0)) }
             switch DockerContainerID.resolve(reference: id, entries: entries) {
             case .match(let nativeId):
@@ -425,7 +434,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
-        let allContainers = try await containerClient.list()
+        let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
 
         var containersToDelete: [ContainerSnapshot] = allContainers.filter { $0.status == .stopped }
 

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -30,7 +30,7 @@ struct ClientNetworkService: ClientNetworkProtocol {
                 // If CoreDNS shows up as an attached container, docker compose down
                 // reports "Resource is still in use" and skips the DELETE /networks/{id}
                 // call — preventing our cleanup hook from firing.
-                guard container.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole else {
+                guard !ClientContainerService.isDNSSidecar(container) else {
                     continue
                 }
                 for attachment in container.networks {

--- a/Sources/socktainer/DNS/NetworkDNSManager.swift
+++ b/Sources/socktainer/DNS/NetworkDNSManager.swift
@@ -27,6 +27,9 @@ actor NetworkDNSManager {
     static let networkLabel = "socktainer.network"
     static let containerPrefix = "socktainer-dns-"
     static let dnsPort = 2054
+    static let sidecarCPUs = 1
+    // Virtualization.framework rejects anything below 200 MiB.
+    static let sidecarMemoryInBytes: UInt64 = 256.mib()
 
     private let appSupportURL: URL
     private let dnsPort: Int
@@ -102,17 +105,31 @@ actor NetworkDNSManager {
         }
     }
 
-    /// Scans for and removes any stale DNS containers left from a previous Socktainer run.
-    /// Should be called once at startup.
-    func cleanupStaleDNSContainers() async {
+    // A recreated sidecar never gets its old IP back (upstream allocates rotating,
+    // never reusing freed addresses), while existing containers keep that IP baked
+    // in resolv.conf — so healthy sidecars must be adopted, never recreated.
+    func adoptOrRemoveSidecarsFromPreviousRun() async {
         let client = ContainerClient()
         guard let containers = try? await client.list() else { return }
         for container in containers {
-            guard container.configuration.labels[Self.roleLabel] == Self.dnsRole else { continue }
-            log.info("[dns-manager] cleaning up stale DNS container: \(container.id)")
+            guard ClientContainerService.isDNSSidecar(container) else { continue }
+            if Self.shouldAdoptSidecar(status: container.status, networkExists: await networkStillExists(for: container)) {
+                log.info("[dns-manager] adopting running DNS container: \(container.id)")
+                continue
+            }
+            log.info("[dns-manager] removing stale DNS container: \(container.id)")
             if container.status == .running { try? await client.stop(id: container.id) }
             try? await client.delete(id: container.id)
         }
+    }
+
+    static func shouldAdoptSidecar(status: RuntimeStatus, networkExists: Bool) -> Bool {
+        status == .running && networkExists
+    }
+
+    private func networkStillExists(for container: ContainerSnapshot) async -> Bool {
+        guard let networkId = container.configuration.labels[Self.networkLabel] else { return false }
+        return (try? await NetworkClient().get(id: networkId)) != nil
     }
 
     // MARK: - Private implementation
@@ -153,6 +170,8 @@ actor NetworkDNSManager {
         )
 
         var config = ContainerConfiguration(id: containerId, image: image.description, process: processConfig)
+        config.resources.cpus = sidecarCPUs
+        config.resources.memoryInBytes = sidecarMemoryInBytes
         config.labels = [
             roleLabel: dnsRole,
             networkLabel: networkId,

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -337,7 +337,7 @@ extension ContainerStartRoute {
 
         if let dnsServer,
             let snapshot = startedSnapshot,
-            snapshot.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole
+            !ClientContainerService.isDNSSidecar(snapshot)
         {
             // Register only on a network that has a DNS forwarder sidecar — same reserved set
             // as sidecarNetwork. On reserved networks (default/bridge/host/none) there is no

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -214,7 +214,7 @@ func configure(_ app: Application) async throws {
     if let runningContainers = try? await resumeClient.list() {
         for container in runningContainers where container.status == .running {
             // Skip DNS-sidecar containers — they are internal infrastructure.
-            guard container.configuration.labels[NetworkDNSManager.roleLabel] != NetworkDNSManager.dnsRole
+            guard !ClientContainerService.isDNSSidecar(container)
             else { continue }
 
             ContainerStartRoute.registerDNSAliasesOnResume(container: container, dnsServer: dnsServer, logger: app.logger)
@@ -229,8 +229,7 @@ func configure(_ app: Application) async throws {
         }
     }
 
-    // Clean up any CoreDNS containers left from a previous run
-    await dnsManager.cleanupStaleDNSContainers()
+    await dnsManager.adoptOrRemoveSidecarsFromPreviousRun()
 
     // Reap networks orphaned by a previous run (containers removed, network left behind).
     // Apple Container's vmnet state degrades as stale networks accumulate and eventually

--- a/Tests/socktainerTests/Clients/DNSSidecarVisibilityTests.swift
+++ b/Tests/socktainerTests/Clients/DNSSidecarVisibilityTests.swift
@@ -1,0 +1,54 @@
+import ContainerAPIClient
+import ContainerResource
+import Testing
+
+@testable import socktainer
+
+@Suite("DNS sidecar Docker API visibility")
+struct DNSSidecarVisibilityTests {
+
+    private func sidecar(network: String = "backend") throws -> ContainerSnapshot {
+        try makeContainerSnapshot(
+            nativeId: "socktainer-dns-\(network)",
+            ip: "192.168.65.2",
+            network: network,
+            labels: [
+                NetworkDNSManager.roleLabel: NetworkDNSManager.dnsRole,
+                NetworkDNSManager.networkLabel: network,
+            ],
+            status: .running
+        )
+    }
+
+    private func userContainer(name: String) throws -> ContainerSnapshot {
+        try makeContainerSnapshot(nativeId: name, ip: "192.168.65.3", network: "backend", labels: ["app": "api"], status: .running)
+    }
+
+    @Test("withoutDNSSidecars drops DNS sidecars and keeps user containers")
+    func withoutDNSSidecarsFiltersSidecars() throws {
+        let snapshots = [try sidecar(), try userContainer(name: "api-server")]
+
+        let visible = ClientContainerService.withoutDNSSidecars(snapshots)
+
+        #expect(visible.map { $0.id } == ["api-server"])
+    }
+
+    @Test("startup adopts a running sidecar whose network exists, removes all others")
+    func staleSidecarAdoption() {
+        #expect(NetworkDNSManager.shouldAdoptSidecar(status: .running, networkExists: true))
+        #expect(!NetworkDNSManager.shouldAdoptSidecar(status: .running, networkExists: false))
+        #expect(!NetworkDNSManager.shouldAdoptSidecar(status: .stopped, networkExists: true))
+    }
+
+    @Test("isDNSSidecar matches only the socktainer.role=dns label")
+    func sidecarDetection() throws {
+        #expect(ClientContainerService.isDNSSidecar(try sidecar()))
+        #expect(!ClientContainerService.isDNSSidecar(try userContainer(name: "api-server")))
+
+        let otherRole = try makeContainerSnapshot(
+            nativeId: "worker", ip: "192.168.65.4", network: "backend",
+            labels: [NetworkDNSManager.roleLabel: "builder"], status: .running
+        )
+        #expect(!ClientContainerService.isDNSSidecar(otherRole))
+    }
+}


### PR DESCRIPTION
## Summary
A DNS sidecar that disappears permanently strands every existing container on its network: upstream's rotating address allocator never re-issues the freed IP, and containers keep the old sidecar address baked into `resolv.conf` at create time (verified live — MAC pinning does not help, the allocator is hostname-keyed and rotating; there is no static-IP attachment option in apple/container 1.1.0). This PR closes every path that loses a sidecar instead of chasing the unwinnable recreate-at-same-IP:

1. **Hide + protect sidecars via the Docker API** — filtered from `/containers/json`, by-id resolution and prune, so `docker rm -f $(docker ps -aq)`-style cleanup scripts cannot remove them; direct `rm`/`stop`/`inspect` answer 404. This extends the exclusion `ClientNetworkService` already applied to network inspect, now consolidated on `ClientContainerService.isDNSSidecar`.
2. **Adopt healthy sidecars at daemon startup** instead of deleting them — a plain socktainer restart no longer breaks DNS for already-running containers (the adopted sidecar keeps its IP; its upstream is the stable `gateway:2054` the new daemon re-binds). Only sidecars that are stopped or whose network no longer exists are removed.
3. **Right-size sidecar VMs** — 1 CPU / 256 MiB instead of the 4 CPU / 1 GiB defaults; the forwarder is a ~388 KB static binary. 256 MiB is the practical floor: Virtualization.framework rejects anything below 200 MiB (verified live with 128 MiB).

## Related Issue
Follow-up to the DNS reliability work in #264 / #262 — live integration testing showed the sidecar-loss scenarios still broke name resolution on current main.

## Changes
- `ClientContainerService`: `withoutDNSSidecars(_:)` filter applied to list/getContainer/prune; `isDNSSidecar(_:)` as the single label check
- `NetworkDNSManager`: `adoptOrRemoveSidecarsFromPreviousRun()` (replaces delete-all `cleanupStaleDNSContainers`), `shouldAdoptSidecar(status:networkExists:)`, sidecar VM sizing constants
- `ClientNetworkService`, `ContainerStartRoute`, `configure.swift`: reuse `isDNSSidecar`
- `Tests/socktainerTests/Clients/DNSSidecarVisibilityTests.swift`: visibility filter, label detection, adoption contract

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - `docker rm -f <sidecar>` refused (404), sidecar invisible in `docker ps`, DNS keeps resolving after client stop/start
  - `docker rm -f $(docker ps -aq)` wipes user containers, sidecar survives, fresh containers resolve immediately
  - daemon restart: sidecar adopted at the same IP, resolution works immediately afterwards
  - 256 MiB sidecar boots (1 CPU / 256 MB in `container ls`) and holds 20/20 lookups under burst; 128 MiB rejected by Virtualization.framework with 'minimum memory amount allowed is 200 MiB'
  - full live integration suite: 87 passed, 0 failed

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))