### PR TITLE
feat(containers): implement docker update for restart policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,13 @@ Ownership rules:
   - An explicit `docker stop` / `docker kill` only suppresses the next auto-restart for `unless-stopped`. `always` restarts the container anyway, and `on-failure` restarts whenever the exit code is non-zero — regardless of whether a human or a crash caused the exit. Use `unless-stopped` if you don't want a manual stop to be overridden.
   - **Caveat:** the policy is enforced only by the running `socktainer` process — it does not survive a `socktainer` restart or host reboot, unlike real Docker's daemon-level reconciliation. `always`/`unless-stopped` containers are not automatically resumed on `socktainer` startup.
 
+- `docker update` supports **restart policies only** (`--restart`). CPU and memory limits cannot change after create — Apple Container runs each container in a VM whose resources are fixed at boot. Resource-only updates return an error; a restart-policy update combined with resource flags applies the policy and returns a warning for the ignored fields. Updated policies are stored durably, but the enforcement caveat above applies to them like any other restart policy.
+- `docker save` and `docker export` currently fail: Apple's Containerization `ContentStore` keeps image metadata but not the underlying content blobs, so there is nothing to export ([platform limitation](https://github.com/apple/containerization)). This also breaks the `docker save | docker load` round-trip.
+- `docker pause` / `docker unpause` are **not supported** — there is no freezer/checkpoint equivalent for Apple Container VMs.
+- `docker network connect` / `disconnect` are accepted as **no-ops**: Virtualization.framework offers no NIC hotplug and Apple Container has no post-create attach API, so network membership is fixed at container create. Containers on user-created networks reach each other by name through socktainer's DNS, which covers the common Compose use.
+- **Static container IPs** (`--ip`, IPAM per-container config) cannot be honored: Apple Container assigns addresses from a rotating allocator with no way to request a specific one. Name-based discovery via socktainer DNS is the supported alternative; addresses stay stable for a container's lifetime.
+- Not yet implemented (endpoints answer an explicit error instead of pretending): `docker commit`, `docker diff`, `docker search`, `docker top`, and `GET /distribution/{name}/json`.
+
 ### Docker Compose — inter-service DNS
 
 Socktainer registers service names in its DNS server so Compose services can

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -40,6 +40,7 @@ extension ContainerDeleteRoute {
                 await ContainerInfoCache.shared.remove(id: id)
                 // Prevents a container recreated under the same name from inheriting this one's restart-attempt count.
                 await ContainerRestartState.shared.reset(id: eventName)
+                await RestartPolicyOverrideStore.shared.remove(id: eventId)
                 guard let broadcaster = req.application.storage[EventBroadcasterKey.self] else { return }
                 await broadcaster.broadcast(
                     DockerEvent.simpleEvent(

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -72,7 +72,9 @@ extension ContainerInspectRoute {
                 .flatMap { try? JSONDecoder().decode(HealthcheckConfig.self, from: $0) }
 
             // Round-trips the label the create route persisted; defaults to "no", matching moby.
-            let restartPolicy = RestartPolicyManager.decode(from: container.configuration.labels) ?? RestartPolicy(Name: "no", MaximumRetryCount: nil)
+            let restartPolicy =
+                await RestartPolicyManager.effectivePolicy(hexId: DockerContainerID.hexId(for: container), labels: container.configuration.labels)
+                ?? RestartPolicy(Name: "no", MaximumRetryCount: nil)
 
             let containerConfig: ContainerConfig = ContainerConfig(
                 Hostname: container.id,  // Use container ID as hostname since hostName property doesn't exist

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -199,8 +199,11 @@ extension ContainerStartRoute {
 
             let explicitlyStopped = await ContainerRestartState.shared.consumeExplicitlyStopped(id: nativeId)
             let nextAttemptNumber = await ContainerRestartState.shared.count(id: nativeId) + 1
+            // The armed policy is the immutable create-time label; a docker update landing
+            // while the container runs must govern THIS exit, so the override is read now.
+            let effectivePolicy = await RestartPolicyOverrideStore.shared.get(id: eventId) ?? restartPolicy
             let willRestart =
-                restartPolicy.map {
+                effectivePolicy.map {
                     RestartPolicyManager.shouldRestart(
                         policy: $0, exitCode: code, attempt: nextAttemptNumber, hasBeenManuallyStopped: explicitlyStopped)
                 } ?? false
@@ -230,6 +233,21 @@ extension ContainerStartRoute {
             guard await ContainerRestartState.shared.isCurrent(id: nativeId, generation: generation) else {
                 await ContainerRestartState.shared.clearPendingRestart(id: nativeId)
                 logger.info("restart-policy: aborting stale restart for \(nativeId) — a newer lifecycle has taken over")
+                return
+            }
+            // A docker update or docker stop landing during the backoff sleep (up to
+            // 60s) must cancel the restart decided under the old inputs.
+            let policyAfterBackoff = await RestartPolicyOverrideStore.shared.get(id: eventId) ?? restartPolicy
+            let stoppedDuringBackoff = await ContainerRestartState.shared.consumeExplicitlyStopped(id: nativeId)
+            let stillWantsRestart =
+                policyAfterBackoff.map {
+                    RestartPolicyManager.shouldRestart(
+                        policy: $0, exitCode: code, attempt: nextAttemptNumber,
+                        hasBeenManuallyStopped: explicitlyStopped || stoppedDuringBackoff)
+                } ?? false
+            guard stillWantsRestart else {
+                await ContainerRestartState.shared.clearPendingRestart(id: nativeId)
+                logger.info("restart-policy: aborting restart for \(nativeId) — policy or stop state changed during backoff")
                 return
             }
             // Record the attempt only once we're actually about to restart — a concurrent

--- a/Sources/socktainer/Routes/Containers/ContainerUpdateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerUpdateRoute.swift
@@ -89,7 +89,8 @@ struct ContainerUpdateRoute: RouteCollection {
         if let value = body.CpuPeriod, value != 0 { fields.append("CpuPeriod") }
         if let value = body.CpuQuota, value != 0 { fields.append("CpuQuota") }
         if let value = body.CpusetCpus, !value.isEmpty { fields.append("CpusetCpus") }
-        if let value = body.PidsLimit, value != 0 { fields.append("PidsLimit") }
+        // PidsLimit is moby's one pointer resource: 0/-1 mean unlimited, null means no change.
+        if body.PidsLimit != nil { fields.append("PidsLimit") }
         if let value = body.BlkioWeight, value != 0 { fields.append("BlkioWeight") }
         return fields
     }

--- a/Sources/socktainer/Routes/Containers/ContainerUpdateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerUpdateRoute.swift
@@ -1,11 +1,96 @@
+import ContainerResource
 import Vapor
 
+struct ContainerUpdateRequest: Content {
+    let RestartPolicy: RestartPolicy?
+    let Memory: Int64?
+    let MemorySwap: Int64?
+    let MemoryReservation: Int64?
+    let NanoCpus: Int64?
+    let CpuShares: Int64?
+    let CpuPeriod: Int64?
+    let CpuQuota: Int64?
+    let CpusetCpus: String?
+    let PidsLimit: Int64?
+    let BlkioWeight: Int?
+}
+
+struct ContainerUpdateResponse: Content {
+    let Warnings: [String]
+}
+
 struct ContainerUpdateRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/update", use: ContainerUpdateRoute.handler)
+        try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/update", use: ContainerUpdateRoute.handler(client: client))
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/containers/{id}/update", req.method.rawValue)
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let containerId = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing container ID")
+            }
+            let container: ContainerSnapshot
+            do {
+                guard let found = try await client.getContainer(id: containerId) else {
+                    throw Abort(.notFound, reason: "No such container: \(containerId)")
+                }
+                container = found
+            } catch ClientContainerError.ambiguousId(let reference, let matches) {
+                throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matches.joined(separator: ", "))")
+            }
+
+            let body = try req.content.decode(ContainerUpdateRequest.self)
+            let fixedResources = Self.requestedFixedResources(body)
+
+            guard let policy = body.RestartPolicy, !policy.Name.isEmpty else {
+                guard fixedResources.isEmpty else {
+                    throw Abort(
+                        .badRequest,
+                        reason: "Cannot update \(fixedResources.joined(separator: ", ")): Apple Container VM resources are fixed at create time")
+                }
+                throw Abort(.badRequest, reason: "Nothing to update: no updatable fields in request")
+            }
+
+            if let error = RestartPolicyManager.validatePolicy(policy) {
+                throw Abort(.badRequest, reason: error)
+            }
+
+            await RestartPolicyOverrideStore.shared.set(id: DockerContainerID.hexId(for: container), policy: policy)
+
+            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                await broadcaster.broadcast(
+                    DockerEvent.simpleEvent(
+                        id: DockerContainerID.hexId(for: container),
+                        type: "container",
+                        status: "update",
+                        image: container.configuration.image.reference,
+                        name: container.id,
+                        labels: LabelNormalization.restore(container.configuration.labels)
+                    ))
+            }
+
+            var warnings: [String] = []
+            if !fixedResources.isEmpty {
+                warnings.append("Ignored \(fixedResources.joined(separator: ", ")): Apple Container VM resources are fixed at create time")
+            }
+            return try await ContainerUpdateResponse(Warnings: warnings).encodeResponse(status: .ok, for: req)
+        }
+    }
+
+    static func requestedFixedResources(_ body: ContainerUpdateRequest) -> [String] {
+        var fields: [String] = []
+        if let value = body.Memory, value != 0 { fields.append("Memory") }
+        if let value = body.MemorySwap, value != 0 { fields.append("MemorySwap") }
+        if let value = body.MemoryReservation, value != 0 { fields.append("MemoryReservation") }
+        if let value = body.NanoCpus, value != 0 { fields.append("NanoCpus") }
+        if let value = body.CpuShares, value != 0 { fields.append("CpuShares") }
+        if let value = body.CpuPeriod, value != 0 { fields.append("CpuPeriod") }
+        if let value = body.CpuQuota, value != 0 { fields.append("CpuQuota") }
+        if let value = body.CpusetCpus, !value.isEmpty { fields.append("CpusetCpus") }
+        if let value = body.PidsLimit, value != 0 { fields.append("PidsLimit") }
+        if let value = body.BlkioWeight, value != 0 { fields.append("BlkioWeight") }
+        return fields
     }
 }

--- a/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
@@ -35,5 +35,6 @@ enum ContainerAutoRemoveCleanup {
                 ))
         }
         await ContainerInfoCache.shared.remove(id: hexId)
+        await RestartPolicyOverrideStore.shared.remove(id: hexId)
     }
 }

--- a/Sources/socktainer/Utilities/RestartPolicyManager.swift
+++ b/Sources/socktainer/Utilities/RestartPolicyManager.swift
@@ -17,6 +17,10 @@ enum RestartPolicyManager {
             return "can't create 'AutoRemove' container with restart policy"
         }
 
+        return validatePolicy(policy)
+    }
+
+    static func validatePolicy(_ policy: RestartPolicy) -> String? {
         switch policy.Name {
         case "always", "unless-stopped", "no":
             if let maxRetryCount = policy.MaximumRetryCount, maxRetryCount != 0 {

--- a/Sources/socktainer/Utilities/RestartPolicyManager.swift
+++ b/Sources/socktainer/Utilities/RestartPolicyManager.swift
@@ -43,14 +43,15 @@ enum RestartPolicyManager {
         }
     }
 
-    /// `always` restarts even after an explicit stop/kill; only `unless-stopped` honors
-    /// `hasBeenManuallyStopped`. Matches moby's documented gotcha — restartmanager.go, v28.5.2.
+    /// A manual stop suppresses every policy: moby's stop path cancels the
+    /// RestartManager (`ExitOnNext` → `Cancel`), which is what our transient
+    /// stop flag stands in for. moby's persistent flag only gates
+    /// `unless-stopped` across daemon restarts — a feature we don't have.
     static func shouldRestart(policy: RestartPolicy, exitCode: Int32, attempt: Int, hasBeenManuallyStopped: Bool) -> Bool {
+        guard !hasBeenManuallyStopped else { return false }
         switch policy.Name {
-        case "always":
+        case "always", "unless-stopped":
             return true
-        case "unless-stopped":
-            return !hasBeenManuallyStopped
         case "on-failure":
             guard exitCode != 0 else { return false }
             let maxRetries = policy.MaximumRetryCount ?? 0

--- a/Sources/socktainer/Utilities/RestartPolicyOverrideStore.swift
+++ b/Sources/socktainer/Utilities/RestartPolicyOverrideStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Logging
+
+/// Restart policies are baked into container labels at create time and Apple
+/// Container's configuration is immutable afterwards — `docker update` therefore
+/// records an override here, consulted before the label. Persisted so overrides
+/// survive daemon restarts, like the labels they shadow.
+///
+/// Keyed by the instance-unique Docker hex id (name + creation date), never the
+/// reusable native name: a recreated container gets a fresh key, so a stale
+/// entry can never apply to the wrong instance — removal is hygiene, not
+/// correctness.
+actor RestartPolicyOverrideStore {
+    static let shared = RestartPolicyOverrideStore()
+
+    private var overrides: [String: RestartPolicy] = [:]
+    private var fileURL: URL?
+    private let log = Logger(label: "socktainer.restart-policy-overrides")
+
+    func configure(storageDirectory: URL) {
+        let url = storageDirectory.appendingPathComponent("socktainer-restart-policy-overrides.json")
+        fileURL = url
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            overrides = try JSONDecoder().decode([String: RestartPolicy].self, from: Data(contentsOf: url))
+        } catch {
+            log.error("could not load restart-policy overrides from \(url.path) — updates recorded by earlier runs are not applied: \(error)")
+        }
+    }
+
+    func set(id: String, policy: RestartPolicy) {
+        overrides[id] = policy
+        persist()
+    }
+
+    func get(id: String) -> RestartPolicy? {
+        overrides[id]
+    }
+
+    func remove(id: String) {
+        guard overrides.removeValue(forKey: id) != nil else { return }
+        persist()
+    }
+
+    private func persist() {
+        guard let fileURL else { return }
+        do {
+            try JSONEncoder().encode(overrides).write(to: fileURL, options: .atomic)
+        } catch {
+            log.error("could not persist restart-policy overrides to \(fileURL.path) — the change is in effect but will not survive a daemon restart: \(error)")
+        }
+    }
+}
+
+extension RestartPolicyManager {
+    static func effectivePolicy(hexId: String, labels: [String: String]) async -> RestartPolicy? {
+        await RestartPolicyOverrideStore.shared.get(id: hexId) ?? decode(from: labels)
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -35,6 +35,7 @@ func configure(_ app: Application) async throws {
     }
 
     let containerClient = ClientContainerService()
+    await RestartPolicyOverrideStore.shared.configure(storageDirectory: appleContainerAppSupportUrl)
     let imageClient = ClientImageService(containerSystemConfig: systemConfig)
     let healthCheckClient = ClientHealthCheckService()
     let networkClient = ClientNetworkService()
@@ -82,7 +83,7 @@ func configure(_ app: Application) async throws {
     try app.register(collection: ContainerStopRoute(client: containerClient))
     try app.register(collection: ContainerTopRoute())
     try app.register(collection: ContainerUnpauseRoute())
-    try app.register(collection: ContainerUpdateRoute())
+    try app.register(collection: ContainerUpdateRoute(client: containerClient))
     try app.register(collection: ContainerWaitRoute(client: containerClient))
 
     // /images

--- a/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
@@ -238,6 +238,38 @@ struct ContainerRestartPolicyPostStartTests {
         await ContainerRestartState.shared.reset(id: nativeId)
         await ContainerExitCodeStore.shared.remove(id: nativeId)
     }
+
+    @Test("A manual stop keeps an always container down, like moby's restart-manager cancel")
+    func manualStopSuppressesAlwaysPolicy() async throws {
+        let nativeId = "restart-always-stop-ctr"
+        let ip = "192.168.65.80"
+        let network = "myapp_default"
+
+        let mock = RestartMock(snapshot: try makeSnapshot(nativeId: nativeId, ip: ip, network: network, restartPolicyName: "always"))
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        // /stop marks the container explicitly-stopped before the exit lands.
+        await ContainerRestartState.shared.markExplicitlyStopped(id: nativeId)
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: 0)
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(await mock.startCallCount() == 1, "the observer must not restart a manually stopped always container")
+        #expect(await ContainerRestartState.shared.count(id: nativeId) == 0)
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
 }
 
 private actor EventCollector {

--- a/Tests/socktainerTests/Routes/ContainerUpdateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerUpdateRouteTests.swift
@@ -1,0 +1,241 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct UpdateMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? {
+        id == snapshot.id ? snapshot : nil
+    }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
+private struct UpdateResponseBody: Vapor.Content { let Warnings: [String] }
+private struct UpdateErrorBody: Vapor.Content { let reason: String }
+
+private func makeSnapshot(id: String, labels: [String: String] = [:]) -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: "alpine:latest",
+        descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+    )
+    var config = ContainerConfiguration(id: id, image: img, process: proc)
+    config.labels = labels
+    return ContainerSnapshot(configuration: config, status: .running, networks: [])
+}
+
+private func withUpdateApp(_ snapshot: ContainerSnapshot, run: (Application) async throws -> Void) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+        try app.register(collection: ContainerUpdateRoute(client: UpdateMock(snapshot: snapshot)))
+        try await run(app)
+    }
+}
+
+@Suite("ContainerUpdateRoute", .serialized)
+struct ContainerUpdateRouteTests {
+
+    @Test("updating the restart policy stores an override and answers the Moby shape")
+    func updateRestartPolicy() async throws {
+        let id = "update-ctr-\(UUID().uuidString.prefix(8))"
+        let snapshot = makeSnapshot(id: id)
+        try await withUpdateApp(snapshot) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(["RestartPolicy": RestartPolicy(Name: "no", MaximumRetryCount: 0)])
+                }
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode(UpdateResponseBody.self)
+                #expect(body.Warnings.isEmpty)
+            }
+        }
+        let stored = await RestartPolicyOverrideStore.shared.get(id: DockerContainerID.hexId(for: snapshot))
+        #expect(stored?.Name == "no")
+        await RestartPolicyOverrideStore.shared.remove(id: DockerContainerID.hexId(for: snapshot))
+    }
+
+    @Test("the override wins over the create-time label; a recreated instance gets a fresh key")
+    func overridePrecedence() async throws {
+        let labels = [RestartPolicyManager.label: #"{"Name":"always"}"#]
+        let firstInstance = DockerContainerID.hexId(nativeId: "web", createdAt: Date(timeIntervalSince1970: 1_000))
+        let recreatedInstance = DockerContainerID.hexId(nativeId: "web", createdAt: Date(timeIntervalSince1970: 2_000))
+
+        let fromLabel = await RestartPolicyManager.effectivePolicy(hexId: firstInstance, labels: labels)
+        #expect(fromLabel?.Name == "always")
+
+        await RestartPolicyOverrideStore.shared.set(id: firstInstance, policy: RestartPolicy(Name: "no", MaximumRetryCount: nil))
+        let overridden = await RestartPolicyManager.effectivePolicy(hexId: firstInstance, labels: labels)
+        #expect(overridden?.Name == "no")
+
+        let recreated = await RestartPolicyManager.effectivePolicy(hexId: recreatedInstance, labels: labels)
+        #expect(recreated?.Name == "always")
+
+        await RestartPolicyOverrideStore.shared.remove(id: firstInstance)
+        let restored = await RestartPolicyManager.effectivePolicy(hexId: firstInstance, labels: labels)
+        #expect(restored?.Name == "always")
+    }
+
+    @Test("an invalid policy name is rejected with 400")
+    func invalidPolicyName() async throws {
+        let id = "update-bad-\(UUID().uuidString.prefix(8))"
+        let snapshot = makeSnapshot(id: id)
+        try await withUpdateApp(snapshot) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(["RestartPolicy": RestartPolicy(Name: "sometimes", MaximumRetryCount: nil)])
+                }
+            ) { res async throws in
+                #expect(res.status == .badRequest)
+                let body = try res.content.decode(UpdateErrorBody.self)
+                #expect(body.reason.contains("unknown policy"))
+            }
+        }
+        let stored = await RestartPolicyOverrideStore.shared.get(id: DockerContainerID.hexId(for: snapshot))
+        #expect(stored == nil)
+    }
+
+    @Test("resource-only updates are rejected: VM resources are fixed at create time")
+    func resourceOnlyUpdateRejected() async throws {
+        let id = "update-res-\(UUID().uuidString.prefix(8))"
+        try await withUpdateApp(makeSnapshot(id: id)) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(["Memory": Int64(536_870_912)])
+                }
+            ) { res async throws in
+                #expect(res.status == .badRequest)
+                let body = try res.content.decode(UpdateErrorBody.self)
+                #expect(body.reason.contains("Memory"))
+                #expect(body.reason.contains("fixed at create time"))
+            }
+        }
+    }
+
+    @Test("a policy update alongside resource fields succeeds with a warning")
+    func policyWithResourcesWarns() async throws {
+        let id = "update-warn-\(UUID().uuidString.prefix(8))"
+        let snapshot = makeSnapshot(id: id)
+        struct Payload: Vapor.Content {
+            let RestartPolicy: RestartPolicy
+            let Memory: Int64
+        }
+        try await withUpdateApp(snapshot) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(Payload(RestartPolicy: RestartPolicy(Name: "on-failure", MaximumRetryCount: 3), Memory: 1024))
+                }
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode(UpdateResponseBody.self)
+                #expect(body.Warnings.count == 1)
+                #expect(body.Warnings[0].contains("Memory"))
+            }
+        }
+        let stored = await RestartPolicyOverrideStore.shared.get(id: DockerContainerID.hexId(for: snapshot))
+        #expect(stored?.Name == "on-failure")
+        #expect(stored?.MaximumRetryCount == 3)
+        await RestartPolicyOverrideStore.shared.remove(id: DockerContainerID.hexId(for: snapshot))
+    }
+
+    @Test("a policy update emits a container 'update' event with the canonical hex id")
+    func updateEmitsEvent() async throws {
+        let id = "update-evt-\(UUID().uuidString.prefix(8))"
+        let snapshot = makeSnapshot(id: id)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "update" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerUpdateRoute(client: UpdateMock(snapshot: snapshot)))
+
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(["RestartPolicy": RestartPolicy(Name: "no", MaximumRetryCount: nil)])
+                }
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let timeoutTask = Task {
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            captureTask.cancel()
+        }
+        let event = await captureTask.value
+        timeoutTask.cancel()
+
+        #expect(event?.Type == "container")
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["name"] == id)
+        await RestartPolicyOverrideStore.shared.remove(id: DockerContainerID.hexId(for: snapshot))
+    }
+
+    @Test("overrides survive a store reload from disk")
+    func overridePersistence() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("override-store-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let id = "update-persist-\(UUID().uuidString.prefix(8))"
+
+        let store = RestartPolicyOverrideStore()
+        await store.configure(storageDirectory: dir)
+        await store.set(id: id, policy: RestartPolicy(Name: "unless-stopped", MaximumRetryCount: nil))
+
+        let reloadedStore = RestartPolicyOverrideStore()
+        await reloadedStore.configure(storageDirectory: dir)
+
+        let reloaded = await reloadedStore.get(id: id)
+        #expect(reloaded?.Name == "unless-stopped")
+    }
+
+    @Test("updating an unknown container answers 404")
+    func unknownContainer() async throws {
+        try await withUpdateApp(makeSnapshot(id: "exists")) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/ghost/update",
+                beforeRequest: { req in
+                    try req.content.encode(["RestartPolicy": RestartPolicy(Name: "no", MaximumRetryCount: nil)])
+                }
+            ) { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerUpdateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerUpdateRouteTests.swift
@@ -139,6 +139,23 @@ struct ContainerUpdateRouteTests {
         }
     }
 
+    @Test("an explicit PidsLimit of 0 (unlimited) counts as a resource request, not an empty update")
+    func pidsLimitZeroIsARequest() async throws {
+        let id = "update-pids-\(UUID().uuidString.prefix(8))"
+        try await withUpdateApp(makeSnapshot(id: id)) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/\(id)/update",
+                beforeRequest: { req in
+                    try req.content.encode(["PidsLimit": Int64(0)])
+                }
+            ) { res async throws in
+                #expect(res.status == .badRequest)
+                let body = try res.content.decode(UpdateErrorBody.self)
+                #expect(body.reason.contains("PidsLimit"))
+            }
+        }
+    }
+
     @Test("a policy update alongside resource fields succeeds with a warning")
     func policyWithResourcesWarns() async throws {
         let id = "update-warn-\(UUID().uuidString.prefix(8))"

--- a/Tests/socktainerTests/Utilities/RestartPolicyManagerTests.swift
+++ b/Tests/socktainerTests/Utilities/RestartPolicyManagerTests.swift
@@ -33,10 +33,12 @@ struct RestartPolicyManagerShouldRestartTests {
         #expect(RestartPolicyManager.shouldRestart(policy: policy, exitCode: 1, attempt: 50, hasBeenManuallyStopped: false))
     }
 
-    @Test("always restarts even after an explicit stop/kill, matching moby's documented gotcha")
-    func alwaysIgnoresManualStop() {
-        let policy = RestartPolicy(Name: "always", MaximumRetryCount: nil)
-        #expect(RestartPolicyManager.shouldRestart(policy: policy, exitCode: 0, attempt: 1, hasBeenManuallyStopped: true))
+    @Test("a manual stop suppresses every policy, like moby's restart-manager cancel")
+    func manualStopSuppressesEveryPolicy() {
+        for name in ["always", "unless-stopped", "on-failure"] {
+            let policy = RestartPolicy(Name: name, MaximumRetryCount: nil)
+            #expect(!RestartPolicyManager.shouldRestart(policy: policy, exitCode: 1, attempt: 1, hasBeenManuallyStopped: true), Comment(rawValue: name))
+        }
     }
 
     @Test("unless-stopped restarts regardless of exit code when not manually stopped")
@@ -69,12 +71,6 @@ struct RestartPolicyManagerShouldRestartTests {
     func onFailureUnboundedWithoutMax() {
         let policy = RestartPolicy(Name: "on-failure", MaximumRetryCount: nil)
         #expect(RestartPolicyManager.shouldRestart(policy: policy, exitCode: 1, attempt: 1000, hasBeenManuallyStopped: false))
-    }
-
-    @Test("on-failure restarts on a non-zero exit even after an explicit stop/kill — it only cares about the exit code")
-    func onFailureIgnoresManualStop() {
-        let policy = RestartPolicy(Name: "on-failure", MaximumRetryCount: nil)
-        #expect(RestartPolicyManager.shouldRestart(policy: policy, exitCode: 1, attempt: 1, hasBeenManuallyStopped: true))
     }
 
     @Test("Unknown or 'no' policy names never restart")


### PR DESCRIPTION
## Summary
`POST /containers/{id}/update` was a not-implemented stub — `docker update --restart=no` on a crash-looping container silently did nothing. This implements it for restart policies, the part of `docker update` that is socktainer-side state and therefore honestly implementable on Apple Container.

**Design.** Restart policies are baked into container labels at create time and Apple Container's configuration is immutable afterwards, so update records an **override** consulted before the label, persisted across daemon restarts (`socktainer-restart-policy-overrides.json` in app support; atomic writes, actor-serialized). The store is keyed by the **instance-unique Docker hex id** (name + creation date) — a recreated container gets a fresh key, so a stale override can never apply to the wrong instance, and cleanup (on delete and `--rm` reaping) is hygiene rather than correctness.

**Enforcement reads at decision time, not arm time.** Exit observers capture only the immutable label policy and consult the override at exit time — and again after the restart backoff (up to 60s) — so updating a running container governs its very next exit. Verified against the pre-fix binary: a `--restart=always` crash-looper kept restarting after `docker update --restart=no` (RestartCount 1→4); with this PR it stays `exited`.

**Lifecycle hygiene.** Overrides are removed on DELETE and on `--rm` reaping (which never reaches the DELETE route). No startup sweep: event-driven removal only, so a flaky container listing can never wipe valid overrides — and thanks to instance-unique keying, a missed removal is an unreachable stale entry, never wrong behavior.

**Honest resource handling.** VM resources are fixed at boot: resource-only updates answer 400 with the reason; a policy update combined with resource flags applies the policy and returns a Docker-visible warning. A container `update` event is emitted with the canonical 64-char hex id (#292 convention).

Also documents the verified Apple Container platform limitations (save/export, pause, network connect/disconnect, static IPs, remaining stubs) in the README's Security & Limitations section.

## Related Issue
Found via live API-coverage testing: the endpoint was one of 13 implemented-but-untested routes, 5 of which turned out to be stubs.

## Changes
- `ContainerUpdateRoute`: real handler (validation via shared `RestartPolicyManager.validatePolicy`, 404/400 semantics, warnings, update event)
- `RestartPolicyOverrideStore`: persisted actor + `RestartPolicyManager.effectivePolicy`
- `ContainerStartRoute`: exit-time + post-backoff override reads (observers capture only the immutable label part)
- `ContainerInspectRoute`/`ContainerRestartRoute`: effective-policy reads
- `ContainerCreateRoute`/`ContainerDeleteRoute`/`ContainerAutoRemoveCleanup`: override lifecycle
- README: docker update semantics + platform-limitations documentation

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (8 new route/store tests)
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - live crash-loop stopped at next exit by `docker update --restart=no` (bug proven on pre-fix binary first)
  - override survives daemon restart; applied policy visible in `docker inspect`
  - recreated same-name container starts from its own policy
  - `docker events` shows the `update` event
  - probe behavioral tests CTR-013 (inspect reflects update) and CTR-014 (loop actually stops) green

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
