### PR TITLE
feat(images): implement docker search; fix Docker boolean parsing everywhere

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -386,7 +386,7 @@ struct ClientImageService: ClientImageProtocol {
 
                 if let danglingFilters = filters["dangling"] {
                     if let danglingValue = danglingFilters.first {
-                        let shouldBeDangling = (danglingValue == "true" || danglingValue == "1")
+                        let shouldBeDangling = MobyBool.parse(danglingValue) ?? false
                         if shouldBeDangling {
                             shouldDelete = isDangling
                         } else {

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -90,9 +90,11 @@ struct ClientNetworkService: ClientNetworkProtocol {
         }
         return allNetworks.filter { network in
             var excludedReason: String? = nil
-            if let danglingArr = filtersDict["dangling"], let danglingStr = danglingArr.first {
+            if let danglingArr = filtersDict["dangling"], let danglingStr = danglingArr.first,
+                let wantsDangling = MobyBool.parse(danglingStr)
+            {
                 let isDangling = (network.Containers == nil || network.Containers?.isEmpty == true)
-                if (danglingStr == "true" && !isDangling) || (danglingStr == "false" && isDangling) {
+                if wantsDangling != isDangling {
                     excludedReason = "dangling mismatch"
                 }
             }

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -33,8 +33,8 @@ extension ContainerLogsRoute {
             let fileHandle = boot ? fhs[1] : fhs[0]
             // Create a streaming body
             // `follow=1` means tail like
-            let follow = (try? req.query.get(Bool.self, at: "follow")) ?? false
-            let timestamps = (try? req.query.get(Bool.self, at: "timestamps")) ?? false
+            let follow = MobyBool.queryValue(req.query["follow"] as String?)
+            let timestamps = MobyBool.queryValue(req.query["timestamps"] as String?)
 
             let body = Response.Body { writer in
                 Task.detached {

--- a/Sources/socktainer/Routes/Containers/ContainerStatsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStatsRoute.swift
@@ -13,7 +13,7 @@ struct ContainerStatsRoute: RouteCollection {
             throw Abort(.badRequest, reason: "Missing container ID")
         }
 
-        let stream = (req.query["stream"] as String?) != "false"
+        let stream = MobyBool.queryValue(req.query["stream"] as String?, defaultingTo: true)
         let client = ContainerClient()
 
         // Verify container exists before starting to stream

--- a/Sources/socktainer/Routes/Images/ImageSearchRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageSearchRoute.swift
@@ -1,11 +1,186 @@
+import Foundation
 import Vapor
 
+struct RESTImageSearchResult: Content {
+    let star_count: Int
+    let is_official: Bool
+    let name: String
+    let is_automated: Bool
+    let description: String
+}
+
+struct DockerHubSearchResponse: Codable, Sendable {
+    let results: [DockerHubSearchResult]
+}
+
+struct DockerHubSearchResult: Codable, Sendable {
+    let star_count: Int?
+    let is_official: Bool?
+    let name: String
+    let is_automated: Bool?
+    let description: String?
+}
+
+protocol ImageSearchProviding: Sendable {
+    func search(term: String, limit: Int) async throws -> [DockerHubSearchResult]
+}
+
+/// moby proxies `docker search` to the index server's v1 search endpoint and
+/// filters the results daemon-side — same contract here, against Docker Hub.
+struct DockerHubSearchProvider: ImageSearchProviding {
+    func search(term: String, limit: Int) async throws -> [DockerHubSearchResult] {
+        let url = ImageSearchRoute.searchURL(term: term, limit: limit)
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw Abort(.internalServerError, reason: "cannot reach index.docker.io: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw Abort(.internalServerError, reason: "registry search failed: index.docker.io answered HTTP \(status)")
+        }
+        do {
+            return try JSONDecoder().decode(DockerHubSearchResponse.self, from: data).results
+        } catch {
+            throw Abort(.internalServerError, reason: "registry search failed: unexpected response from index.docker.io")
+        }
+    }
+}
+
 struct ImageSearchRoute: RouteCollection {
-    func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/images/search", use: ImageSearchRoute.handler)
+    let searchProvider: ImageSearchProviding
+
+    init(searchProvider: ImageSearchProviding = DockerHubSearchProvider()) {
+        self.searchProvider = searchProvider
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/images/search", req.method.rawValue)
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/images/search", use: ImageSearchRoute.handler(searchProvider: searchProvider))
+    }
+
+    static func handler(searchProvider: ImageSearchProviding) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let term = try? req.query.get(String.self, at: "term"), !term.isEmpty else {
+                throw Abort(.badRequest, reason: "term is required")
+            }
+            if let registry = registryQualifier(of: term) {
+                throw Abort(.badRequest, reason: "searching registries other than Docker Hub is not supported (term references '\(registry)')")
+            }
+            let limit = try validatedLimit(req.query[Int.self, at: "limit"])
+            let filters = try parseFilters(req.query[String.self, at: "filters"])
+
+            let results = try await searchProvider.search(term: term, limit: limit)
+            let response = try apply(filters: filters, to: results.map(restResult))
+            return try await response.encodeResponse(status: .ok, for: req)
+        }
+    }
+
+    /// moby rejects limits outside 1...100 (registry/search.go, v28.5.2) and
+    /// defaults to 25 when the client sends none.
+    static func validatedLimit(_ raw: Int?) throws -> Int {
+        guard let raw else { return 25 }
+        guard (1...100).contains(raw) else {
+            throw Abort(.badRequest, reason: "limit \(raw) is outside the range of [1, 100]")
+        }
+        return raw
+    }
+
+    /// Docker clients encode filters either as lists ({"stars":["100"]}) or as
+    /// value maps ({"stars":{"100":true}}) — the docker CLI sends the latter.
+    static func parseFilters(_ raw: String?) throws -> [String: [String]] {
+        guard let raw, !raw.isEmpty, let data = raw.data(using: .utf8) else { return [:] }
+        guard let decoded = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw Abort(.badRequest, reason: "invalid filters: \(raw)")
+        }
+        let known: Set<String> = ["is-official", "is-automated", "stars"]
+        var parsed: [String: [String]] = [:]
+        for (key, value) in decoded {
+            guard known.contains(key) else {
+                throw Abort(.badRequest, reason: "invalid filter '\(key)'")
+            }
+            if let list = value as? [String] {
+                parsed[key] = list
+            } else if let map = value as? [String: Bool] {
+                parsed[key] = map.filter { $0.value }.map { $0.key }.sorted()
+            } else {
+                throw Abort(.badRequest, reason: "invalid filter value for '\(key)'")
+            }
+        }
+        return parsed
+    }
+
+    static func apply(filters: [String: [String]], to results: [RESTImageSearchResult]) throws -> [RESTImageSearchResult] {
+        var filtered = results
+        if let official = try boolValue(filters, key: "is-official") {
+            filtered = filtered.filter { $0.is_official == official }
+        }
+        if let automated = try boolValue(filters, key: "is-automated") {
+            filtered = filtered.filter { $0.is_automated == automated }
+        }
+        if let minStars = try minStarsValue(filters) {
+            filtered = filtered.filter { $0.star_count >= minStars }
+        }
+        return filtered
+    }
+
+    static func boolValue(_ filters: [String: [String]], key: String) throws -> Bool? {
+        guard let values = filters[key], !values.isEmpty else { return nil }
+        let parsed = Set(
+            try values.map { value -> Bool in
+                guard let flag = MobyBool.parse(value) else {
+                    throw Abort(.badRequest, reason: "invalid filter '\(key)=\(value)': must be true or false")
+                }
+                return flag
+            })
+        guard parsed.count == 1 else {
+            throw Abort(.badRequest, reason: "invalid filter '\(key)': conflicting values")
+        }
+        return parsed.first
+    }
+
+    static func minStarsValue(_ filters: [String: [String]]) throws -> Int? {
+        guard let values = filters["stars"], !values.isEmpty else { return nil }
+        let parsed = try values.map { value -> Int in
+            guard let stars = Int(value), stars >= 0 else {
+                throw Abort(.badRequest, reason: "invalid filter 'stars=\(value)': must be a non-negative integer")
+            }
+            return stars
+        }
+        return parsed.max()
+    }
+
+    /// A term like `myregistry.example.com/image` targets a specific registry
+    /// in moby; only Docker Hub is supported here, so such terms are rejected
+    /// instead of returning confusing empty Hub matches. Same hostname
+    /// heuristic as docker's reference splitting: the first path segment is a
+    /// registry when it contains a dot, a colon, or is "localhost".
+    static func registryQualifier(of term: String) -> String? {
+        guard let slash = term.firstIndex(of: "/") else { return nil }
+        let candidate = String(term[..<slash])
+        guard candidate.contains(".") || candidate.contains(":") || candidate == "localhost" else { return nil }
+        return candidate
+    }
+
+    static func searchURL(term: String, limit: Int) -> URL {
+        var components = URLComponents(string: "https://index.docker.io/v1/search")!
+        components.queryItems = [
+            URLQueryItem(name: "q", value: term),
+            URLQueryItem(name: "n", value: String(limit)),
+        ]
+        return components.url!
+    }
+
+    static func restResult(_ result: DockerHubSearchResult) -> RESTImageSearchResult {
+        RESTImageSearchResult(
+            star_count: result.star_count ?? 0,
+            is_official: result.is_official ?? false,
+            name: result.name,
+            is_automated: result.is_automated ?? false,
+            description: result.description ?? ""
+        )
     }
 }

--- a/Sources/socktainer/Utilities/DockerConnectionUtility.swift
+++ b/Sources/socktainer/Utilities/DockerConnectionUtility.swift
@@ -535,7 +535,7 @@ public struct ConnectionHijackingMiddleware: AsyncMiddleware {
 
             // Determine content type based on TTY setting if not already set
             if headers.first(name: "Content-Type") == nil {
-                let ttyEnabled = request.query["tty"] == "true" || request.query["Tty"] == "true"
+                let ttyEnabled = MobyBool.queryValue(request.query["tty"]) || MobyBool.queryValue(request.query["Tty"])
                 let contentType = ttyEnabled ? "application/vnd.docker.raw-stream" : "application/vnd.docker.multiplexed-stream"
 
                 headers.replaceOrAdd(name: "Content-Type", value: contentType)

--- a/Sources/socktainer/Utilities/MobyBool.swift
+++ b/Sources/socktainer/Utilities/MobyBool.swift
@@ -1,0 +1,28 @@
+/// Docker clients express booleans two different ways, and moby parses them
+/// with two different rules — mirrored here so every route agrees with dockerd.
+enum MobyBool {
+    /// Filter values: Go's strconv.ParseBool. Anything else is invalid and
+    /// callers should reject it.
+    static func parse(_ value: String) -> Bool? {
+        switch value {
+        case "1", "t", "T", "TRUE", "true", "True": return true
+        case "0", "f", "F", "FALSE", "false", "False": return false
+        default: return nil
+        }
+    }
+
+    /// Query parameters: moby's httputils.BoolValue. Lowercased, false only
+    /// for a small set of spellings — any other non-empty value is true
+    /// (so `tty=1` and even `tty=yes-please` are true, exactly like dockerd).
+    static func queryValue(_ value: String?) -> Bool {
+        !["", "0", "no", "false", "none"].contains((value ?? "").lowercased())
+    }
+
+    /// moby's httputils.BoolValueOrDefault: an absent parameter keeps the
+    /// endpoint's default (stats' `stream` defaults to true); a present one
+    /// follows BoolValue.
+    static func queryValue(_ value: String?, defaultingTo defaultValue: Bool) -> Bool {
+        guard let value else { return defaultValue }
+        return queryValue(value)
+    }
+}

--- a/Sources/socktainer/Utilities/MobyBool.swift
+++ b/Sources/socktainer/Utilities/MobyBool.swift
@@ -11,11 +11,11 @@ enum MobyBool {
         }
     }
 
-    /// Query parameters: moby's httputils.BoolValue. Lowercased, false only
-    /// for a small set of spellings — any other non-empty value is true
-    /// (so `tty=1` and even `tty=yes-please` are true, exactly like dockerd).
+    /// Query parameters: moby's httputils.BoolValue. Trimmed and lowercased,
+    /// false only for a small set of spellings — any other non-empty value is
+    /// true (so `tty=1` and even `tty=yes-please` are true, exactly like dockerd).
     static func queryValue(_ value: String?) -> Bool {
-        !["", "0", "no", "false", "none"].contains((value ?? "").lowercased())
+        !["", "0", "no", "false", "none"].contains((value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
     }
 
     /// moby's httputils.BoolValueOrDefault: an absent parameter keeps the

--- a/Tests/socktainerTests/Routes/ImageSearchRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ImageSearchRouteTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct FakeSearchProvider: ImageSearchProviding {
+    let results: [DockerHubSearchResult]
+    func search(term: String, limit: Int) async throws -> [DockerHubSearchResult] { results }
+}
+
+private let hubResults = [
+    DockerHubSearchResult(star_count: 11_000, is_official: true, name: "nginx", is_automated: false, description: "Official build of Nginx."),
+    DockerHubSearchResult(star_count: 250, is_official: false, name: "bitnami/nginx", is_automated: true, description: "Bitnami nginx"),
+    DockerHubSearchResult(star_count: nil, is_official: nil, name: "someone/nginx-fork", is_automated: nil, description: nil),
+]
+
+private func withSearchApp(_ provider: FakeSearchProvider, run: (Application) async throws -> Void) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+        try app.register(collection: ImageSearchRoute(searchProvider: provider))
+        try await run(app)
+    }
+}
+
+@Suite("ImageSearchRoute")
+struct ImageSearchRouteTests {
+
+    @Test("returns Moby-shaped results with defaults for missing Hub fields")
+    func returnsResults() async throws {
+        try await withSearchApp(FakeSearchProvider(results: hubResults)) { app in
+            try await app.testing().test(.GET, "/v1.51/images/search?term=nginx") { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode([RESTImageSearchResult].self)
+                #expect(body.count == 3)
+                #expect(body[0].name == "nginx")
+                #expect(body[0].is_official)
+                #expect(body[2].star_count == 0)
+                #expect(body[2].description == "")
+            }
+        }
+    }
+
+    @Test("a missing term answers 400")
+    func missingTerm() async throws {
+        try await withSearchApp(FakeSearchProvider(results: [])) { app in
+            try await app.testing().test(.GET, "/v1.51/images/search") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("limits outside 1...100 answer 400, like moby")
+    func invalidLimit() async throws {
+        try await withSearchApp(FakeSearchProvider(results: [])) { app in
+            try await app.testing().test(.GET, "/v1.51/images/search?term=nginx&limit=0") { res async in
+                #expect(res.status == .badRequest)
+            }
+            try await app.testing().test(.GET, "/v1.51/images/search?term=nginx&limit=101") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("is-official and stars filters narrow the results")
+    func filters() async throws {
+        let all = hubResults.map(ImageSearchRoute.restResult)
+
+        let official = try ImageSearchRoute.apply(filters: ["is-official": ["true"]], to: all)
+        #expect(official.map(\.name) == ["nginx"])
+
+        let starred = try ImageSearchRoute.apply(filters: ["stars": ["100"]], to: all)
+        #expect(starred.map(\.name) == ["nginx", "bitnami/nginx"])
+
+        let automated = try ImageSearchRoute.apply(filters: ["is-automated": ["true"]], to: all)
+        #expect(automated.map(\.name) == ["bitnami/nginx"])
+    }
+
+    @Test("invalid filter values are rejected instead of silently ignored")
+    func invalidFilterValues() throws {
+        let all = hubResults.map(ImageSearchRoute.restResult)
+
+        #expect(throws: Abort.self) {
+            try ImageSearchRoute.apply(filters: ["stars": ["abc"]], to: all)
+        }
+        #expect(throws: Abort.self) {
+            try ImageSearchRoute.apply(filters: ["is-official": ["maybe"]], to: all)
+        }
+        #expect(throws: Abort.self) {
+            try ImageSearchRoute.apply(filters: ["is-official": ["false", "true"]], to: all)
+        }
+    }
+
+    @Test("multiple stars values apply the strongest bound")
+    func multipleStarsValues() throws {
+        let all = hubResults.map(ImageSearchRoute.restResult)
+        let filtered = try ImageSearchRoute.apply(filters: ["stars": ["100", "1000"]], to: all)
+        #expect(filtered.map(\.name) == ["nginx"])
+    }
+
+    @Test("boolean filter values accept Go's ParseBool spellings")
+    func parseBoolSpellings() throws {
+        let all = hubResults.map(ImageSearchRoute.restResult)
+        for spelling in ["1", "t", "T", "TRUE", "true", "True"] {
+            let filtered = try ImageSearchRoute.apply(filters: ["is-official": [spelling]], to: all)
+            #expect(filtered.map(\.name) == ["nginx"], "spelling \(spelling)")
+        }
+        #expect(MobyBool.parse("False") == false)
+        #expect(MobyBool.parse("yes") == nil)
+    }
+
+    @Test("registry-qualified terms are rejected: only Docker Hub is searchable")
+    func registryQualifiedTerm() async throws {
+        #expect(ImageSearchRoute.registryQualifier(of: "quay.io/podman") == "quay.io")
+        #expect(ImageSearchRoute.registryQualifier(of: "localhost:5000/img") == "localhost:5000")
+        #expect(ImageSearchRoute.registryQualifier(of: "bitnami/nginx") == nil)
+        #expect(ImageSearchRoute.registryQualifier(of: "nginx") == nil)
+
+        try await withSearchApp(FakeSearchProvider(results: [])) { app in
+            try await app.testing().test(.GET, "/v1.51/images/search?term=quay.io%2Fpodman") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("the docker CLI's map-encoded filters are accepted")
+    func mapEncodedFilters() throws {
+        let parsed = try ImageSearchRoute.parseFilters(#"{"is-official":{"true":true},"stars":{"100":true}}"#)
+        #expect(parsed["is-official"] == ["true"])
+        #expect(parsed["stars"] == ["100"])
+    }
+
+    @Test("unknown filter keys answer 400")
+    func unknownFilter() async throws {
+        try await withSearchApp(FakeSearchProvider(results: [])) { app in
+            try await app.testing().test(
+                .GET, "/v1.51/images/search?term=nginx&filters=%7B%22label%22%3A%5B%22x%22%5D%7D"
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("the Hub URL carries the encoded term and limit")
+    func urlBuilding() {
+        let url = ImageSearchRoute.searchURL(term: "web app", limit: 3)
+        #expect(url.absoluteString == "https://index.docker.io/v1/search?q=web%20app&n=3")
+    }
+
+    @Test("the default limit is moby's 25")
+    func defaultLimit() throws {
+        #expect(try ImageSearchRoute.validatedLimit(nil) == 25)
+        #expect(try ImageSearchRoute.validatedLimit(100) == 100)
+    }
+}

--- a/Tests/socktainerTests/Utilities/MobyBoolTests.swift
+++ b/Tests/socktainerTests/Utilities/MobyBoolTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("MobyBool")
+struct MobyBoolTests {
+
+    @Test("filter values follow Go's strconv.ParseBool")
+    func filterParsing() {
+        for value in ["1", "t", "T", "TRUE", "true", "True"] {
+            #expect(MobyBool.parse(value) == true, "\(value)")
+        }
+        for value in ["0", "f", "F", "FALSE", "false", "False"] {
+            #expect(MobyBool.parse(value) == false, "\(value)")
+        }
+        for value in ["yes", "no", "tRuE", "", " true"] {
+            #expect(MobyBool.parse(value) == nil, "\(value)")
+        }
+    }
+
+    @Test("an absent query parameter keeps the endpoint default, a present one follows BoolValue")
+    func queryDefaulting() {
+        #expect(MobyBool.queryValue(nil, defaultingTo: true))
+        #expect(!MobyBool.queryValue(nil, defaultingTo: false))
+        #expect(!MobyBool.queryValue("0", defaultingTo: true))
+        #expect(MobyBool.queryValue("1", defaultingTo: false))
+    }
+
+    @Test("query parameters follow moby's httputils.BoolValue: only a few spellings are false")
+    func queryParsing() {
+        for value in [nil, "", "0", "no", "false", "FALSE", "none", "No"] as [String?] {
+            #expect(!MobyBool.queryValue(value), "\(value ?? "nil")")
+        }
+        for value in ["1", "true", "t", "yes", "anything-else", " false"] {
+            #expect(MobyBool.queryValue(value), "\(value)")
+        }
+    }
+}

--- a/Tests/socktainerTests/Utilities/MobyBoolTests.swift
+++ b/Tests/socktainerTests/Utilities/MobyBoolTests.swift
@@ -22,16 +22,17 @@ struct MobyBoolTests {
     func queryDefaulting() {
         #expect(MobyBool.queryValue(nil, defaultingTo: true))
         #expect(!MobyBool.queryValue(nil, defaultingTo: false))
+        #expect(!MobyBool.queryValue("", defaultingTo: true))
         #expect(!MobyBool.queryValue("0", defaultingTo: true))
         #expect(MobyBool.queryValue("1", defaultingTo: false))
     }
 
-    @Test("query parameters follow moby's httputils.BoolValue: only a few spellings are false")
+    @Test("query parameters follow moby's httputils.BoolValue: trimmed, only a few spellings are false")
     func queryParsing() {
-        for value in [nil, "", "0", "no", "false", "FALSE", "none", "No"] as [String?] {
+        for value in [nil, "", "0", "no", "false", "FALSE", "none", "No", " false", " 0 "] as [String?] {
             #expect(!MobyBool.queryValue(value), "\(value ?? "nil")")
         }
-        for value in ["1", "true", "t", "yes", "anything-else", " false"] {
+        for value in ["1", "true", "t", "yes", "anything-else"] {
             #expect(MobyBool.queryValue(value), "\(value)")
         }
     }


### PR DESCRIPTION
## Summary
Two related changes, one commit each:

**1. `fix(routes)`: parse Docker booleans with moby's exact semantics.** moby uses two different rules — `strconv.ParseBool` for filter values (`1/t/T/TRUE/true/True` + false variants, error otherwise) and `httputils.BoolValue` for query parameters (lowercased; only `""/0/no/false/none` are false, anything else true; stats' `stream` defaults to true when absent). Socktainer hand-rolled these checks differently at every site. The worst instance: **image prune treated `dangling=True` as `dangling=false` and deleted every image, tagged ones included** — a valid Docker spelling triggering `prune --all` semantics. Also fixed: the network `dangling` filter silently ignoring `1`/`True`, `tty=1` in the attach/exec content-type fallback, `docker stats --no-stream` (`stream=0`) keeping a needless server-side streaming loop, and logs `follow`/`timestamps` dropping truthy spellings. Both rules now live in a single `MobyBool` utility so future routes cannot drift.

**2. `feat(images)`: implement `docker search` as a Docker Hub proxy.** `GET /images/search` was a not-implemented stub. moby forwards search to the index server's v1 endpoint and filters daemon-side — same here against `index.docker.io`, behind an `ImageSearchProviding` seam so the route logic is unit-tested without network. Moby parity: limit 1–100 (default 25, 400 outside), both filter encodings (the docker CLI sends the value-map form), all `ParseBool` boolean spellings, multiple `stars` values take the strongest bound, invalid filter values answer 400 instead of being silently ignored, registry-qualified terms (`quay.io/...`) are rejected with an explicit error, and transport failures report `cannot reach index.docker.io` instead of a generic 500.

**Stated scope boundaries:** search always queries Docker Hub anonymously (no `X-Registry-Auth`, no per-registry routing); fetch-then-filter can return fewer than `limit` results (moby's own behavior); `force`/`all`/`v` style Codable query booleans keep Vapor's decoding, which handles every spelling real Go clients send.

## Related Issue
Found via live API-coverage testing (the endpoint was one of 13 implemented-but-untested routes; 5 turned out to be stubs).

## Changes
- `MobyBool`: strict filter parsing + loose query parsing + defaulting variant, with truth-table tests
- `ClientImageService`/`ClientNetworkService`/`DockerConnectionUtility`/`ContainerStatsRoute`/`ContainerLogsRoute`: migrated to `MobyBool`
- `ImageSearchRoute`: full implementation + 12 route/parsing tests

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (15 new tests across three suites)
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - `docker search` happy path, CLI map-encoded filters, `is-official=True`, invalid `stars=abc` → moby-style 400, `--limit 200` → moby's exact error, `quay.io/podman` → explicit unsupported-registry error
  - `docker stats --no-stream` returns a single sample promptly
  - `docker logs --timestamps` intact
  - probe checks IMG-008 (search), STS-001, LOG-001/002 green against the release binary

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))