### PR TITLE
fix(images): Docker error frames for push/pull/load; aggregate pull progress bars

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -22,7 +22,7 @@ protocol ClientImageProtocol: Sendable {
     func list(includeSystemImages: Bool) async throws -> [ClientImage]
     func delete(id: String) async throws -> ImageDeletionResult
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
-        String, Error
+        PullProgress, Error
     >
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
@@ -40,6 +40,46 @@ extension ClientImageProtocol {
 
 enum ClientImageError: Error {
     case notFound(id: String)
+}
+
+enum PullProgress: Sendable {
+    case message(String)
+    case downloading(current: Int64, total: Int64)
+    case extracting(current: Int64, total: Int64)
+}
+
+actor PullByteCounter {
+    private var current: Int64 = 0
+    private var total: Int64 = 0
+    private var lastEmit: ContinuousClock.Instant?
+    private let emitInterval: Duration
+
+    init(emitInterval: Duration = .milliseconds(100)) {
+        self.emitInterval = emitInterval
+    }
+
+    func apply(_ events: [ProgressUpdateEvent]) -> (current: Int64, total: Int64)? {
+        var changed = false
+        for event in events {
+            switch event {
+            case .addSize(let value): current += value
+            case .setSize(let value): current = value
+            case .addTotalSize(let value): total += value
+            case .setTotalSize(let value): total = value
+            default: continue
+            }
+            changed = true
+        }
+        guard changed, shouldEmitNow() else { return nil }
+        lastEmit = .now
+        return (current, total)
+    }
+
+    private func shouldEmitNow() -> Bool {
+        if total > 0 && current >= total { return true }
+        guard let lastEmit else { return true }
+        return ContinuousClock.Instant.now - lastEmit >= emitInterval
+    }
 }
 
 /// Seam that abstracts the static `ClientImage` API for testing.
@@ -192,7 +232,7 @@ struct ClientImageService: ClientImageProtocol {
     }
 
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<
-        String, Error
+        PullProgress, Error
     > {
         let reference = try {
             guard let tag, !tag.isEmpty else {
@@ -213,9 +253,10 @@ struct ClientImageService: ClientImageProtocol {
 
         return AsyncThrowingStream { continuation in
             logger.info("Starting to pull image \(reference) for platform \(platform.description)")
-            continuation.yield("Trying to pull \(reference)")
+            continuation.yield(.message("Trying to pull \(reference)"))
             Task {
                 do {
+                    let byteCounter = PullByteCounter()
                     let image = try await ClientImage.pull(
                         reference: reference,
                         platform: platform,
@@ -225,30 +266,29 @@ struct ClientImageService: ClientImageProtocol {
                                 switch event {
                                 case .setDescription(let description),
                                     .setSubDescription(let description),
-                                    .setItemsName(let description),
                                     .custom(let description):
-                                    continuation.yield(description)
-                                case .addTotalSize(let size),
-                                    .setTotalSize(let size),
-                                    .addSize(let size),
-                                    .setSize(let size):
-                                    let humanReadableSize = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
-                                    continuation.yield("Downloaded \(humanReadableSize)")
-                                case .addTotalItems(let items),
-                                    .setTotalItems(let items),
-                                    .addItems(let items),
-                                    .setItems(let items):
-                                    continuation.yield("Processing \(items) layer\(items == 1 ? "" : "s")")
+                                    continuation.yield(.message(description))
                                 default:
                                     break
                                 }
                             }
+                            if let bytes = await byteCounter.apply(progressEvents) {
+                                continuation.yield(.downloading(current: bytes.current, total: bytes.total))
+                            }
                         }
                     )
-                    continuation.yield("Unpacking image")
-                    try await image.unpack(platform: platform, progressUpdate: nil)
+                    continuation.yield(.message("Unpacking image"))
+                    let unpackCounter = PullByteCounter()
+                    try await image.unpack(
+                        platform: platform,
+                        progressUpdate: { progressEvents in
+                            if let bytes = await unpackCounter.apply(progressEvents) {
+                                continuation.yield(.extracting(current: bytes.current, total: bytes.total))
+                            }
+                        }
+                    )
                     logger.info("Successfully pulled image \(reference) for platform \(platform.description)")
-                    continuation.yield("Image digest: \(image.digest)")
+                    continuation.yield(.message("Image digest: \(image.digest)"))
                     continuation.finish()
                 } catch {
                     // On arm64 hosts: if the image has no arm64 variant, fall back to amd64 (Rosetta).
@@ -259,7 +299,7 @@ struct ClientImageService: ClientImageProtocol {
                     {
                         let amd64 = Platform(arch: "amd64", os: platform.os, variant: nil)
                         logger.info("arm64 not available for \(reference), retrying with amd64 (Rosetta)")
-                        continuation.yield("linux/arm64 not available — retrying with linux/amd64 (Rosetta)")
+                        continuation.yield(.message("linux/arm64 not available — retrying with linux/amd64 (Rosetta)"))
                         do {
                             let fallbackImage = try await ClientImage.pull(
                                 reference: reference,
@@ -269,16 +309,14 @@ struct ClientImageService: ClientImageProtocol {
                             )
                             try await fallbackImage.unpack(platform: amd64, progressUpdate: nil)
                             logger.info("Successfully pulled \(reference) for amd64 (Rosetta)")
-                            continuation.yield("Image digest: \(fallbackImage.digest)")
+                            continuation.yield(.message("Image digest: \(fallbackImage.digest)"))
                             continuation.finish()
                         } catch let fallbackError {
                             logger.error("amd64 fallback also failed for \(reference): \(fallbackError)")
-                            continuation.yield(String(describing: fallbackError))
                             continuation.finish(throwing: fallbackError)
                         }
                     } else {
                         logger.error("Failed to pull image \(reference): \(error)")
-                        continuation.yield(errMsg)
                         continuation.finish(throwing: error)
                     }
                 }

--- a/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
@@ -54,23 +54,15 @@ extension ImageCreateRoute {
             let pulledRef = "\(image)\(decodedTag.isEmpty ? "" : ":\(decodedTag)")"
             response.body = .init(stream: { writer in
                 Task {
-                    do {
-                        for try await progress in progressStream {
-                            let json = "{\"status\": \"\(progress.replacingOccurrences(of: "\"", with: "\\\""))\"}"  // Docker style
-                            _ = writer.write(.buffer(ByteBuffer(string: json + "\n")))
-                        }
-                        _ = writer.write(.end)
-                        if let broadcaster = app.storage[EventBroadcasterKey.self] {
-                            // moby's pull event uses the reference as Actor.ID and the
-                            // image name as the `name` attribute (no `image` key).
-                            await broadcaster.broadcast(
-                                DockerEvent.make(
-                                    type: "image", action: "pull", actorID: pulledRef,
-                                    attributes: ["name": image]))
-                        }
-                    } catch {
-                        _ = writer.write(.buffer(ByteBuffer(string: "{\"error\": \"\(error.localizedDescription)\"}\n")))
-                        _ = writer.write(.error(error))
+                    let progressId = pulledRef.split(separator: "/").last.map(String.init) ?? pulledRef
+                    await DockerProgressFrame.pipe(progressStream, id: progressId, to: writer) {
+                        guard let broadcaster = app.storage[EventBroadcasterKey.self] else { return }
+                        // moby's pull event uses the reference as Actor.ID and the
+                        // image name as the `name` attribute (no `image` key).
+                        await broadcaster.broadcast(
+                            DockerEvent.make(
+                                type: "image", action: "pull", actorID: pulledRef,
+                                attributes: ["name": image]))
                     }
                 }
             })

--- a/Sources/socktainer/Routes/Images/ImagePushRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagePushRoute.swift
@@ -46,10 +46,7 @@ extension ImagePushRoute {
                 do {
                     platform = try platformOrThrow(platformString)
                 } catch {
-                    let response = Response(status: .internalServerError)
-                    response.headers.add(name: .contentType, value: "application/json")
-                    response.body = .init(string: "{\"message\": \"Failed to parse platform\"}\n")
-                    return response
+                    throw Abort(.badRequest, reason: "invalid platform: \(platformString)")
                 }
             } else {
                 platform = nil
@@ -58,24 +55,24 @@ extension ImagePushRoute {
             let response = Response()
             response.headers.add(name: .contentType, value: "application/json")
 
-            let progressStream = try await client.push(
-                reference: reference,
-                platform: platform,
-                logger: req.logger
-            )
+            let progressStream: AsyncThrowingStream<String, Error>
+            do {
+                progressStream = try await client.push(
+                    reference: reference,
+                    platform: platform,
+                    logger: req.logger
+                )
+            } catch ClientImageError.notFound(let id) {
+                throw Abort(.notFound, reason: "No such image: \(id)")
+            } catch let abort as Abort {
+                throw abort
+            } catch {
+                throw Abort(.internalServerError, reason: "Failed to push \(reference): \(error)")
+            }
 
             response.body = .init(stream: { writer in
                 Task {
-                    do {
-                        for try await progress in progressStream {
-                            let json = "{\"status\": \"\(progress.replacingOccurrences(of: "\"", with: "\\\""))\"}"
-                            _ = writer.write(.buffer(ByteBuffer(string: json + "\n")))
-                        }
-                        _ = writer.write(.end)
-                    } catch {
-                        _ = writer.write(.buffer(ByteBuffer(string: "{\"error\": \"\(error.localizedDescription)\"}\n")))
-                        _ = writer.write(.error(error))
-                    }
+                    await DockerProgressFrame.pipe(progressStream, to: writer)
                 }
             })
             return response

--- a/Sources/socktainer/Routes/Images/ImagesLoadRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesLoadRoute.swift
@@ -25,10 +25,7 @@ extension ImagesLoadRoute {
                 do {
                     platform = try platformOrThrow(platformString)
                 } catch {
-                    let response = Response(status: .badRequest)
-                    response.headers.add(name: .contentType, value: "application/json")
-                    response.body = .init(string: "{\"message\": \"Failed to parse platform\"}\n")
-                    return response
+                    throw Abort(.badRequest, reason: "invalid platform: \(platformString)")
                 }
             } else {
                 platform = currentPlatform()
@@ -53,7 +50,7 @@ extension ImagesLoadRoute {
                         }
 
                         guard bodyBuffer.readableBytes > 0 else {
-                            _ = writer.write(.buffer(ByteBuffer(string: "{\"message\": \"Request body is required\"}\n")))
+                            DockerProgressFrame.write(DockerProgressFrame.error("Request body is required"), to: writer)
                             _ = writer.write(.end)
                             return
                         }
@@ -69,13 +66,13 @@ extension ImagesLoadRoute {
                         try Data(buffer: bodyBuffer).write(to: tarPath)
 
                         guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
-                            _ = writer.write(.buffer(ByteBuffer(string: "{\"error\": \"AppleContainerAppSupportUrl not configured\"}\n")))
+                            DockerProgressFrame.write(DockerProgressFrame.error("AppleContainerAppSupportUrl not configured"), to: writer)
                             _ = writer.write(.end)
                             return
                         }
 
                         if !quiet {
-                            _ = writer.write(.buffer(ByteBuffer(string: "{\"status\": \"Loading images from tarball\"}\n")))
+                            DockerProgressFrame.write(DockerProgressFrame.status("Loading images from tarball"), to: writer)
                         }
 
                         let loadedImages = try await client.load(
@@ -83,16 +80,16 @@ extension ImagesLoadRoute {
 
                         for image in loadedImages {
                             if !quiet {
-                                _ = writer.write(.buffer(ByteBuffer(string: "{\"status\": \"Loaded image \(image)\"}\n")))
+                                DockerProgressFrame.write(DockerProgressFrame.status("Loaded image \(image)"), to: writer)
                             }
-                            _ = writer.write(.buffer(ByteBuffer(string: "{\"stream\": \"Loaded image: \(image)\"}\n")))
+                            DockerProgressFrame.write(DockerProgressFrame.stream("Loaded image: \(image)\n"), to: writer)
                         }
 
                         _ = writer.write(.end)
                     } catch {
                         req.logger.error("Failed to load images: \(error)")
-                        _ = writer.write(.buffer(ByteBuffer(string: "{\"error\": \"\(error.localizedDescription)\"}\n")))
-                        _ = writer.write(.error(error))
+                        DockerProgressFrame.write(DockerProgressFrame.error(String(describing: error)), to: writer)
+                        _ = writer.write(.end)
                     }
                 }
             })

--- a/Sources/socktainer/Utilities/DockerProgressFrame.swift
+++ b/Sources/socktainer/Utilities/DockerProgressFrame.swift
@@ -76,4 +76,29 @@ enum DockerProgressFrame {
         _ = writer.write(.end)
     }
 
+    /// Pull variant: byte counts become a single aggregate progress bar
+    /// keyed on `id` (apple/container reports no per-layer attribution).
+    static func pipe(
+        _ progress: AsyncThrowingStream<PullProgress, Error>,
+        id: String,
+        to writer: any BodyStreamWriter,
+        onSuccess: (() async -> Void)? = nil
+    ) async {
+        do {
+            for try await update in progress {
+                switch update {
+                case .message(let message):
+                    write(status(message), to: writer)
+                case .downloading(let current, let total):
+                    write(Self.progress(status: "Downloading", id: id, current: current, total: total), to: writer)
+                case .extracting(let current, let total):
+                    write(Self.progress(status: "Extracting", id: id, current: current, total: total), to: writer)
+                }
+            }
+            await onSuccess?()
+        } catch {
+            write(Self.error(String(describing: error)), to: writer)
+        }
+        _ = writer.write(.end)
+    }
 }

--- a/Sources/socktainer/Utilities/DockerProgressFrame.swift
+++ b/Sources/socktainer/Utilities/DockerProgressFrame.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Vapor
+
+/// JSON frames for Docker's progress-stream protocol (push/pull/load).
+/// Failures must travel as a final error frame on a cleanly-ended body:
+/// aborting the connection makes the docker CLI report "unexpected EOF".
+enum DockerProgressFrame {
+    private struct StatusFrame: Encodable {
+        let status: String
+    }
+
+    private struct ErrorFrame: Encodable {
+        struct Detail: Encodable {
+            let message: String
+        }
+        let errorDetail: Detail
+        let error: String
+    }
+
+    private struct StreamFrame: Encodable {
+        let stream: String
+    }
+
+    private struct ProgressBarFrame: Encodable {
+        struct Detail: Encodable {
+            let current: Int64
+            let total: Int64
+        }
+        let status: String
+        let id: String
+        let progressDetail: Detail
+    }
+
+    static func status(_ message: String) -> String {
+        encode(StatusFrame(status: message))
+    }
+
+    static func stream(_ message: String) -> String {
+        encode(StreamFrame(stream: message))
+    }
+
+    static func progress(status: String, id: String, current: Int64, total: Int64) -> String {
+        encode(ProgressBarFrame(status: status, id: id, progressDetail: .init(current: current, total: total)))
+    }
+
+    static func error(_ message: String) -> String {
+        encode(ErrorFrame(errorDetail: .init(message: message), error: message))
+    }
+
+    private static func encode(_ frame: some Encodable) -> String {
+        guard let data = try? JSONEncoder().encode(frame), let json = String(data: data, encoding: .utf8) else {
+            return #"{"error": "internal error"}"# + "\n"
+        }
+        return json + "\n"
+    }
+
+    static func write(_ frame: String, to writer: any BodyStreamWriter) {
+        _ = writer.write(.buffer(ByteBuffer(string: frame)))
+    }
+
+    /// Streams progress messages as status frames, converts a thrown error
+    /// into a final error frame, and always ends the body cleanly.
+    static func pipe(
+        _ progress: AsyncThrowingStream<String, Error>,
+        to writer: any BodyStreamWriter,
+        onSuccess: (() async -> Void)? = nil
+    ) async {
+        do {
+            for try await message in progress {
+                write(status(message), to: writer)
+            }
+            await onSuccess?()
+        } catch {
+            write(Self.error(String(describing: error)), to: writer)
+        }
+        _ = writer.write(.end)
+    }
+
+}

--- a/Tests/socktainerTests/Clients/PullByteCounterTests.swift
+++ b/Tests/socktainerTests/Clients/PullByteCounterTests.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("PullByteCounter")
+struct PullByteCounterTests {
+
+    @Test("accumulates add and set size events")
+    func accumulation() async {
+        let counter = PullByteCounter(emitInterval: .zero)
+        let first = await counter.apply([.addTotalSize(1000), .addSize(200)])
+        #expect(first?.current == 200)
+        #expect(first?.total == 1000)
+
+        let second = await counter.apply([.addSize(300), .setTotalSize(2000)])
+        #expect(second?.current == 500)
+        #expect(second?.total == 2000)
+
+        let overridden = await counter.apply([.setSize(1999)])
+        #expect(overridden?.current == 1999)
+    }
+
+    @Test("batches without size events emit nothing")
+    func ignoresNonSizeEvents() async {
+        let counter = PullByteCounter(emitInterval: .zero)
+        let result = await counter.apply([.setDescription("Pulling"), .addItems(3)])
+        #expect(result == nil)
+    }
+
+    @Test("rapid batches are throttled, completion always emits")
+    func throttling() async {
+        let counter = PullByteCounter(emitInterval: .seconds(3600))
+        let first = await counter.apply([.addTotalSize(100), .addSize(10)])
+        #expect(first != nil)
+
+        let suppressed = await counter.apply([.addSize(10)])
+        #expect(suppressed == nil)
+
+        let completion = await counter.apply([.addSize(80)])
+        #expect(completion?.current == 100)
+        #expect(completion?.total == 100)
+    }
+}

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -134,7 +134,7 @@ private struct DanglingImageDeleteMock: ClientImageProtocol {
         ImageDeletionResult(untagged: untagged, digest: "sha256:abc123", deletedDigest: "sha256:abc123")
     }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
-        -> AsyncThrowingStream<String, Error>
+        -> AsyncThrowingStream<PullProgress, Error>
     { AsyncThrowingStream { $0.finish() } }
     func push(reference: String, platform: Platform?, logger: Logger) async throws
         -> AsyncThrowingStream<String, Error>
@@ -155,7 +155,7 @@ private struct ImageDeleteMock: ClientImageProtocol {
         ImageDeletionResult(untagged: "docker.io/library/\(id)", digest: digest, deletedDigest: nil)
     }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
-        -> AsyncThrowingStream<String, Error>
+        -> AsyncThrowingStream<PullProgress, Error>
     {
         AsyncThrowingStream { $0.finish() }
     }

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -436,7 +436,7 @@ private struct StubImageClient: ClientImageProtocol {
         ImageDeletionResult(untagged: id, digest: "sha256:abc", deletedDigest: nil)
     }
     func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws
-        -> AsyncThrowingStream<String, Error>
+        -> AsyncThrowingStream<PullProgress, Error>
     {
         AsyncThrowingStream { $0.finish() }
     }

--- a/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
+++ b/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
@@ -102,7 +102,7 @@ private struct FixedResultImageMock: ClientImageProtocol {
     let result: ImageDeletionResult
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
     func delete(id: String) async throws -> ImageDeletionResult { result }
-    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
         AsyncThrowingStream { $0.finish() }
     }
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {

--- a/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
@@ -52,7 +52,7 @@ private struct EmptyContainerClient: ClientContainerProtocol {
 private struct StubImageClient: ClientImageProtocol {
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
     func delete(id: String) async throws -> ImageDeletionResult { ImageDeletionResult(untagged: id, digest: "sha256:abc", deletedDigest: nil) }
-    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
         AsyncThrowingStream { $0.finish() }
     }
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {

--- a/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
@@ -12,7 +12,7 @@ import VaporTesting
 private struct EmptyImageClient: ClientImageProtocol {
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
     func delete(id: String) async throws -> ImageDeletionResult { fatalError("not exercised by this test") }
-    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
         AsyncThrowingStream { $0.finish() }
     }
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {

--- a/Tests/socktainerTests/Utilities/DockerProgressFrameTests.swift
+++ b/Tests/socktainerTests/Utilities/DockerProgressFrameTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("DockerProgressFrame")
+struct DockerProgressFrameTests {
+
+    private func decode(_ frame: String) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: Data(frame.utf8))
+        return object as? [String: Any] ?? [:]
+    }
+
+    @Test("status frames carry the message and end with a newline")
+    func statusFrame() throws {
+        let frame = DockerProgressFrame.status("Pushing layer 3/5")
+        #expect(frame.hasSuffix("\n"))
+        let json = try decode(frame)
+        #expect(json["status"] as? String == "Pushing layer 3/5")
+    }
+
+    @Test("error frames use moby's errorDetail shape")
+    func errorFrame() throws {
+        let frame = DockerProgressFrame.error("no credentials found for host registry-1.docker.io")
+        let json = try decode(frame)
+        #expect(json["error"] as? String == "no credentials found for host registry-1.docker.io")
+        let detail = json["errorDetail"] as? [String: Any]
+        #expect(detail?["message"] as? String == "no credentials found for host registry-1.docker.io")
+    }
+
+    @Test("progress-bar frames carry status, id and aggregate byte counts")
+    func progressBarFrame() throws {
+        let frame = DockerProgressFrame.progress(status: "Downloading", id: "alpine:3.21", current: 1_048_576, total: 4_194_304)
+        let json = try decode(frame)
+        #expect(json["status"] as? String == "Downloading")
+        #expect(json["id"] as? String == "alpine:3.21")
+        let detail = json["progressDetail"] as? [String: Any]
+        #expect(detail?["current"] as? Int == 1_048_576)
+        #expect(detail?["total"] as? Int == 4_194_304)
+    }
+
+    @Test("messages with quotes, newlines and backslashes stay valid JSON")
+    func escaping() throws {
+        let hostile = "HTTP request failed:\n response: 401 \"Unauthorized\" \\ raw"
+        let statusJson = try decode(DockerProgressFrame.status(hostile))
+        #expect(statusJson["status"] as? String == hostile)
+        let errorJson = try decode(DockerProgressFrame.error(hostile))
+        #expect(errorJson["error"] as? String == hostile)
+    }
+}


### PR DESCRIPTION
## Summary
Two commits:

**1. `fix(images)`: deliver push/pull/load failures as Docker error frames, not connection aborts.** Docker's progress-stream protocol carries failures as a final `{"errorDetail":…}` frame on a **cleanly-ended** body — aborting the connection (`writer.write(.error(…))`) made the CLI report `unexpected EOF` and bury the actual registry error on every failed `docker push`, `pull` and `load`. All streaming now goes through `DockerProgressFrame`, which owns the frame shapes (JSON-encoded — registry errors contain newlines/quotes that broke the old interpolated encoding) and the loop/error/clean-end choreography. The invariant across all three routes: pre-stream failures → `Abort` with a real reason (push: 404 unknown image; push/load: 400 invalid platform), in-stream failures → error frame + clean end (CLI prints the message once, exits 1). Load's `stream` frame carries moby's trailing newline and its empty-body guard answers a real error frame.

**2. `feat(images)`: aggregate pull progress bars.** apple/container reports progress as **aggregate byte counters with no per-layer attribution** (verified against both upstream progress APIs), so moby's per-layer bars are impossible — but single **Downloading** and **Extracting** bars with real current/total counts are: pull yields typed `PullProgress` and the route emits moby-shaped `progressDetail` frames keyed on the short image reference, throttled to moby's ~100ms cadence (477 → 7 frames on a busybox pull) with the completion frame always emitted. Unpack is no longer silent on large images. Pull failures surface once — the redundant pre-throw message frame is gone.

**Known boundary:** per-layer progress requires per-layer attribution that apple/container's progress API doesn't provide; the aggregate bar is the honest maximum.

## Related Issue
Found via live API-coverage testing (probe IMG-009 flagged push error swallowing; the pull/load instances surfaced while fixing the class).

## Changes
- `DockerProgressFrame`: status/stream/progress-bar/error frames + `write`/`pipe` plumbing, truth-table tests incl. hostile characters
- `ImagePushRoute`/`ImageCreateRoute`/`ImagesLoadRoute`: refactored onto the frame pipeline
- `ClientImageService`: typed `PullProgress` stream; `PullByteCounter` actor (accumulation + throttling, injectable interval) with tests
- 5 test mocks migrated to the typed pull signature

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (7 new tests: frame encoding, counter accumulation/throttle/completion)
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - push to unauthorized registry: real 401 shown once, exit 1, no `unexpected EOF`
  - pull of nonexistent image: real error, exit 1; happy pull streams and completes
  - `docker load` of garbage tar and of an empty body: real error frames, exit 1
  - wire captures: `progressDetail` frames with growing totals, both Downloading and Extracting phases, 7 frames after throttling
  - full live integration suite: 91 passed; remaining failures are features on sibling PRs (#308/#309) plus one pre-existing `--rm` flake cleared by 8 consecutive passes

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))