### PR TITLE
feat(registry): implement GET /distribution/{name}/json

### DIFF
--- a/Sources/socktainer/Routes/Registry/DistributionJsonRoute.swift
+++ b/Sources/socktainer/Routes/Registry/DistributionJsonRoute.swift
@@ -1,11 +1,154 @@
+import ContainerAPIClient
+import ContainerPersistence
+import ContainerizationOCI
+import Foundation
 import Vapor
 
-struct DistributionJsonRoute: RouteCollection {
-    func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/distribution/{name}/json", use: DistributionJsonRoute.handler)
+struct RESTDistributionInspect: Vapor.Content {
+    struct RESTDescriptor: Vapor.Content {
+        let mediaType: String
+        let digest: String
+        let size: Int64
     }
 
-    static func handler(_ req: Request) async throws -> Response {
-        NotImplemented.respond("/distribution/{name}/json", req.method.rawValue)
+    struct RESTPlatform: Vapor.Content {
+        let architecture: String
+        let os: String
+        let variant: String?
+    }
+
+    let Descriptor: RESTDescriptor
+    let Platforms: [RESTPlatform]
+}
+
+protocol DistributionInspectProviding: Sendable {
+    func inspect(reference: String, authentication: Authentication?) async throws -> RESTDistributionInspect
+}
+
+struct RegistryDistributionProvider: DistributionInspectProviding {
+    let containerSystemConfig: ContainerSystemConfig
+
+    func inspect(reference: String, authentication: Authentication?) async throws -> RESTDistributionInspect {
+        let parsed: Reference
+        do {
+            let normalized = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
+            parsed = try Reference.parse(normalized)
+            parsed.normalize()
+        } catch {
+            throw Abort(.badRequest, reason: "invalid reference: \(reference)")
+        }
+        guard let server = parsed.resolvedDomain else {
+            throw Abort(.badRequest, reason: "invalid reference: \(reference)")
+        }
+        let auth = authentication ?? keychainAuthentication(host: server) ?? parsed.domain.flatMap(keychainAuthentication)
+        let client = try registryClient(server: server, authentication: auth)
+
+        let name = parsed.path
+        let descriptor = try await client.resolve(name: name, tag: parsed.digest ?? parsed.tag ?? "latest")
+        let platforms = try await platforms(of: descriptor, name: name, client: client)
+
+        return RESTDistributionInspect(
+            Descriptor: .init(mediaType: descriptor.mediaType, digest: descriptor.digest, size: descriptor.size),
+            Platforms: platforms
+        )
+    }
+
+    private func registryClient(server: String, authentication: Authentication?) throws -> RegistryClient {
+        let scheme = try RequestScheme.auto.schemeFor(host: server, internalDnsDomain: containerSystemConfig.dns.domain)
+        guard let url = URL(string: "\(scheme.rawValue)://\(server)"), let host = url.host else {
+            throw Abort(.badRequest, reason: "invalid registry host: \(server)")
+        }
+        return RegistryClient(host: host, scheme: scheme.rawValue, port: url.port, authentication: authentication)
+    }
+
+    private func keychainAuthentication(host: String) -> Authentication? {
+        try? KeychainHelper(securityDomain: Constants.keychainID).lookup(hostname: host)
+    }
+
+    private func platforms(of descriptor: Descriptor, name: String, client: RegistryClient) async throws -> [RESTDistributionInspect.RESTPlatform] {
+        switch descriptor.mediaType {
+        case MediaTypes.index, MediaTypes.dockerManifestList:
+            let index: Index = try await client.fetch(name: name, descriptor: descriptor)
+            return index.manifests
+                .compactMap(\.platform)
+                .filter { $0.os != "unknown" && $0.architecture != "unknown" }
+                .map { RESTDistributionInspect.RESTPlatform(architecture: $0.architecture, os: $0.os, variant: $0.variant) }
+        case MediaTypes.imageManifest, MediaTypes.dockerManifest:
+            let manifest: Manifest = try await client.fetch(name: name, descriptor: descriptor)
+            let config: Image = try await client.fetch(name: name, descriptor: manifest.config)
+            return [RESTDistributionInspect.RESTPlatform(architecture: config.architecture, os: config.os, variant: config.variant)]
+        default:
+            return []
+        }
+    }
+}
+
+struct DistributionJsonRoute: RouteCollection {
+    let inspectProvider: DistributionInspectProviding
+
+    init(inspectProvider: DistributionInspectProviding) {
+        self.inspectProvider = inspectProvider
+    }
+
+    init(systemConfig: ContainerSystemConfig) {
+        self.inspectProvider = RegistryDistributionProvider(containerSystemConfig: systemConfig)
+    }
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/distribution/{name:.*}/json", use: DistributionJsonRoute.handler(inspectProvider: inspectProvider))
+    }
+
+    static func handler(inspectProvider: DistributionInspectProviding) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name"), !name.isEmpty else {
+                throw Abort(.badRequest, reason: "Missing image reference")
+            }
+            do {
+                let inspect = try await inspectProvider.inspect(reference: name, authentication: registryAuth(from: req))
+                return try await inspect.encodeResponse(status: .ok, for: req)
+            } catch let error as RegistryClient.Error {
+                throw abort(for: error, reference: name)
+            } catch let abort as Abort {
+                throw abort
+            } catch {
+                throw Abort(.internalServerError, reason: "distribution inspect of \(name) failed: \(error)")
+            }
+        }
+    }
+
+    /// moby's X-Registry-Auth header: base64url JSON credentials sent by
+    /// docker clients that logged in via `docker login`.
+    static func registryAuth(from req: Request) -> Authentication? {
+        guard let header = req.headers.first(name: "X-Registry-Auth"), !header.isEmpty else { return nil }
+        guard let credentials = decodeRegistryAuth(header), !credentials.username.isEmpty else { return nil }
+        return BasicAuthentication(username: credentials.username, password: credentials.password)
+    }
+
+    static func decodeRegistryAuth(_ header: String) -> (username: String, password: String)? {
+        var base64 = header.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64.append("=") }
+        struct AuthConfig: Decodable {
+            let username: String?
+            let password: String?
+        }
+        guard let data = Data(base64Encoded: base64),
+            let config = try? JSONDecoder().decode(AuthConfig.self, from: data)
+        else { return nil }
+        guard let username = config.username, let password = config.password else { return nil }
+        return (username, password)
+    }
+
+    static func abort(for error: RegistryClient.Error, reference: String) -> Abort {
+        switch error {
+        case .invalidStatus(_, let status, let reason):
+            switch status.code {
+            case 404:
+                return Abort(.notFound, reason: "manifest unknown: \(reference)")
+            case 401, 403:
+                return Abort(.unauthorized, reason: "access to \(reference) is denied: \(reason ?? "authentication required")")
+            default:
+                return Abort(.internalServerError, reason: String(describing: error))
+            }
+        }
     }
 }

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -126,7 +126,7 @@ func configure(_ app: Application) async throws {
     // --- build/distribution routes ---
     try app.register(collection: BuildPruneRoute(builderClient: builderClient))
     try app.register(collection: BuildRoute(client: containerClient, builderClient: builderClient, systemConfig: systemConfig))
-    try app.register(collection: DistributionJsonRoute())
+    try app.register(collection: DistributionJsonRoute(systemConfig: systemConfig))
 
     // --- plugin routes ---
     try app.register(collection: PluginsCreateRoute())

--- a/Tests/socktainerTests/Routes/DistributionJsonRouteTests.swift
+++ b/Tests/socktainerTests/Routes/DistributionJsonRouteTests.swift
@@ -1,0 +1,134 @@
+import ContainerizationError
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+private struct FakeDistributionProvider: DistributionInspectProviding {
+    let result: RESTDistributionInspect?
+    let error: Error?
+
+    func inspect(reference: String, authentication: Authentication?) async throws -> RESTDistributionInspect {
+        if let error { throw error }
+        return result!
+    }
+}
+
+private let alpineInspect = RESTDistributionInspect(
+    Descriptor: .init(
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        digest: "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d",
+        size: 1638
+    ),
+    Platforms: [
+        .init(architecture: "arm64", os: "linux", variant: "v8"),
+        .init(architecture: "amd64", os: "linux", variant: nil),
+    ]
+)
+
+private func withDistributionApp(_ provider: FakeDistributionProvider, run: (Application) async throws -> Void) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+        try app.register(collection: DistributionJsonRoute(inspectProvider: provider))
+        try await run(app)
+    }
+}
+
+@Suite("DistributionJsonRoute")
+struct DistributionJsonRouteTests {
+
+    @Test("returns the Moby-shaped descriptor and platforms")
+    func returnsInspect() async throws {
+        try await withDistributionApp(FakeDistributionProvider(result: alpineInspect, error: nil)) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/alpine/json") { res async throws in
+                #expect(res.status == .ok)
+                let body = try res.content.decode(RESTDistributionInspect.self)
+                #expect(body.Descriptor.digest.hasPrefix("sha256:"))
+                #expect(body.Platforms.count == 2)
+                #expect(body.Platforms[0].architecture == "arm64")
+            }
+        }
+    }
+
+    @Test("slash-qualified references reach the provider intact")
+    func slashQualifiedReference() async throws {
+        try await withDistributionApp(FakeDistributionProvider(result: alpineInspect, error: nil)) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/public.ecr.aws/docker/library/alpine/json") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test("registry 404 answers manifest unknown")
+    func manifestUnknown() async throws {
+        let registryError = RegistryClient.Error.invalidStatus(url: "https://x", .notFound, reason: nil)
+        try await withDistributionApp(FakeDistributionProvider(result: nil, error: registryError)) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/ghost/json") { res async throws in
+                #expect(res.status == .notFound)
+                struct Body: Vapor.Content { let reason: String }
+                let body = try res.content.decode(Body.self)
+                #expect(body.reason.contains("manifest unknown"))
+            }
+        }
+    }
+
+    @Test("registry 401 answers unauthorized")
+    func unauthorized() async throws {
+        let registryError = RegistryClient.Error.invalidStatus(url: "https://x", .unauthorized, reason: "auth required")
+        try await withDistributionApp(FakeDistributionProvider(result: nil, error: registryError)) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/private/json") { res async in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
+    @Test("provider-thrown 400s pass through untouched")
+    func invalidReference() async throws {
+        let parseError = Abort(.badRequest, reason: "invalid reference: UPPER!!bad")
+        try await withDistributionApp(FakeDistributionProvider(result: nil, error: parseError)) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/UPPER!!bad/json") { res async throws in
+                #expect(res.status == .badRequest)
+                struct Body: Vapor.Content { let reason: String }
+                let body = try res.content.decode(Body.self)
+                #expect(body.reason.contains("invalid reference"))
+            }
+        }
+    }
+
+    @Test("transport failures surface their reason instead of a masked 500")
+    func transportFailure() async throws {
+        struct ConnectionRefused: Error, CustomStringConvertible {
+            var description: String { "Connection refused (localhost:5000)" }
+        }
+        try await withDistributionApp(FakeDistributionProvider(result: nil, error: ConnectionRefused())) { app in
+            try await app.testing().test(.GET, "/v1.51/distribution/localhost:5000/img/json") { res async throws in
+                #expect(res.status == .internalServerError)
+                struct Body: Vapor.Content { let reason: String }
+                let body = try res.content.decode(Body.self)
+                #expect(body.reason.contains("Connection refused"))
+            }
+        }
+    }
+
+    @Test("X-Registry-Auth decodes docker's base64url credential JSON")
+    func registryAuthHeader() {
+        let json = #"{"username":"sylvain","password":"hunter2","serveraddress":"https://index.docker.io/v1/"}"#
+        let header = Data(json.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let decoded = DistributionJsonRoute.decodeRegistryAuth(header)
+        #expect(decoded?.username == "sylvain")
+        #expect(decoded?.password == "hunter2")
+
+        #expect(DistributionJsonRoute.decodeRegistryAuth("not-base64!") == nil)
+        #expect(DistributionJsonRoute.decodeRegistryAuth(Data("{}".utf8).base64EncodedString()) == nil)
+    }
+}

--- a/Tests/socktainerTests/Routes/DistributionJsonRouteTests.swift
+++ b/Tests/socktainerTests/Routes/DistributionJsonRouteTests.swift
@@ -7,11 +7,18 @@ import VaporTesting
 
 @testable import socktainer
 
-private struct FakeDistributionProvider: DistributionInspectProviding {
+private actor FakeDistributionProvider: DistributionInspectProviding {
     let result: RESTDistributionInspect?
     let error: Error?
+    private(set) var receivedReference: String?
+
+    init(result: RESTDistributionInspect?, error: Error?) {
+        self.result = result
+        self.error = error
+    }
 
     func inspect(reference: String, authentication: Authentication?) async throws -> RESTDistributionInspect {
+        receivedReference = reference
         if let error { throw error }
         return result!
     }
@@ -58,11 +65,13 @@ struct DistributionJsonRouteTests {
 
     @Test("slash-qualified references reach the provider intact")
     func slashQualifiedReference() async throws {
-        try await withDistributionApp(FakeDistributionProvider(result: alpineInspect, error: nil)) { app in
+        let provider = FakeDistributionProvider(result: alpineInspect, error: nil)
+        try await withDistributionApp(provider) { app in
             try await app.testing().test(.GET, "/v1.51/distribution/public.ecr.aws/docker/library/alpine/json") { res async in
                 #expect(res.status == .ok)
             }
         }
+        #expect(await provider.receivedReference == "public.ecr.aws/docker/library/alpine")
     }
 
     @Test("registry 404 answers manifest unknown")


### PR DESCRIPTION
## Summary
`GET /distribution/{name}/json` was a not-implemented stub. It now resolves the manifest **descriptor** and **platform list** from the registry without pulling — what compose and other tooling probe before pulls — using the dependency tree's own `RegistryClient` (anonymous token flow, proxy support).

**Reference handling.** References are normalized through socktainer's configured default registry first (OCI's `Reference.normalize()` never adds a missing domain, so bare `alpine` would otherwise fail — caught live). Short refs, fully-qualified refs, tags and digests all work.

**Registry client construction mirrors `container registry login`**: `RequestScheme.auto` (http for localhost/private IPs/internal-DNS hosts, https otherwise) and URL-based host/port splitting, so insecure local registries (`localhost:5000/img`) work.

**Authentication, three tiers**: the docker client's `X-Registry-Auth` header (base64url credential JSON), then the keychain under the **resolved** domain — verified against `RegistryLogin`'s save path; looking up the raw domain would silently miss stored credentials — then anonymous.

**Platforms** come from the index (attestation manifests' `unknown/unknown` filtered, like moby) or, for single-manifest images, from the config blob.

**Error matrix, phase-correct**: invalid references answer 400 (scoped to the parse phase — a registry protocol defect no longer gets blamed on the user's reference), unknown manifests 404 `manifest unknown`, denied access 401 with the registry's reason, and unreachable registries surface the actual transport error instead of a masked 500.

**Scope boundary**: identity-token credential helpers aren't supported (Basic auth covers standard `docker login`).

## Related Issue
Found via live API-coverage testing (the endpoint was one of 13 implemented-but-untested routes; 5 turned out to be stubs).

## Changes
- `DistributionJsonRoute`: full implementation behind a `DistributionInspectProviding` seam
- 7 route/parsing tests (response shape, slash-qualified refs, 404/401/400 mapping, transport-failure surfacing, X-Registry-Auth decoding incl. hostile inputs)

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - Docker Hub shorthand (`alpine`) and ECR full ref (`public.ecr.aws/docker/library/alpine:3.21`): real descriptors, complete platform lists (8 platforms)
  - unknown Hub repo → 401 (Hub's anti-enumeration answer), garbage reference → 400, unreachable `localhost:5000` → 500 carrying `HTTPClientError.connectTimeout`
  - probe DIST-001 flipped from expected-fail to green

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))