### PR TITLE
fix(volumes): prune only anonymous volumes unless all=true

### DIFF
--- a/Sources/socktainer/Clients/ClientVolumeService.swift
+++ b/Sources/socktainer/Clients/ClientVolumeService.swift
@@ -12,6 +12,10 @@ protocol ClientVolumeProtocol: Sendable {
 }
 
 struct ClientVolumeService: ClientVolumeProtocol {
+    /// moby's volume.AnonymousLabel — stamped on volumes auto-created without a
+    /// user-supplied name so that volume prune (without all=true) targets only them.
+    static let anonymousVolumeLabel = "com.docker.volume.anonymous"
+
     func create(request: RESTVolumeCreate) async throws -> Volume {
         let result = try await ClientVolume.create(
             name: request.Name,

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -605,7 +605,12 @@ extension ContainerCreateRoute {
                             name: parsed.name,
                             driver: "local",
                             driverOpts: [:],
-                            labels: [:]
+                            // moby marks anonymous volumes with this label so that
+                            // volume prune (without all=true) targets only them.
+                            // Apple's own anonymous label keeps `container volume ls`
+                            // displaying it as anonymous too.
+                            labels: parsed.isAnonymous
+                                ? [ClientVolumeService.anonymousVolumeLabel: "", ContainerResource.VolumeConfiguration.anonymousLabel: ""] : [:]
                         )
                     }
 

--- a/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeCreateRoute.swift
@@ -14,7 +14,8 @@ struct VolumeCreateRoute: RouteCollection {
     /// name already exists (idempotent, matching Docker's `POST /volumes/create`).
     func handler(_ req: Request) async throws -> Response {
         let createRequest = try req.content.decode(VolumeRequest.self)
-        let resolvedName = (createRequest.Name?.isEmpty == false) ? createRequest.Name! : "volume-\(UUID().uuidString)"
+        let isAnonymous = createRequest.Name?.isEmpty != false
+        let resolvedName = isAnonymous ? "volume-\(UUID().uuidString)" : createRequest.Name!
 
         // Strip `sync` from DriverOpts (Apple Container ignores it, but it's
         // Socktainer-specific) and persist it as a label so ContainerCreateRoute
@@ -33,6 +34,13 @@ struct VolumeCreateRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "Invalid sync mode '\(syncValue)'. Valid values: nosync, fsync, full")
             }
             labels[Filesystem.SyncMode.socktainerLabel] = syncValue
+        }
+        if isAnonymous {
+            // moby marks nameless creates anonymous so that volume prune
+            // (without all=true) targets only them. Also stamp Apple's own
+            // anonymous label so `container volume ls` agrees.
+            labels[ClientVolumeService.anonymousVolumeLabel] = ""
+            labels[VolumeConfiguration.anonymousLabel] = ""
         }
 
         let restRequest = RESTVolumeCreate(

--- a/Sources/socktainer/Routes/Volumes/VolumePruneRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumePruneRoute.swift
@@ -1,3 +1,4 @@
+import ContainerResource
 import Vapor
 
 struct RESTVolumesPruneQuery: Content {
@@ -23,10 +24,17 @@ struct VolumePruneRoute: RouteCollection {
         let logger = req.logger
         let query = try req.query.decode(RESTVolumesPruneQuery.self)
         let filtersParam = query.filters
-        let parsedFilters = try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: filtersParam, logger: logger)
+        var parsedFilters = try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: filtersParam, logger: logger)
+        // Docker Engine API v1.42+: prune removes only anonymous volumes unless
+        // the all=true filter is set ('docker volume prune -a'). "all" is a
+        // prune directive, not a volume-matching filter, so strip it before list.
+        let pruneAll = try Self.parsePruneAll(parsedFilters.removeValue(forKey: "all"))
         let filtersJSON = try JSONEncoder().encode(parsedFilters)
         let filtersJSONString = String(data: filtersJSON, encoding: .utf8)
-        let filteredVolumes = try await client.list(filters: filtersJSONString, logger: logger)
+        let filteredVolumes = Self.volumesToPrune(
+            try await client.list(filters: filtersJSONString, logger: logger),
+            pruneAll: pruneAll
+        )
 
         var volumesDeleted: [String] = []
         // we do not calculate reclaimed space at the moment
@@ -56,5 +64,32 @@ struct VolumePruneRoute: RouteCollection {
                     attributes: ["reclaimed": String(spaceReclaimed)]))
         }
         return PruneResponse(VolumesDeleted: volumesDeleted, SpaceReclaimed: spaceReclaimed)
+    }
+
+    /// Parses the "all" prune filter like moby's strconv.ParseBool: at most one
+    /// value, and an unrecognized value is a 400 rather than silently false.
+    static func parsePruneAll(_ values: [String]?) throws -> Bool {
+        guard let values, !values.isEmpty else { return false }
+        guard values.count == 1 else {
+            throw Abort(.badRequest, reason: "invalid filter 'all': got more than one value")
+        }
+        switch values[0].lowercased() {
+        case "1", "t", "true": return true
+        case "0", "f", "false": return false
+        default: throw Abort(.badRequest, reason: "invalid filter 'all=\(values[0])'")
+        }
+    }
+
+    /// Narrows the prune set to anonymous volumes unless all=true was given.
+    /// Anonymous volumes carry moby's com.docker.volume.anonymous label
+    /// (stamped at auto-creation) or Apple's equivalent for volumes created by
+    /// the container CLI itself. Named volumes are never pruned by default,
+    /// as in Docker.
+    static func volumesToPrune(_ volumes: [Volume], pruneAll: Bool) -> [Volume] {
+        guard !pruneAll else { return volumes }
+        return volumes.filter {
+            $0.Labels?[ClientVolumeService.anonymousVolumeLabel] != nil
+                || $0.Labels?[VolumeConfiguration.anonymousLabel] != nil
+        }
     }
 }

--- a/Sources/socktainer/Routes/Volumes/VolumePruneRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumePruneRoute.swift
@@ -73,11 +73,10 @@ struct VolumePruneRoute: RouteCollection {
         guard values.count == 1 else {
             throw Abort(.badRequest, reason: "invalid filter 'all': got more than one value")
         }
-        switch values[0].lowercased() {
-        case "1", "t", "true": return true
-        case "0", "f", "false": return false
-        default: throw Abort(.badRequest, reason: "invalid filter 'all=\(values[0])'")
+        guard let parsed = MobyBool.parse(values[0]) else {
+            throw Abort(.badRequest, reason: "invalid filter 'all=\(values[0])'")
         }
+        return parsed
     }
 
     /// Narrows the prune set to anonymous volumes unless all=true was given.

--- a/Tests/socktainerTests/Routes/VolumePruneAnonymousTests.swift
+++ b/Tests/socktainerTests/Routes/VolumePruneAnonymousTests.swift
@@ -1,0 +1,75 @@
+import ContainerResource
+import Foundation
+import Logging
+import Testing
+
+@testable import socktainer
+
+/// Docker Engine API v1.42+: POST /volumes/prune removes only anonymous
+/// volumes unless the all=true filter is set. The previous implementation
+/// deleted every filtered volume, so a plain `docker volume prune` destroyed
+/// named volumes and their data.
+@Suite("VolumePruneRoute — anonymous-only default")
+struct VolumePruneAnonymousTests {
+
+    @Test("Without all, only volumes carrying the anonymous label are pruned")
+    func defaultPrunesOnlyAnonymous() {
+        let volumes = [
+            Self.volume(name: "pgdata"),
+            Self.volume(name: "0f1e2d3c-anon", labels: [ClientVolumeService.anonymousVolumeLabel: ""]),
+            Self.volume(name: "appcache", labels: ["team": "web"]),
+        ]
+
+        let selected = VolumePruneRoute.volumesToPrune(volumes, pruneAll: false)
+        #expect(selected.map(\.Name) == ["0f1e2d3c-anon"])
+    }
+
+    @Test("With all=true, named volumes are pruned too")
+    func allPrunesEverything() {
+        let volumes = [
+            Self.volume(name: "pgdata"),
+            Self.volume(name: "0f1e2d3c-anon", labels: [ClientVolumeService.anonymousVolumeLabel: ""]),
+        ]
+
+        let selected = VolumePruneRoute.volumesToPrune(volumes, pruneAll: true)
+        #expect(selected.map(\.Name) == ["pgdata", "0f1e2d3c-anon"])
+    }
+
+    @Test("Volumes carrying Apple's own anonymous label are pruned by default too")
+    func appleAnonymousLabelCounts() {
+        let volumes = [
+            Self.volume(name: "pgdata"),
+            Self.volume(name: "apple-anon", labels: [VolumeConfiguration.anonymousLabel: ""]),
+        ]
+
+        let selected = VolumePruneRoute.volumesToPrune(volumes, pruneAll: false)
+        #expect(selected.map(\.Name) == ["apple-anon"])
+    }
+
+    @Test("The all filter key is parsed from the docker CLI's map form")
+    func allFilterKeyParses() throws {
+        let logger = Logger(label: "test")
+        // docker volume prune -a sends filters={"all":{"true":true}}
+        let parsed = try DockerVolumeFilterUtility.parsePruneFilters(filtersParam: #"{"all":{"true":true}}"#, logger: logger)
+        #expect(parsed["all"] == ["true"])
+    }
+
+    @Test("all accepts moby's ParseBool forms and rejects garbage")
+    func allValueParsing() throws {
+        #expect(try VolumePruneRoute.parsePruneAll(nil) == false)
+        #expect(try VolumePruneRoute.parsePruneAll(["true"]) == true)
+        #expect(try VolumePruneRoute.parsePruneAll(["T"]) == true)
+        #expect(try VolumePruneRoute.parsePruneAll(["0"]) == false)
+        #expect(throws: (any Error).self) { try VolumePruneRoute.parsePruneAll(["bogus"]) }
+        #expect(throws: (any Error).self) { try VolumePruneRoute.parsePruneAll(["true", "false"]) }
+    }
+
+    // MARK: - Helpers
+
+    private static func volume(name: String, labels: [String: String]? = nil) -> Volume {
+        Volume(
+            Name: name, Driver: "local", Mountpoint: "/tmp/\(name)", CreatedAt: nil,
+            Status: nil, Labels: labels, Scope: "local", ClusterVolume: nil,
+            Options: [:], UsageData: nil)
+    }
+}


### PR DESCRIPTION
## Summary

`POST /volumes/prune` deleted **every** unused volume it could, ignoring the `all` filter entirely. Since Docker Engine API v1.42, a plain `docker volume prune` removes only **anonymous** volumes; named volumes require `docker volume prune -a` (`all=true`). Ignoring that contract turns a routine cleanup command into data loss: named volumes like a Postgres data volume were wiped by the default prune.

Three changes, mirroring moby:

- Volumes auto-created for an anonymous mount are stamped at creation with moby's `com.docker.volume.anonymous` label (Apple's parser already tells us via `ParsedVolume.isAnonymous`), plus Apple's own `com.apple.container.resource.anonymous` so `container volume ls` agrees. A nameless `POST /volumes/create` — which moby also marks anonymous — gets the same labels. Named volumes never get them.
- The prune route parses the `all` filter with moby's `ParseBool` semantics (`t`/`true`/`1` etc.; an invalid value or multiple values is a 400, not a silent false) and strips it before list filtering, since it is a prune directive rather than a volume matcher. By default the prune set is narrowed to volumes carrying either anonymous label — including anonymous volumes created by Apple's `container` CLI itself. `all=true` keeps today's full-prune behavior.

Volumes created before this change carry no label, so a default prune leaves them alone (safe direction); `all=true` still removes them.

Known divergence left out of scope: moby's router injects `all=true` for clients negotiated below API v1.42; socktainer applies the ≥1.42 semantics to all versioned paths (failing safe — it under-prunes for old clients).

## Before

```console
$ docker volume create pgdata
$ docker volume prune -f        # no -a — named volumes must survive
Deleted Volumes:
pgdata                          # ← data gone
```

## After

```console
$ docker volume create pgdata
$ docker volume prune -f
Total reclaimed space: 0B       # named volume untouched
$ docker volume prune -af
Deleted Volumes:
pgdata
```

Matches Docker Engine behavior (API v1.42+).

## Testing

- New unit tests in `Tests/socktainerTests/Routes/VolumePruneAnonymousTests.swift`:
  - default prune selects only volumes carrying the anonymous label (moby's or Apple's)
  - `all=true` selects named volumes too
  - the `all` filter parses from the docker CLI's map form (`{"all":{"true":true}}`)
  - `all` value parsing accepts moby's `ParseBool` forms and 400s on garbage or multiple values
- The default-prune test fails against the previous implementation (named volumes selected), confirming it reproduces the bug.
- `make fmt`, `make build`, `make test` pass.
