### PR TITLE
fix(dns): embed the DNS image in the binary via dns-forwarder 0.2.0 (fixes #316)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0fc1974a4dbd6489e4087033c59ae2bd461f7532dd1acca9f01ae2783128f7d0",
+  "originHash" : "2930f73e155f13128787a8b274ba55eb02b39ac723d368e18975989422af2428",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/socktainer/dns-forwarder.git",
       "state" : {
-        "revision" : "13aab5bf2e348ec3a501684e798bff7119f6038e",
-        "version" : "0.1.0"
+        "revision" : "07a861b754bcc6e7b749d149178054d215941faa",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
         .package(url: "https://github.com/mw99/DataCompression.git", from: "3.9.0"),
-        .package(url: "https://github.com/socktainer/dns-forwarder.git", exact: "0.1.0"),
+        .package(url: "https://github.com/socktainer/dns-forwarder.git", exact: "0.2.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/socktainer/DNS/EmbeddedDNSImage.swift
+++ b/Sources/socktainer/DNS/EmbeddedDNSImage.swift
@@ -50,7 +50,7 @@ enum EmbeddedDNSImage {
         log.info("[dns-embedded] importing embedded DNS forwarder image")
         let imageClient = ClientImageService(containerSystemConfig: containerSystemConfig)
         let loaded = try await imageClient.load(
-            tarballPath: SocktainerDNSImage.archiveURL,
+            tarballPath: try SocktainerDNSImage.archiveURL(),
             platform: .current,
             appleContainerAppSupportUrl: appSupportURL,
             logger: log

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -270,16 +270,19 @@ struct SocktainerDNSQueryTests {
     }
 }
 
-// MARK: - EmbeddedDNSImage / SocktainerDNSImage SwiftPM resource
+// MARK: - EmbeddedDNSImage / SocktainerDNSImage
 
-@Suite("EmbeddedDNSImage — SwiftPM resource")
+@Suite("EmbeddedDNSImage")
 struct EmbeddedDNSImageTests {
 
-    @Test("SocktainerDNSImage.archiveURL resolves to an existing file")
-    func archiveURLResolvesToExistingFile() {
-        let url = SocktainerDNSImage.archiveURL
-        #expect(url.lastPathComponent == "socktainer-dns.tar.gz")
-        #expect(FileManager.default.fileExists(atPath: url.path), "tarball must be present in SwiftPM resource bundle")
+    @Test("SocktainerDNSImage carries a gzip archive that archiveURL() materializes to disk")
+    func archiveMaterializesFromEmbeddedBytes() throws {
+        let data = SocktainerDNSImage.archiveData
+        #expect(!data.isEmpty)
+        #expect(Array(data.prefix(2)) == [0x1f, 0x8b], "embedded archive must be gzip")
+
+        let url = try SocktainerDNSImage.archiveURL()
+        #expect(try Data(contentsOf: url) == data, "materialized file must match the embedded archive")
     }
 
     @Test("EmbeddedDNSImage.tag matches SocktainerDNSImage.reference")


### PR DESCRIPTION
## Summary

Fixes #316 — a standalone `socktainer` binary (Homebrew built from source, the release `.zip`, the bare-binary asset) **crashes with SIGTRAP** the first time Docker Compose creates a container on a user-defined network. `SocktainerDNSImage` shipped the DNS OCI archive as a SwiftPM `.copy` resource, which macOS SwiftPM emits as a separate `SocktainerDNSImage_SocktainerDNSImage.bundle` loaded via `Bundle.module`. A binary with no co-located bundle → `Bundle.module` fatal-errors the daemon.

## Fix

Bump the `dns-forwarder` pin to **0.2.0**, which compiles the image **into the binary** as a C byte array instead of a resource bundle (socktainer/dns-forwarder#2). No `Bundle.module`, no `fatalError`, nothing external to lose — a lone binary carries the image, so **every** distribution format is fixed, **including Homebrew-from-source, with no formula or packaging change**.

## Changes

- `Package.swift` / `Package.resolved`: `dns-forwarder` `0.1.0 → 0.2.0`.
- `Sources/socktainer/DNS/EmbeddedDNSImage.swift`: `SocktainerDNSImage.archiveURL` → `try SocktainerDNSImage.archiveURL()` (now a throwing func — it materializes the embedded bytes to a temp file, which can fail rather than `fatalError`; the caller is already `async throws`).
- `Tests/…/SocktainerDNSServerTests.swift`: the DNS-image test now asserts the embedded contract (`archiveData` is a gzip archive that `archiveURL()` materializes) instead of the old resource-bundle path/filename.

## Verification

Builds and links against `dns-forwarder 0.2.0`; full suite green (662 tests / 124 suites). The embed itself is verified in dns-forwarder#2 (232 KB embedded, gzip-valid, round-trips).

## Note

Requires `dns-forwarder v0.2.0` (released). This is the durable global fix for #316; no interim packaging/formula change is needed once this ships in a socktainer release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)