### PR TITLE
fix(clients): reconnect on stale XPC connection to apple container daemon

### DIFF
--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -45,7 +45,7 @@ protocol ClientBuilderProtocol: Sendable {
 }
 
 struct ClientBuilderService: ClientBuilderProtocol {
-    private let containerClient = ContainerClient()
+    private let containerClient = ReconnectingContainerClient(makeClient: { ContainerClient() })
     private let networkClient = NetworkClient()
     private let builderContainerId: String
     private let builderPort: UInt32
@@ -168,13 +168,13 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
     private func dialBuilderSocket() async throws -> FileHandle {
         let container = try await runningBuilderContainer(logger: nil)
-        return try await containerClient.dial(id: container.id, port: builderPort)
+        return try await containerClient.withClient { try await $0.dial(id: container.id, port: builderPort) }
     }
 
     private func runningBuilderContainer(logger: Logger?) async throws -> ContainerSnapshot {
         let container: ContainerSnapshot
         do {
-            container = try await containerClient.get(id: builderContainerId)
+            container = try await containerClient.withClient { try await $0.get(id: builderContainerId) }
         } catch let error as ContainerizationError where error.code == .notFound {
             logger?.info("Builder container not found, creating a new builder instance")
             return try await createAndStartBuilder(logger: logger)
@@ -187,12 +187,12 @@ struct ClientBuilderService: ClientBuilderProtocol {
             case .stopped:
                 logger?.info("Builder container is stopped, starting it")
                 try await startBuildKit(containerId: container.id)
-                return try await containerClient.get(id: container.id)
+                return try await containerClient.withClient { try await $0.get(id: container.id) }
             case .stopping:
                 throw ContainerizationError(.invalidState, message: "BuildKit container '\(builderContainerId)' is stopping")
             case .unknown:
                 logger?.warning("Builder container has unknown state, recreating it")
-                try? await containerClient.delete(id: container.id)
+                try? await containerClient.withClient { try await $0.delete(id: container.id) }
                 return try await createAndStartBuilder(logger: logger)
             @unknown default:
                 throw ContainerizationError(.invalidState, message: "BuildKit container '\(builderContainerId)' is in an unsupported state")
@@ -236,9 +236,9 @@ struct ClientBuilderService: ClientBuilderProtocol {
         )
 
         let kernel = try await ClientKernel.getDefaultKernel(for: .current)
-        try await containerClient.create(configuration: config, options: .default, kernel: kernel)
+        try await containerClient.withClient { try await $0.create(configuration: config, options: .default, kernel: kernel) }
         try await startBuildKit(containerId: builderContainerId)
-        return try await containerClient.get(id: builderContainerId)
+        return try await containerClient.withClient { try await $0.get(id: builderContainerId) }
     }
 
     /// Pure construction of the BuildKit guest's ContainerConfiguration — no real service
@@ -288,12 +288,12 @@ struct ClientBuilderService: ClientBuilderProtocol {
         defer { try? io.close() }
 
         do {
-            let process = try await containerClient.bootstrap(id: containerId, stdio: io.stdio)
+            let process = try await containerClient.withClient { try await $0.bootstrap(id: containerId, stdio: io.stdio) }
             try await process.start()
             try io.closeAfterStart()
         } catch {
-            try? await containerClient.stop(id: containerId)
-            try? await containerClient.delete(id: containerId)
+            try? await containerClient.withClient { try await $0.stop(id: containerId) }
+            try? await containerClient.withClient { try await $0.delete(id: containerId) }
             if let containerizationError = error as? ContainerizationError {
                 throw containerizationError
             }
@@ -311,13 +311,16 @@ struct ClientBuilderService: ClientBuilderProtocol {
             throw ContainerizationError(.internalError, message: "Failed to create I/O pipes")
         }
         let process: ClientProcess
+        let processConfigToSend = processConfig
         do {
-            process = try await containerClient.createProcess(
-                containerId: container.id,
-                processId: UUID().uuidString.lowercased(),
-                configuration: processConfig,
-                stdio: pipes.stdioArray
-            )
+            process = try await containerClient.withClient {
+                try await $0.createProcess(
+                    containerId: container.id,
+                    processId: UUID().uuidString.lowercased(),
+                    configuration: processConfigToSend,
+                    stdio: pipes.stdioArray
+                )
+            }
         } catch {
             pipes.closeAll()
             throw error

--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -46,7 +46,7 @@ protocol ClientBuilderProtocol: Sendable {
 
 struct ClientBuilderService: ClientBuilderProtocol {
     private let containerClient = ReconnectingContainerClient(makeClient: { ContainerClient() })
-    private let networkClient = NetworkClient()
+    private let networkClient = ReconnectingContainerClient(makeClient: { NetworkClient() })
     private let builderContainerId: String
     private let builderPort: UInt32
     private let builderCPUs: Int64
@@ -218,7 +218,7 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
         let imageConfig = try await image.config(for: builderPlatform).config
 
-        guard let defaultNetwork = try await networkClient.builtin else {
+        guard let defaultNetwork = try await networkClient.withClient({ try await $0.builtin }) else {
             throw ContainerizationError(.invalidState, message: "default network is not present")
         }
         let nameserver = IPv4Address(defaultNetwork.status.ipv4Subnet.lower.value + 1).description

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -97,10 +97,10 @@ enum ClientContainerError: Error {
 }
 
 struct ClientContainerService: ClientContainerProtocol {
-    private let containerClient = ContainerClient()
+    private let containerClient = ReconnectingContainerClient(makeClient: { ContainerClient() })
 
     func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] {
-        let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
+        let allContainers = Self.withoutDNSSidecars(try await containerClient.withClient { try await $0.list() })
         let running = showAll ? allContainers : allContainers.filter { $0.status == .running }
         return Self.applyFilters(running, filters: filters, allContainers: allContainers)
     }
@@ -230,13 +230,13 @@ struct ClientContainerService: ClientContainerProtocol {
     func getContainer(id: String) async throws -> ContainerSnapshot? {
         let id = ContainerNameUtility.sanitize(id)
         do {
-            let snapshot = try await containerClient.get(id: id)
+            let snapshot = try await containerClient.withClient { try await $0.get(id: id) }
             return Self.isDNSSidecar(snapshot) ? nil : snapshot
         } catch let error as ContainerizationError where error.code == .notFound {
             // The reference may be a Docker-shaped hex ID, or a truncated
             // prefix of one fed back from `docker ps` output; resolve it
             // against the derived IDs of all containers.
-            let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
+            let allContainers = Self.withoutDNSSidecars(try await containerClient.withClient { try await $0.list() })
             let entries = allContainers.map { (nativeId: $0.id, hexId: DockerContainerID.hexId(for: $0)) }
             switch DockerContainerID.resolve(reference: id, entries: entries) {
             case .match(let nativeId):
@@ -284,7 +284,7 @@ struct ClientContainerService: ClientContainerProtocol {
         let stdio = [stdin, stdout, stderr]
 
         do {
-            let process = try await containerClient.bootstrap(id: container.id, stdio: stdio)
+            let process = try await containerClient.withClient { try await $0.bootstrap(id: container.id, stdio: stdio) }
             // Clear any exit code recorded by a previous run of this container so
             // /wait blocks for the new init process rather than immediately
             // returning the stale code (e.g. after a restart).
@@ -330,7 +330,7 @@ struct ClientContainerService: ClientContainerProtocol {
     private func stopInternal(container: ContainerSnapshot, signal: String?, timeout: Int?) async throws {
         let signal = signal ?? "SIGTERM"
         let options = ContainerStopOptions(timeoutInSeconds: Int32(timeout ?? 5), signal: signal)
-        try await containerClient.stop(id: container.id, opts: options)
+        try await containerClient.withClient { try await $0.stop(id: container.id, opts: options) }
     }
 
     func kill(id: String, signal: String?) async throws {
@@ -346,7 +346,7 @@ struct ClientContainerService: ClientContainerProtocol {
         let signal = signal ?? "SIGKILL"
 
         await ContainerRestartState.shared.markExplicitlyStopped(id: container.id)
-        try await containerClient.kill(id: container.id, signal: signal)
+        try await containerClient.withClient { try await $0.kill(id: container.id, signal: signal) }
     }
 
     func restart(id: String, signal: String?, timeout: Int?) async throws {
@@ -375,7 +375,7 @@ struct ClientContainerService: ClientContainerProtocol {
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
-        try await containerClient.delete(id: container.id)
+        try await containerClient.withClient { try await $0.delete(id: container.id) }
     }
 
     // Poll until the container is no longer running, then return the real exit
@@ -408,7 +408,7 @@ struct ClientContainerService: ClientContainerProtocol {
             // the recorder), so also stop once it's gone, then grace-poll the
             // store below.
             while await ContainerExitCodeStore.shared.get(id: id) == nil {
-                let current = try await containerClient.list().filter { $0.id == id }.first
+                let current = try await containerClient.withClient { try await $0.list() }.filter { $0.id == id }.first
                 if current == nil {
                     var graceTries = 0
                     while await ContainerExitCodeStore.shared.get(id: id) == nil && graceTries < 30 {
@@ -423,7 +423,7 @@ struct ClientContainerService: ClientContainerProtocol {
             // `removed` must block until the container is actually gone, not just
             // exited — otherwise the requested condition was never satisfied.
             if condition == .removed {
-                while (try await containerClient.list().filter { $0.id == id }.first) != nil {
+                while (try await containerClient.withClient { try await $0.list() }.filter { $0.id == id }.first) != nil {
                     try await Task.sleep(nanoseconds: 200_000_000)  // 200ms
                 }
             }
@@ -434,7 +434,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
-        let allContainers = Self.withoutDNSSidecars(try await containerClient.list())
+        let allContainers = Self.withoutDNSSidecars(try await containerClient.withClient { try await $0.list() })
 
         var containersToDelete: [ContainerSnapshot] = allContainers.filter { $0.status == .stopped }
 
@@ -506,7 +506,7 @@ struct ClientContainerService: ClientContainerProtocol {
 
         for container in containersToDelete {
             do {
-                try await containerClient.delete(id: container.id)
+                try await containerClient.withClient { try await $0.delete(id: container.id) }
                 deletedIds.append(container.id)
             } catch {
                 continue

--- a/Sources/socktainer/Clients/ClientNetworkService.swift
+++ b/Sources/socktainer/Clients/ClientNetworkService.swift
@@ -13,10 +13,10 @@ protocol ClientNetworkProtocol: Sendable {
 }
 
 struct ClientNetworkService: ClientNetworkProtocol {
-    private let networkClient = NetworkClient()
+    private let networkClient = ReconnectingContainerClient(makeClient: { NetworkClient() })
 
     func list(filters: String? = nil, logger: Logger) async throws -> [RESTNetworkSummary] {
-        let networksList = try await networkClient.list()
+        let networksList = try await networkClient.withClient { try await $0.list() }
         var allNetworks = networksList.map { RESTNetworkSummary(networkResource: $0) }
         let containerClient = ClientContainerService()
         let allContainers = try await containerClient.list(showAll: true, filters: [:])
@@ -154,7 +154,7 @@ struct ClientNetworkService: ClientNetworkProtocol {
     }
 
     func delete(id: String, logger: Logger) async throws {
-        try await networkClient.delete(id: id)
+        try await networkClient.withClient { try await $0.delete(id: id) }
         logger.debug("Deleted network with id: \(id)")
     }
 
@@ -168,7 +168,7 @@ struct ClientNetworkService: ClientNetworkProtocol {
             labels: ResourceLabels(labels),
             plugin: "container-network-vmnet"
         )
-        _ = try await networkClient.create(configuration: configuration)
+        _ = try await networkClient.withClient { try await $0.create(configuration: configuration) }
         logger.debug("Created network with id: \(configuration.name)")
         return RESTNetworkCreate(Id: configuration.name, Warning: "")
     }

--- a/Sources/socktainer/Clients/ReconnectingContainerClient.swift
+++ b/Sources/socktainer/Clients/ReconnectingContainerClient.swift
@@ -27,11 +27,10 @@ import ContainerizationError
 /// long-running server process holding the stale struct would otherwise fail every
 /// subsequent request until restarted.
 ///
-/// `withClient` runs the operation against the current client and, on that specific
-/// error code, replaces it with a freshly constructed one (a new XPC connection) and
-/// retries exactly once. Any other error — a real "not found", a bad argument, etc. — is
-/// rethrown immediately without reconnecting, since it isn't evidence of a stale
-/// connection.
+/// `withClient` runs the operation against the current client and, if the failure is
+/// evidence of a stale connection, replaces it with a freshly constructed one (a new
+/// XPC connection) and retries exactly once. Any other error — a real "not found", a bad
+/// argument, etc. — is rethrown immediately without reconnecting.
 actor ReconnectingContainerClient<Client: Sendable> {
     private var client: Client
     private let makeClient: @Sendable () -> Client
@@ -49,7 +48,7 @@ actor ReconnectingContainerClient<Client: Sendable> {
         let currentClient = client
         do {
             return try await operation(currentClient)
-        } catch let error as ContainerizationError where error.code == .interrupted {
+        } catch let error as ContainerizationError where Self.isStaleConnection(error) {
             // Guard against a reconnect storm: if many concurrent callers hit the same
             // stale connection, only the first to reach here (reconnectCount still
             // matches what it observed before the call) recreates the client — the
@@ -60,5 +59,22 @@ actor ReconnectingContainerClient<Client: Sendable> {
             }
             return try await operation(client)
         }
+    }
+
+    /// `ContainerClient`'s own methods (`create`, `get`, `bootstrap`, `kill`, `stop`,
+    /// `delete`, `createProcess`, `dial`, ...) wrap the XPC-layer error in an outer
+    /// `ContainerizationError(.internalError, cause: error)` before it reaches us, so the
+    /// stale-connection code is usually buried in `cause` rather than on the error we
+    /// catch directly. Walk the chain to find it, the same way apple/container's own
+    /// callers unwrap `cause` (e.g. `MachineCreate.swift`'s `error.cause as?
+    /// ContainerizationError`).
+    private static func isStaleConnection(_ error: ContainerizationError) -> Bool {
+        if error.code == .interrupted {
+            return true
+        }
+        guard let cause = error.cause as? ContainerizationError else {
+            return false
+        }
+        return isStaleConnection(cause)
     }
 }

--- a/Sources/socktainer/Clients/ReconnectingContainerClient.swift
+++ b/Sources/socktainer/Clients/ReconnectingContainerClient.swift
@@ -45,11 +45,19 @@ actor ReconnectingContainerClient<Client: Sendable> {
     }
 
     func withClient<T>(_ operation: @Sendable (Client) async throws -> T) async throws -> T {
+        let currentCount = reconnectCount
+        let currentClient = client
         do {
-            return try await operation(client)
+            return try await operation(currentClient)
         } catch let error as ContainerizationError where error.code == .interrupted {
-            reconnectCount += 1
-            client = makeClient()
+            // Guard against a reconnect storm: if many concurrent callers hit the same
+            // stale connection, only the first to reach here (reconnectCount still
+            // matches what it observed before the call) recreates the client — the
+            // rest reuse the one that task already built.
+            if reconnectCount == currentCount {
+                reconnectCount += 1
+                client = makeClient()
+            }
             return try await operation(client)
         }
     }

--- a/Sources/socktainer/Clients/ReconnectingContainerClient.swift
+++ b/Sources/socktainer/Clients/ReconnectingContainerClient.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 the socktainer authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+
+/// Wraps a client whose underlying XPC connection can go stale.
+///
+/// `ContainerClient` holds a single `xpc_connection_t` for its lifetime. If the Apple
+/// Container daemon (`com.apple.container.apiserver`) restarts — e.g. after an update or
+/// a crash — that connection becomes permanently invalid and every call on it fails with
+/// `ContainerizationError(.interrupted, message: "XPC connection error: Connection
+/// invalid")` (see apple/container's `XPCClient.parseReply`, which maps
+/// `XPC_ERROR_CONNECTION_INVALID`/`XPC_ERROR_CONNECTION_INTERRUPTED` to that code). A
+/// long-running server process holding the stale struct would otherwise fail every
+/// subsequent request until restarted.
+///
+/// `withClient` runs the operation against the current client and, on that specific
+/// error code, replaces it with a freshly constructed one (a new XPC connection) and
+/// retries exactly once. Any other error — a real "not found", a bad argument, etc. — is
+/// rethrown immediately without reconnecting, since it isn't evidence of a stale
+/// connection.
+actor ReconnectingContainerClient<Client: Sendable> {
+    private var client: Client
+    private let makeClient: @Sendable () -> Client
+
+    /// Number of times the underlying client has been recreated. Exposed for tests.
+    private(set) var reconnectCount = 0
+
+    init(makeClient: @escaping @Sendable () -> Client) {
+        self.makeClient = makeClient
+        self.client = makeClient()
+    }
+
+    func withClient<T>(_ operation: @Sendable (Client) async throws -> T) async throws -> T {
+        do {
+            return try await operation(client)
+        } catch let error as ContainerizationError where error.code == .interrupted {
+            reconnectCount += 1
+            client = makeClient()
+            return try await operation(client)
+        }
+    }
+}

--- a/Tests/socktainerTests/Clients/ReconnectingContainerClientTests.swift
+++ b/Tests/socktainerTests/Clients/ReconnectingContainerClientTests.swift
@@ -53,6 +53,36 @@ struct ReconnectingContainerClientTests {
         #expect(reconnectCount == 1)
     }
 
+    @Test("Reconnects when the stale connection is buried inside ContainerClient's own error wrapping")
+    func retryRecoversWhenStaleErrorIsWrapped() async throws {
+        let generations = Counter()
+        let client = ReconnectingContainerClient<FakeConnection>(makeClient: {
+            FakeConnection(generation: generations.nextSync())
+        })
+
+        let attempts = Counter()
+        let result = try await client.withClient { connection -> Int in
+            let attempt = attempts.nextSync()
+            if attempt == 1 {
+                // Mirrors what ContainerClient's own methods actually throw: they catch
+                // the raw XPC error and rewrap it as `.internalError` with the original
+                // `.interrupted` error as `cause` (see e.g. ContainerClient.get/create/
+                // bootstrap/kill/stop/delete/createProcess/dial). A naive check of only
+                // the outer `error.code` would miss this and never reconnect.
+                throw ContainerizationError(
+                    .internalError,
+                    message: "failed to get container",
+                    cause: ContainerizationError(.interrupted, message: "XPC connection error: Connection invalid")
+                )
+            }
+            return connection.generation
+        }
+
+        #expect(result == 2, "the retried call should observe the freshly reconnected client (generation 2)")
+        let reconnectCount = await client.reconnectCount
+        #expect(reconnectCount == 1)
+    }
+
     @Test("Does not retry or reconnect for a non-stale error")
     func nonStaleErrorNotRetried() async throws {
         let generations = Counter()

--- a/Tests/socktainerTests/Clients/ReconnectingContainerClientTests.swift
+++ b/Tests/socktainerTests/Clients/ReconnectingContainerClientTests.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 the socktainer authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("ReconnectingContainerClient")
+struct ReconnectingContainerClientTests {
+
+    /// Stands in for a `ContainerClient` connection. Each value made by `makeClient`
+    /// carries the next `generation`, so tests can tell whether an operation ran
+    /// against the original client or a freshly reconnected one.
+    struct FakeConnection: Sendable {
+        let generation: Int
+    }
+
+    @Test("Reconnects once and recovers when the client reports a stale XPC connection")
+    func retryRecoversOnceOnStaleConnection() async throws {
+        let generations = Counter()
+        let client = ReconnectingContainerClient<FakeConnection>(makeClient: {
+            FakeConnection(generation: generations.nextSync())
+        })
+
+        let attempts = Counter()
+        let result = try await client.withClient { connection -> Int in
+            let attempt = attempts.nextSync()
+            if attempt == 1 {
+                // Mirrors apple/container's XPCClient.parseReply mapping
+                // XPC_ERROR_CONNECTION_INVALID to ContainerizationError(.interrupted, ...).
+                throw ContainerizationError(.interrupted, message: "XPC connection error: Connection invalid")
+            }
+            return connection.generation
+        }
+
+        #expect(result == 2, "the retried call should observe the freshly reconnected client (generation 2)")
+        let reconnectCount = await client.reconnectCount
+        #expect(reconnectCount == 1)
+    }
+
+    @Test("Does not retry or reconnect for a non-stale error")
+    func nonStaleErrorNotRetried() async throws {
+        let generations = Counter()
+        let client = ReconnectingContainerClient<FakeConnection>(makeClient: {
+            FakeConnection(generation: generations.nextSync())
+        })
+
+        let attempts = Counter()
+        await #expect(throws: ContainerizationError.self) {
+            try await client.withClient { _ -> Int in
+                attempts.nextSync()
+                throw ContainerizationError(.notFound, message: "container not found")
+            }
+        }
+
+        #expect(attempts.countSync() == 1, "a non-stale error must not be retried")
+        let reconnectCount = await client.reconnectCount
+        #expect(reconnectCount == 0)
+    }
+}
+
+/// A tiny thread-safe counter used to observe call/reconnect counts from
+/// synchronous, non-isolated closures (e.g. the `makeClient` factory).
+final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    @discardableResult
+    func nextSync() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
+    }
+
+    func countSync() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}

--- a/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
+++ b/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
@@ -216,6 +216,13 @@ private struct FakeImageClient: ClientImageProtocol {
         ([], 0)
     }
 
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String],
+        platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (repo, "sha256:" + String(repeating: "a", count: 64))
+    }
+
     func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] {
         loadedImages
     }


### PR DESCRIPTION
When the Apple Container daemon (`com.apple.container.apiserver`) restarts, the `xpc_connection_t` held by `ContainerClient` for its lifetime becomes permanently invalid. Every subsequent call then fails with `ContainerizationError(.interrupted, message: "XPC connection error: Connection invalid")` until socktainer itself is restarted.

`ReconnectingContainerClient` wraps calls to `ContainerClient`, detects that specific error code, rebuilds the underlying client, and retries the operation exactly once. Any other error passes through untouched — no changes in behavior for real failures like not-found or invalid-argument.

Wired into `ClientContainerService` and `ClientBuilderService`, replacing direct `containerClient.xyz(...)` calls with `containerClient.withClient { try await $0.xyz(...) }`.