### PR TITLE
fix(images): don't report tags whose config is missing from the archive

### DIFF
--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -87,10 +87,9 @@ enum ContainerImageUtility {
                 }
 
                 indexManifests.append(manifestDescriptor)
-            }
-
-            for repoTag in dockerManifest.repoTags ?? [] {
-                loadedImages.append(repoTag)
+                loadedImages.append(contentsOf: dockerManifest.repoTags ?? [])
+            } else {
+                logger.warning("Skipping \((dockerManifest.repoTags ?? []).joined(separator: ", ")): config \(configFile) missing from archive")
             }
         }
 

--- a/Tests/socktainerTests/Utilities/ContainerImageConvertTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageConvertTests.swift
@@ -64,6 +64,40 @@ struct ContainerImageConvertTests {
         #expect(!fixture.blobExists("sha256:\(claimed)"))
     }
 
+    @Test("a tag whose config file is missing from the archive is not reported as loaded")
+    func missingConfigTagIsNotReported() async throws {
+        let fixture = try DockerArchiveFixture()
+        defer { fixture.cleanUp() }
+
+        let layerDigest = try fixture.writeLayer()
+        try fixture.writeManifest(configDigest: String(repeating: "c", count: 64), layerDigest: layerDigest, tag: "phantom:latest")
+
+        let loaded = try await ContainerImageUtility.convertDockerTarToOCI(
+            dockerFormatPath: fixture.dockerFormatDir, ociLayoutPath: fixture.ociLayoutDir, logger: Logger(label: "test"))
+
+        #expect(loaded.isEmpty)
+        #expect(try fixture.allManifests().isEmpty)
+    }
+
+    @Test("an entry with a missing config does not suppress reporting of the valid entries")
+    func missingConfigOnlySkipsItsOwnTag() async throws {
+        let fixture = try DockerArchiveFixture()
+        defer { fixture.cleanUp() }
+
+        let configDigest = try fixture.writeConfig()
+        let layerDigest = try fixture.writeLayer()
+        try fixture.writeManifests([
+            (config: configDigest, layer: layerDigest, tag: "kept:latest"),
+            (config: String(repeating: "c", count: 64), layer: layerDigest, tag: "phantom:latest"),
+        ])
+
+        let loaded = try await ContainerImageUtility.convertDockerTarToOCI(
+            dockerFormatPath: fixture.dockerFormatDir, ociLayoutPath: fixture.ociLayoutDir, logger: Logger(label: "test"))
+
+        #expect(loaded == ["kept:latest"])
+        #expect(try fixture.allManifests().count == 1)
+    }
+
     @Test("a layer larger than the streaming-hash chunk is hashed correctly across chunk boundaries")
     func largeLayerHashesAcrossChunks() async throws {
         let fixture = try DockerArchiveFixture()


### PR DESCRIPTION
## Summary

`docker load` reported a tag as loaded even when its config file was missing from the tarball, because `convertDockerTarToOCI` appended the manifest's `repoTags` to `loadedImages` unconditionally — including for manifests it skipped due to a missing config.

## Changes

- Move the `repoTags` append inside the config-exists branch, so a skipped manifest never contributes a phantom tag.
- Log a warning naming the skipped tags and the missing config file.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (696 tests)
- [x] Unit tests added: a tag with a missing config is not reported as loaded; a missing config on one entry doesn't suppress reporting of valid entries

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)