### PR TITLE
feat(events): emit attach/detach, resize, archive, image transfer, and volume mount/unmount events

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -36,6 +36,13 @@ extension ClientImageProtocol {
     func list() async throws -> [ClientImage] {
         try await list(includeSystemImages: false)
     }
+
+    /// Store-reference → digest map used to shape save/load events like moby's, whose
+    /// Actor.ID is the image digest. References the store cannot resolve fall back to
+    /// the reference itself at the emission site.
+    func digestsByReference() async -> [String: String] {
+        ((try? await list()) ?? []).reduce(into: [:]) { $0[$1.reference] = $1.digest }
+    }
 }
 
 enum ClientImageError: Error {

--- a/Sources/socktainer/Events/EventBroadcaster.swift
+++ b/Sources/socktainer/Events/EventBroadcaster.swift
@@ -1,3 +1,4 @@
+import ContainerResource
 import Vapor
 
 struct EventBroadcasterKey: StorageKey {
@@ -69,6 +70,25 @@ extension DockerEvent {
         attributes["name"] = name.isEmpty ? id : name
         for (key, value) in extraAttributes { attributes[key] = value }
         return make(type: type, action: status, actorID: id, attributes: attributes)
+    }
+
+    /// Container-shaped event derived from a snapshot: canonical 64-char Docker id,
+    /// image reference, native name, and restored labels — the fields every
+    /// container lifecycle event site otherwise re-derives by hand.
+    static func containerEvent(
+        _ action: String,
+        container: ContainerSnapshot,
+        extraAttributes: [String: String] = [:]
+    ) -> DockerEvent {
+        simpleEvent(
+            id: DockerContainerID.hexId(for: container),
+            type: "container",
+            status: action,
+            image: container.configuration.image.reference,
+            name: container.id,
+            labels: LabelNormalization.restore(container.configuration.labels),
+            extraAttributes: extraAttributes
+        )
     }
 }
 

--- a/Sources/socktainer/Events/VolumeMountEvents.swift
+++ b/Sources/socktainer/Events/VolumeMountEvents.swift
@@ -1,0 +1,44 @@
+import ContainerResource
+
+/// Emits moby's per-volume `mount`/`unmount` events for a container's named-volume
+/// mounts (moby daemon/volumes_unix.go and container.UnmountVolumes). `containerId`
+/// is the canonical 64-char Docker id, matching moby's full `c.ID` attribute.
+/// Propagation has no equivalent on Apple Container and is reported as "" — the
+/// same value the inspect route uses.
+enum VolumeMountEvents {
+    static func broadcastMounts(for snapshot: ContainerSnapshot, containerId: String, broadcaster: EventBroadcaster) async {
+        for mount in volumeMounts(in: snapshot) {
+            guard case .volume(let name, _, _, _) = mount.type else { continue }
+            await broadcaster.broadcast(
+                DockerEvent.make(
+                    type: "volume", action: "mount", actorID: name,
+                    attributes: [
+                        "driver": "local",
+                        "container": containerId,
+                        "destination": mount.destination,
+                        "read/write": String(!mount.options.readonly),
+                        "propagation": "",
+                    ]))
+        }
+    }
+
+    static func broadcastUnmounts(for snapshot: ContainerSnapshot, containerId: String, broadcaster: EventBroadcaster) async {
+        for mount in volumeMounts(in: snapshot) {
+            guard case .volume(let name, _, _, _) = mount.type else { continue }
+            await broadcaster.broadcast(
+                DockerEvent.make(
+                    type: "volume", action: "unmount", actorID: name,
+                    attributes: [
+                        "driver": "local",
+                        "container": containerId,
+                    ]))
+        }
+    }
+
+    private static func volumeMounts(in snapshot: ContainerSnapshot) -> [Filesystem] {
+        snapshot.configuration.mounts.filter {
+            if case .volume = $0.type { return true }
+            return false
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
@@ -68,6 +68,12 @@ struct ContainerArchiveRoute: RouteCollection {
                 headers.add(name: .contentType, value: "application/x-tar")
                 headers.add(name: "X-Docker-Container-Path-Stat", value: statBase64)
 
+                // moby emits "archive-path" on a successful GET (daemon/archive_unix.go);
+                // HEAD emits nothing.
+                if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                    await broadcaster.broadcast(DockerEvent.containerEvent("archive-path", container: container))
+                }
+
                 return Response(
                     status: .ok,
                     headers: headers,
@@ -151,6 +157,12 @@ struct ContainerArchiveRoute: RouteCollection {
                     tarPath: tarPath,
                     noOverwriteDirNonDir: query.noOverwriteDirNonDir ?? false
                 )
+
+                // moby emits "extract-to-dir" after a successful extraction
+                // (daemon/archive_unix.go).
+                if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                    await broadcaster.broadcast(DockerEvent.containerEvent("extract-to-dir", container: container))
+                }
 
                 return Response(status: .ok)
             } catch let error as ClientArchiveError {

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -33,6 +33,33 @@ extension ContainerAttachRoute {
         DockerEvent.simpleEvent(id: id, type: "container", status: "destroy", image: image, name: name, labels: labels)
     }
 
+    /// moby logs "attach" once the attach is set up, before streaming — including a
+    /// logs-only attach (daemon/attach.go). Nothing is emitted when the container
+    /// lookup failed or neither stream nor logs was requested.
+    /// Shared by the HTTP and WS attach routes.
+    static func broadcastAttach(container: ContainerSnapshot?, stream: Bool, logs: Bool, broadcaster: EventBroadcaster?) async {
+        guard let container, stream || logs, let broadcaster else { return }
+        await broadcaster.broadcast(DockerEvent.containerEvent("attach", container: container))
+    }
+
+    /// moby logs "detach" only when a streaming attach ends while the container still
+    /// runs (daemon/attach.go) — never for a logs-only attach, and never when the
+    /// container's own exit closed the stream. Shared by the HTTP and WS attach routes.
+    static func broadcastLogDetach(container: ContainerSnapshot, stream: Bool, currentStatus: RuntimeStatus?, broadcaster: EventBroadcaster?) async {
+        guard stream, currentStatus == .running, let broadcaster else { return }
+        await broadcaster.broadcast(DockerEvent.containerEvent("detach", container: container))
+    }
+
+    /// Interactive (bootstrap) attach detach: the connection died while no exit code is
+    /// recorded yet, so the client left a still-running process — moby's
+    /// interactive-detach path (daemon/attach.go). A process exit records its code
+    /// before the exit monitor tears the connection down, so it never lands here.
+    /// Shared by the HTTP TCP-upgrade and WS attach routes.
+    static func broadcastInteractiveDetach(container: ContainerSnapshot, channelActive: Bool, recordedExitCode: Int32?, broadcaster: EventBroadcaster?) async {
+        guard !channelActive, recordedExitCode == nil, let broadcaster else { return }
+        await broadcaster.broadcast(DockerEvent.containerEvent("detach", container: container))
+    }
+
     static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             // TODO: This should be refactored to some generic implementation that is shared
@@ -152,6 +179,9 @@ extension ContainerAttachRoute {
         // that same source rather than short-circuiting to no output.
         let shouldStreamOutput = stdout || stderr || (!stdout && !stderr)
 
+        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+        await broadcastAttach(container: container, stream: stream, logs: logs, broadcaster: broadcaster)
+
         // Create streaming response body using container logs when not using stdin
         let body = Response.Body { writer in
             Task.detached {
@@ -229,6 +259,12 @@ extension ContainerAttachRoute {
                     }
                 } catch {
                     // Client disconnected (a write failed) — stop streaming.
+                    await broadcastLogDetach(
+                        container: container,
+                        stream: stream,
+                        currentStatus: (try? await containerClient.get(id: container.id))?.status,
+                        broadcaster: broadcaster
+                    )
                 }
             }
         }
@@ -296,6 +332,13 @@ extension ContainerAttachRoute {
         }
 
         await ProcessRegistry.shared.set(id: container.id, process: process)
+
+        await broadcastAttach(
+            container: container,
+            stream: query.stream ?? false,
+            logs: query.logs ?? false,
+            broadcaster: req.application.storage[EventBroadcasterKey.self]
+        )
 
         let contentType =
             isTTY
@@ -451,6 +494,14 @@ extension ContainerAttachRoute {
         }
 
         await ProcessRegistry.shared.set(id: container.id, process: process)
+
+        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+        await broadcastAttach(
+            container: container,
+            stream: query.stream ?? false,
+            logs: query.logs ?? false,
+            broadcaster: broadcaster
+        )
 
         guard shouldUpgrade else {
 
@@ -709,6 +760,12 @@ extension ContainerAttachRoute {
                         guard channel.isActive else { break }
                         try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
                     }
+                    await broadcastInteractiveDetach(
+                        container: container,
+                        channelActive: channel.isActive,
+                        recordedExitCode: await ContainerExitCodeStore.shared.get(id: container.id),
+                        broadcaster: broadcaster
+                    )
                 }
 
                 group.addTask {

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -112,6 +112,10 @@ extension ContainerAttachWSRoute {
 
         await ProcessRegistry.shared.set(id: container.id, process: process)
 
+        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+        // A bootstrap attach streams the process stdio regardless of query flags.
+        await ContainerAttachRoute.broadcastAttach(container: container, stream: true, logs: query.logs ?? false, broadcaster: broadcaster)
+
         // Wire WS → stdin. Guard ws.isClosed so a late-arriving frame after
         // teardown doesn't write to a closed fd.
         if stdin {
@@ -136,10 +140,20 @@ extension ContainerAttachWSRoute {
                     fallbackImage: container.configuration.image.reference,
                     fallbackLabels: LabelNormalization.restore(container.configuration.labels),
                     dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                    broadcaster: req.application.storage[EventBroadcasterKey.self]
+                    broadcaster: broadcaster
                 )
 
                 try? await ws.close()
+            }
+
+            group.addTask {
+                try? await ws.onClose.get()
+                await ContainerAttachRoute.broadcastInteractiveDetach(
+                    container: container,
+                    channelActive: false,
+                    recordedExitCode: await ContainerExitCodeStore.shared.get(id: container.id),
+                    broadcaster: broadcaster
+                )
             }
 
             // Stdout → WS binary frames. Break on send error (client disconnected).
@@ -192,6 +206,9 @@ extension ContainerAttachWSRoute {
             return
         }
 
+        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+        await ContainerAttachRoute.broadcastAttach(container: container, stream: stream, logs: logs, broadcaster: broadcaster)
+
         // Wait for the log file, escaping when the WS closes or after ~10s.
         // The timeout guards against an indefinite poll when a container is
         // removed via another API call while the WS is still open.
@@ -220,11 +237,21 @@ extension ContainerAttachWSRoute {
 
         let containerClient = ContainerClient()
 
+        @Sendable func broadcastDetachIfStillRunning() async {
+            await ContainerAttachRoute.broadcastLogDetach(
+                container: container,
+                stream: stream,
+                currentStatus: (try? await containerClient.get(id: container.id))?.status,
+                broadcaster: broadcaster
+            )
+        }
+
         // Drain buffered output, breaking on client disconnect.
         while !ws.isClosed, let data = try? fileHandle.read(upToCount: 4096), !data.isEmpty {
             do {
                 try await ws.send(raw: data, opcode: .binary)
             } catch {
+                await broadcastDetachIfStillRunning()
                 try? await ws.close()
                 return
             }
@@ -250,6 +277,7 @@ extension ContainerAttachWSRoute {
             }
         }
 
+        await broadcastDetachIfStillRunning()
         try? await ws.close()
     }
 

--- a/Sources/socktainer/Routes/Containers/ContainerResizeRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerResizeRoute.swift
@@ -2,7 +2,7 @@ import ContainerizationOS
 import Vapor
 
 struct ContainerResizeRoute: RouteCollection {
-    let client: ClientContainerService
+    let client: ClientContainerProtocol
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.POST, pattern: "/containers/{id}/resize", use: ContainerResizeRoute.resize(client: client))
     }
@@ -28,7 +28,18 @@ struct ContainerResizeRoute: RouteCollection {
 
             if let process = await ProcessRegistry.shared.get(id: container.id) {
                 let size = Terminal.Size(width: UInt16(min(w, Int(UInt16.max))), height: UInt16(min(h, Int(UInt16.max))))
-                try? await process.resize(size)
+                // moby emits "resize" only after the task resize succeeded, carrying the
+                // requested height/width as decimal strings (daemon/resize.go). Exec resize
+                // stays silent — moby logs no event there.
+                if (try? await process.resize(size)) != nil,
+                    let broadcaster = req.application.storage[EventBroadcasterKey.self]
+                {
+                    await broadcaster.broadcast(
+                        DockerEvent.containerEvent(
+                            "resize", container: container,
+                            extraAttributes: ["height": String(h), "width": String(w)]
+                        ))
+                }
             }
 
             return Response(status: .ok)

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -98,6 +98,13 @@ extension ContainerStartRoute {
                 return .noContent
             }
 
+            // moby logs per-volume "mount" events while setting up the container's mounts,
+            // before the "start" event (daemon/volumes_unix.go). Same pragmatism as the
+            // ungated "start" below: a redundant /start re-emits them.
+            if let snap = metadataSnapshot {
+                await VolumeMountEvents.broadcastMounts(for: snap, containerId: eventId, broadcaster: broadcaster)
+            }
+
             // Emit "start" on every successful /start. We intentionally do NOT gate this on
             // "did this call transition the container to running": for a foreground `docker run`,
             // the attach route bootstraps and starts the container BEFORE /start is invoked, so
@@ -172,8 +179,20 @@ extension ContainerStartRoute {
             guard await ContainerRestartState.shared.isCurrent(id: nativeId, generation: generation) else { return }
 
             let executionDuration = Date().timeIntervalSince(startedAt)
+
+            // moby unmounts the container's volumes during exit cleanup, before logging
+            // "die" (daemon/monitor.go → daemon.Cleanup → container.UnmountVolumes). The
+            // snapshot is re-fetched here; a --rm container already reaped by Apple
+            // Container resolves to nil and skips its unmount events.
+            let exitSnapshot = (try? await client.getContainer(id: nativeId)) ?? nil
+            if let exitSnapshot {
+                await VolumeMountEvents.broadcastUnmounts(for: exitSnapshot, containerId: eventId, broadcaster: broadcaster)
+            }
+
             var attrs = labels
             attrs["exitCode"] = String(code)
+            // moby's die event carries the run duration in whole seconds (daemon/monitor.go).
+            attrs["execDuration"] = String(Int(executionDuration))
             let dieEvent = DockerEvent.simpleEvent(
                 id: eventId, type: "container", status: "die",
                 image: image, name: name, labels: attrs
@@ -285,6 +304,9 @@ extension ContainerStartRoute {
                 client: client,
                 logger: logger
             )
+            if let snap = restartedSnapshot ?? exitSnapshot {
+                await VolumeMountEvents.broadcastMounts(for: snap, containerId: eventId, broadcaster: broadcaster)
+            }
             await broadcaster.broadcast(
                 DockerEvent.simpleEvent(id: eventId, type: "container", status: "start", image: image, name: name, labels: labels)
             )

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -184,7 +184,7 @@ extension ContainerStartRoute {
             // "die" (daemon/monitor.go → daemon.Cleanup → container.UnmountVolumes). The
             // snapshot is re-fetched here; a --rm container already reaped by Apple
             // Container resolves to nil and skips its unmount events.
-            let exitSnapshot = (try? await client.getContainer(id: nativeId)) ?? nil
+            let exitSnapshot = try? await client.getContainer(id: nativeId)
             if let exitSnapshot {
                 await VolumeMountEvents.broadcastUnmounts(for: exitSnapshot, containerId: eventId, broadcaster: broadcaster)
             }

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -764,7 +764,13 @@ struct ExecRoute: RouteCollection {
                             try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
                         }
 
-                        // Connection was closed - the process monitor will handle cleanup
+                        // Connection was closed - the process monitor will handle cleanup.
+                        await ExecRoute.broadcastExecDetach(
+                            execRunning: await ExecManager.shared.isRunning(id: execId),
+                            execId: execId,
+                            container: container,
+                            broadcaster: execBroadcaster
+                        )
                     }
 
                     // Process monitor with proper cleanup
@@ -801,6 +807,15 @@ struct ExecRoute: RouteCollection {
                 // `GET /exec/{id}/json` can read the recorded exit code.
             }
         }
+    }
+
+    /// The client's channel died while the exec still runs (no exit code recorded):
+    /// the client detached — moby emits a plain "exec_detach" carrying the execID
+    /// (daemon/exec.go). A process exit records its code before the monitor closes
+    /// the channel, so `execRunning` is false there and nothing is emitted.
+    static func broadcastExecDetach(execRunning: Bool, execId: String, container: ContainerSnapshot, broadcaster: EventBroadcaster?) async {
+        guard execRunning, let broadcaster else { return }
+        await broadcaster.broadcast(DockerEvent.containerEvent("exec_detach", container: container, extraAttributes: ["execID": execId]))
     }
 
     /// Maps Docker's exec-start `ConsoleSize` to an initial terminal size.

--- a/Sources/socktainer/Routes/Images/ImagePushRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagePushRoute.swift
@@ -70,9 +70,19 @@ extension ImagePushRoute {
                 throw Abort(.internalServerError, reason: "Failed to push \(reference): \(error)")
             }
 
+            let app = req.application
+            // moby's push event uses the familiar reference as Actor.ID and the familiar
+            // name without tag as the `name` attribute (daemon/containerd/image_push.go).
+            let familiarName = (try? Reference.parse(reference))?.name ?? imageName
             response.body = .init(stream: { writer in
                 Task {
-                    await DockerProgressFrame.pipe(progressStream, to: writer)
+                    await DockerProgressFrame.pipe(progressStream, to: writer) {
+                        guard let broadcaster = app.storage[EventBroadcasterKey.self] else { return }
+                        await broadcaster.broadcast(
+                            DockerEvent.make(
+                                type: "image", action: "push", actorID: reference,
+                                attributes: ["name": familiarName]))
+                    }
                 }
             })
             return response

--- a/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
@@ -54,7 +54,22 @@ struct ImagesGetRoute: RouteCollection {
         }
         let tempDir = tarballPath.deletingLastPathComponent()
 
-        let response = try await req.fileio.asyncStreamFile(at: tarballPath.path)
+        // moby emits one "save" event per exported image with the digest as Actor.ID
+        // (daemon/containerd/image_exporter.go). A reference the store cannot resolve
+        // to a digest is carried as-is.
+        let digestsByReference = await client.digestsByReference()
+        let savedActorIds = references.map { digestsByReference[$0] ?? $0 }
+        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+
+        let response = try await req.fileio.asyncStreamFile(at: tarballPath.path) { result in
+            guard case .success = result, let broadcaster else { return }
+            for actorId in savedActorIds {
+                await broadcaster.broadcast(
+                    DockerEvent.make(
+                        type: "image", action: "save", actorID: actorId,
+                        attributes: ["name": actorId]))
+            }
+        }
 
         response.headers.contentType = HTTPMediaType(type: "application", subType: "x-tar")
 

--- a/Sources/socktainer/Routes/Images/ImagesLoadRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesLoadRoute.swift
@@ -78,11 +78,25 @@ extension ImagesLoadRoute {
                         let loadedImages = try await client.load(
                             tarballPath: tarPath, platform: platform, appleContainerAppSupportUrl: appleContainerAppSupportUrl, logger: req.logger)
 
+                        // moby emits one "load" event per loaded image with the digest as
+                        // Actor.ID (daemon/containerd/image_exporter.go). Loaded references
+                        // come straight from the store, so the digest lookup normally hits;
+                        // a miss falls back to the reference.
+                        let broadcaster = req.application.storage[EventBroadcasterKey.self]
+                        let digestsByReference = broadcaster != nil ? await client.digestsByReference() : [:]
+
                         for image in loadedImages {
                             if !quiet {
                                 DockerProgressFrame.write(DockerProgressFrame.status("Loaded image \(image)"), to: writer)
                             }
                             DockerProgressFrame.write(DockerProgressFrame.stream("Loaded image: \(image)\n"), to: writer)
+                            if let broadcaster {
+                                let actorId = digestsByReference[image] ?? image
+                                await broadcaster.broadcast(
+                                    DockerEvent.make(
+                                        type: "image", action: "load", actorID: actorId,
+                                        attributes: ["name": actorId]))
+                            }
                         }
 
                         _ = writer.write(.end)

--- a/Tests/socktainerTests/Events/AttachDetachEventTests.swift
+++ b/Tests/socktainerTests/Events/AttachDetachEventTests.swift
@@ -1,0 +1,247 @@
+import ContainerAPIClient
+import ContainerResource
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Attach/detach/exec_detach emission decisions, extracted from the streaming plumbing
+/// so moby's gating (daemon/attach.go, daemon/exec.go) is unit-testable: attach fires
+/// for streaming and logs-only attaches alike; detach fires only when the client leaves
+/// a still-running process, never when the process's own exit ended the attach.
+@Suite("Attach/detach/exec_detach events")
+struct AttachDetachEventTests {
+
+    @Test("attach is broadcast for a streaming attach on a running container")
+    func attachEmittedForStreamingAttach() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: ["app": "web"], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastAttach(container: snapshot, stream: true, logs: false, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.count == 1)
+        #expect(events.first?.Action == "attach")
+        #expect(events.first?.Type == "container")
+        #expect(events.first?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(events.first?.Actor.Attributes["name"] == "web")
+        #expect(events.first?.Actor.Attributes["app"] == "web")
+    }
+
+    @Test("attach is broadcast for a logs-only attach, like moby")
+    func attachEmittedForLogsOnlyAttach() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastAttach(container: snapshot, stream: false, logs: true, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.count == 1)
+        #expect(events.first?.Action == "attach")
+    }
+
+    @Test("attach is silent when the container lookup failed")
+    func attachSilentWhenLookupFailed() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastAttach(container: nil, stream: true, logs: true, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("attach is silent when neither stream nor logs was requested")
+    func attachSilentWithoutStreamOrLogs() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastAttach(container: snapshot, stream: false, logs: false, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("POST /containers/{id}/attach on an unknown container returns 404 and broadcasts nothing")
+    func attachRouteSilentOnUnknownContainer() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerAttachRoute(client: EmptyClientMock()))
+
+            try await app.testing().test(.POST, "/v1.51/containers/ghost/attach?stream=1&stdout=1") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("log-path detach fires when the client leaves a still-running container")
+    func logDetachEmittedForRunningContainer() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastLogDetach(container: snapshot, stream: true, currentStatus: .running, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.count == 1)
+        #expect(events.first?.Action == "detach")
+        #expect(events.first?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+    }
+
+    @Test("log-path detach is silent when the container already exited")
+    func logDetachSilentWhenContainerExited() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastLogDetach(container: snapshot, stream: true, currentStatus: .stopped, broadcaster: broadcaster)
+        await ContainerAttachRoute.broadcastLogDetach(container: snapshot, stream: true, currentStatus: nil, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("log-path detach is silent for a logs-only attach")
+    func logDetachSilentForLogsOnlyAttach() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastLogDetach(container: snapshot, stream: false, currentStatus: .running, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("interactive detach fires when the channel died with no exit code recorded")
+    func interactiveDetachEmittedForClientDisconnect() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastInteractiveDetach(container: snapshot, channelActive: false, recordedExitCode: nil, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.count == 1)
+        #expect(events.first?.Action == "detach")
+    }
+
+    @Test("interactive detach is silent when the process exit closed the connection")
+    func interactiveDetachSilentAfterProcessExit() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastInteractiveDetach(container: snapshot, channelActive: false, recordedExitCode: 0, broadcaster: broadcaster)
+        await ContainerAttachRoute.broadcastInteractiveDetach(container: snapshot, channelActive: false, recordedExitCode: 137, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("interactive detach is silent while the channel is still active")
+    func interactiveDetachSilentWhileChannelActive() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ContainerAttachRoute.broadcastInteractiveDetach(container: snapshot, channelActive: true, recordedExitCode: nil, broadcaster: broadcaster)
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+
+    @Test("exec_detach fires with a plain action and execID when the client detaches a running exec")
+    func execDetachEmittedForRunningExec() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let execId = await ExecManager.shared.create(config: makeExecConfig())
+        defer { Task { await ExecManager.shared.remove(id: execId) } }
+        #expect(await ExecManager.shared.markStarted(id: execId))
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ExecRoute.broadcastExecDetach(
+            execRunning: await ExecManager.shared.isRunning(id: execId),
+            execId: execId, container: snapshot, broadcaster: broadcaster
+        )
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.count == 1)
+        #expect(events.first?.Action == "exec_detach")
+        #expect(events.first?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(events.first?.Actor.Attributes["execID"] == execId)
+    }
+
+    @Test("exec_detach is silent once the exec's exit code was recorded")
+    func execDetachSilentAfterProcessExit() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let execId = await ExecManager.shared.create(config: makeExecConfig())
+        defer { Task { await ExecManager.shared.remove(id: execId) } }
+        #expect(await ExecManager.shared.markStarted(id: execId))
+        await ExecManager.shared.setExitCode(id: execId, code: 0)
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+
+        await ExecRoute.broadcastExecDetach(
+            execRunning: await ExecManager.shared.isRunning(id: execId),
+            execId: execId, container: snapshot, broadcaster: broadcaster
+        )
+
+        let events = await drainUntilSentinel(stream, broadcaster: broadcaster)
+        #expect(events.isEmpty)
+    }
+}
+
+// MARK: - Helpers
+
+/// Deterministic capture without sleeps: every broadcast before the sentinel is already
+/// buffered in the stream, so reading up to the sentinel yields exactly the events the
+/// exercised code emitted.
+private func drainUntilSentinel(_ stream: AsyncStream<DockerEvent>, broadcaster: EventBroadcaster) async -> [DockerEvent] {
+    await broadcaster.broadcast(DockerEvent.make(type: "test", action: "sentinel", actorID: "sentinel", attributes: [:]))
+    var events: [DockerEvent] = []
+    for await event in stream {
+        if event.Action == "sentinel" { break }
+        events.append(event)
+    }
+    return events
+}
+
+private func makeExecConfig() -> ExecManager.ExecConfig {
+    ExecManager.ExecConfig(
+        containerId: "web", cmd: ["sh", "-c", "sleep 1"],
+        attachStdin: true, attachStdout: true, attachStderr: false,
+        tty: true, detach: false, env: [], user: nil, workingDir: nil
+    )
+}
+
+private struct EmptyClientMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) { ([], 0) }
+}

--- a/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
+++ b/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
@@ -1,0 +1,161 @@
+import ContainerAPIClient
+import ContainerResource
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// moby emits "archive-path" on a successful GET /containers/{id}/archive and
+/// "extract-to-dir" on a successful PUT; HEAD emits nothing (daemon/archive_unix.go).
+@Suite("Archive events")
+struct ContainerArchiveEventTests {
+
+    @Test("GET /archive broadcasts 'archive-path' on success")
+    func getEmitsArchivePath() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: ["app": "web"], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "archive-path" { return event }
+            return nil
+        }
+
+        try await withArchiveApp(snapshot: snapshot, archive: FakeArchiveClient(), broadcaster: broadcaster) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/etc/hosts") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "container")
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["name"] == "web")
+        #expect(event?.Actor.Attributes["app"] == "web")
+    }
+
+    @Test("a failed GET /archive broadcasts nothing")
+    func failedGetStaysSilent() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "archive-path" { return event }
+            return nil
+        }
+
+        try await withArchiveApp(snapshot: snapshot, archive: FakeArchiveClient(getResult: .failure(.pathNotFound(path: "/missing"))), broadcaster: broadcaster) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/missing") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+
+    @Test("PUT /archive broadcasts 'extract-to-dir' on success")
+    func putEmitsExtractToDir() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "extract-to-dir" { return event }
+            return nil
+        }
+
+        try await withArchiveApp(snapshot: snapshot, archive: FakeArchiveClient(), broadcaster: broadcaster) { app in
+            try await app.testing().test(
+                .PUT, "/v1.51/containers/web/archive?path=/tmp",
+                body: ByteBuffer(data: Data("fake-tar-bytes".utf8))
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "container")
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+    }
+
+    @Test("HEAD /archive broadcasts nothing, like moby")
+    func headStaysSilent() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Type == "container" { return event }
+            return nil
+        }
+
+        try await withArchiveApp(snapshot: snapshot, archive: FakeArchiveClient(), broadcaster: broadcaster) { app in
+            try await app.testing().test(.HEAD, "/v1.51/containers/web/archive?path=/etc/hosts") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func withArchiveApp(
+    snapshot: ContainerSnapshot,
+    archive: FakeArchiveClient,
+    broadcaster: EventBroadcaster,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = broadcaster
+        try app.register(
+            collection: ContainerArchiveRoute(
+                containerClient: StaticSnapshotClientMock(snapshot: snapshot),
+                archiveClient: archive
+            ))
+        try await test(app)
+    }
+}
+
+private func withTimeout<T>(_ task: Task<T, Never>) async -> T {
+    let timeout = Task {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        task.cancel()
+    }
+    let value = await task.value
+    timeout.cancel()
+    return value
+}
+
+private struct FakeArchiveClient: ClientArchiveProtocol {
+    var getResult: Result<Void, ClientArchiveError> = .success(())
+
+    func getRootfsPath(containerId: String) -> URL {
+        URL(fileURLWithPath: "/nonexistent/rootfs.ext4")
+    }
+
+    func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat) {
+        if case .failure(let error) = getResult { throw error }
+        return (
+            Data("fake-tar".utf8),
+            PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+        )
+    }
+
+    func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws {}
+
+    func exportRootfs(containerId: String) async throws -> URL {
+        throw ClientArchiveError.operationFailed(message: "not under test")
+    }
+}

--- a/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
+++ b/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
@@ -1,0 +1,230 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// moby's push event carries the familiar reference as Actor.ID and the familiar name
+/// (no tag) as `name` (daemon/containerd/image_push.go); save/load emit one event per
+/// image with the digest as Actor.ID (daemon/containerd/image_exporter.go). Socktainer
+/// falls back to the reference when the store cannot resolve a digest.
+@Suite("Image push/save/load events")
+struct ImagePushSaveLoadEventTests {
+
+    @Test("a successful push broadcasts 'push' with the reference as Actor.ID and the familiar name")
+    func pushEmitsEvent() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "push" { return event }
+            return nil
+        }
+
+        try await withImageApp(client: FakeImageClient(), broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/images/alpine/push?tag=latest") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "image")
+        #expect(event?.Actor.ID == "alpine:latest")
+        #expect(event?.Actor.Attributes["name"] == "alpine")
+    }
+
+    @Test("a failed push broadcasts nothing")
+    func failedPushStaysSilent() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "push" { return event }
+            return nil
+        }
+
+        try await withImageApp(client: FakeImageClient(failPushStream: true), broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/images/alpine/push?tag=latest") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+
+    @Test("docker save broadcasts one 'save' per image with the digest as Actor.ID when resolvable")
+    func saveEmitsPerImageWithDigest() async throws {
+        let digest = "sha256:" + String(repeating: "a", count: 64)
+        let client = FakeImageClient(images: [makeClientImage(reference: "docker.io/library/alpine:latest", digest: digest)])
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "save" { return event }
+            return nil
+        }
+
+        try await withImageApp(client: client, broadcaster: broadcaster) { app in
+            try await app.testing().test(.GET, "/v1.51/images/docker.io/library/alpine:latest/get") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "image")
+        #expect(event?.Actor.ID == digest)
+        #expect(event?.Actor.Attributes["name"] == digest)
+    }
+
+    @Test("docker save falls back to the reference when the store cannot resolve a digest")
+    func saveFallsBackToReference() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "save" { return event }
+            return nil
+        }
+
+        try await withImageApp(client: FakeImageClient(), broadcaster: broadcaster) { app in
+            try await app.testing().test(.GET, "/v1.51/images/ghost:latest/get") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event?.Actor.ID == "ghost:latest")
+    }
+
+    @Test("docker load broadcasts one 'load' per loaded image with the digest as Actor.ID")
+    func loadEmitsPerImage() async throws {
+        let alpineDigest = "sha256:" + String(repeating: "b", count: 64)
+        let client = FakeImageClient(
+            images: [makeClientImage(reference: "docker.io/library/alpine:latest", digest: alpineDigest)],
+            loadedImages: ["docker.io/library/alpine:latest", "docker.io/library/busybox:latest"]
+        )
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<[DockerEvent], Never> {
+            var events: [DockerEvent] = []
+            for await event in stream where event.Action == "load" {
+                events.append(event)
+                if events.count == 2 { return events }
+            }
+            return events
+        }
+
+        try await withImageApp(client: client, broadcaster: broadcaster) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/images/load",
+                body: ByteBuffer(data: Data("fake-tarball".utf8))
+            ) { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let events = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(events.count == 2)
+        #expect(events.first?.Type == "image")
+        // Resolvable reference → digest; unresolvable → the reference itself.
+        #expect(events.first?.Actor.ID == alpineDigest)
+        #expect(events.last?.Actor.ID == "docker.io/library/busybox:latest")
+    }
+}
+
+// MARK: - Helpers
+
+private func withImageApp(
+    client: FakeImageClient,
+    broadcaster: EventBroadcaster,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = broadcaster
+        app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+        try app.register(collection: ImagePushRoute(client: client))
+        try app.register(collection: ImagesGetRoute(client: client))
+        try app.register(collection: ImagesLoadRoute(client: client))
+        try await test(app)
+    }
+}
+
+private func withTimeout<T>(_ task: Task<T, Never>) async -> T {
+    let timeout = Task {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        task.cancel()
+    }
+    let value = await task.value
+    timeout.cancel()
+    return value
+}
+
+private func makeClientImage(reference: String, digest: String) -> ClientImage {
+    ClientImage(
+        description: ImageDescription(
+            reference: reference,
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: digest,
+                size: 0
+            )
+        )
+    )
+}
+
+private struct FakeImageClient: ClientImageProtocol {
+    var images: [ClientImage] = []
+    var loadedImages: [String] = []
+    var failPushStream = false
+
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { images }
+
+    func delete(id: String) async throws -> ImageDeletionResult {
+        ImageDeletionResult(untagged: id, digest: "sha256:abc", deletedDigest: nil)
+    }
+
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        let fail = failPushStream
+        return AsyncThrowingStream { continuation in
+            continuation.yield("Pushing \(reference)")
+            if fail {
+                continuation.finish(throwing: ClientImageError.notFound(id: reference))
+            } else {
+                continuation.finish()
+            }
+        }
+    }
+
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] {
+        loadedImages
+    }
+
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tarball = tempDir.appendingPathComponent("images.tar")
+        try Data("fake-saved-tarball".utf8).write(to: tarball)
+        return tarball
+    }
+}

--- a/Tests/socktainerTests/Events/ResizeEventTests.swift
+++ b/Tests/socktainerTests/Events/ResizeEventTests.swift
@@ -1,0 +1,186 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOS
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// moby emits "resize" only after a successful container TTY resize, with the requested
+/// height/width as decimal-string attributes (daemon/resize.go). Exec resize emits nothing.
+@Suite("Resize events")
+struct ResizeEventTests {
+
+    @Test("a successful container resize broadcasts 'resize' with height/width attributes")
+    func containerResizeEmitsEvent() async throws {
+        let nativeId = "resize-ctr-\(Int.random(in: 10000...99999))"
+        let snapshot = try makeContainerSnapshot(nativeId: nativeId, ip: "192.168.65.2", network: "bridge", labels: ["app": "tty"], status: .running)
+        await ProcessRegistry.shared.set(id: nativeId, process: RecordingProcess(failResize: false))
+        defer { Task { await ProcessRegistry.shared.remove(id: nativeId) } }
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "resize" { return event }
+            return nil
+        }
+
+        try await withResizeApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/resize?h=40&w=120") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "container")
+        #expect(event?.Actor.ID == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["height"] == "40")
+        #expect(event?.Actor.Attributes["width"] == "120")
+        #expect(event?.Actor.Attributes["app"] == "tty")
+    }
+
+    @Test("a failed resize broadcasts nothing")
+    func failedResizeStaysSilent() async throws {
+        let nativeId = "resize-fail-\(Int.random(in: 10000...99999))"
+        let snapshot = try makeContainerSnapshot(nativeId: nativeId, ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        await ProcessRegistry.shared.set(id: nativeId, process: RecordingProcess(failResize: true))
+        defer { Task { await ProcessRegistry.shared.remove(id: nativeId) } }
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "resize" { return event }
+            return nil
+        }
+
+        try await withResizeApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/resize?h=40&w=120") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+
+    @Test("a container with no running process broadcasts nothing")
+    func noProcessStaysSilent() async throws {
+        let nativeId = "resize-none-\(Int.random(in: 10000...99999))"
+        let snapshot = try makeContainerSnapshot(nativeId: nativeId, ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "resize" { return event }
+            return nil
+        }
+
+        try await withResizeApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/resize?h=40&w=120") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+
+    @Test("a successful exec resize broadcasts nothing, like moby")
+    func execResizeStaysSilent() async throws {
+        let execId = await ExecManager.shared.create(
+            config: ExecManager.ExecConfig(
+                containerId: "resize-exec-ctr", cmd: ["sh"],
+                attachStdin: false, attachStdout: true, attachStderr: true,
+                tty: true, detach: false, env: [], user: nil, workingDir: nil
+            ))
+        await ProcessRegistry.shared.set(id: execId, process: RecordingProcess(failResize: false))
+        defer {
+            Task {
+                await ProcessRegistry.shared.remove(id: execId)
+                await ExecManager.shared.remove(id: execId)
+            }
+        }
+
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "resize" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ExecRoute(client: StubClientMock()))
+
+            try await app.testing().test(.POST, "/v1.51/exec/\(execId)/resize?h=40&w=120") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        #expect(event == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func withResizeApp(
+    snapshot: ContainerSnapshot,
+    broadcaster: EventBroadcaster,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = broadcaster
+        try app.register(collection: ContainerResizeRoute(client: StaticSnapshotClientMock(snapshot: snapshot)))
+        try await test(app)
+    }
+}
+
+private func withTimeout<T>(_ task: Task<T, Never>) async -> T {
+    let timeout = Task {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        task.cancel()
+    }
+    let value = await task.value
+    timeout.cancel()
+    return value
+}
+
+private struct RecordingProcess: ClientProcess {
+    let id = "resize-test-process"
+    let failResize: Bool
+    func start() async throws {}
+    func resize(_ size: ContainerizationOS.Terminal.Size) async throws {
+        if failResize { throw Abort(.internalServerError, reason: "resize failed") }
+    }
+    func kill(_ signal: Int32) async throws {}
+    func wait() async throws -> Int32 { 0 }
+}
+
+private struct StubClientMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) { ([], 0) }
+}

--- a/Tests/socktainerTests/Events/VolumeMountEventTests.swift
+++ b/Tests/socktainerTests/Events/VolumeMountEventTests.swift
@@ -1,0 +1,205 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// moby emits per-volume "mount" events while setting up mounts at container start
+/// (daemon/volumes_unix.go) and "unmount" during exit cleanup, before "die"
+/// (container.UnmountVolumes). The die event also carries execDuration in whole
+/// seconds (daemon/monitor.go).
+@Suite("Volume mount/unmount events & die execDuration")
+struct VolumeMountEventTests {
+
+    @Test("/start broadcasts a 'mount' per named volume with moby's attributes")
+    func startEmitsMountPerVolume() async throws {
+        let nativeId = "mount-ctr-\(Int.random(in: 10000...99999))"
+        let snapshot = makeMountedSnapshot(nativeId: nativeId, readonly: false)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "mount" { return event }
+            return nil
+        }
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+
+        try await withStartApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        await releaseDieObserver(nativeId: nativeId)
+
+        #expect(event?.Type == "volume")
+        #expect(event?.Actor.ID == "pgdata")
+        #expect(event?.Actor.Attributes["driver"] == "local")
+        #expect(event?.Actor.Attributes["container"] == DockerContainerID.hexId(for: snapshot))
+        #expect(event?.Actor.Attributes["destination"] == "/var/lib/postgresql/data")
+        #expect(event?.Actor.Attributes["read/write"] == "true")
+        #expect(event?.Actor.Attributes["propagation"] == "")
+    }
+
+    @Test("a read-only volume mount reports read/write=false")
+    func readOnlyMountReportsFalse() async throws {
+        let nativeId = "mount-ro-\(Int.random(in: 10000...99999))"
+        let snapshot = makeMountedSnapshot(nativeId: nativeId, readonly: true)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "mount" { return event }
+            return nil
+        }
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+
+        try await withStartApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        await releaseDieObserver(nativeId: nativeId)
+
+        #expect(event?.Actor.Attributes["read/write"] == "false")
+    }
+
+    @Test("a container without volume mounts broadcasts no 'mount'")
+    func noVolumesNoMountEvent() async throws {
+        let nativeId = "mount-none-\(Int.random(in: 10000...99999))"
+        let snapshot = makeMountedSnapshot(nativeId: nativeId, readonly: false, includeVolume: false)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "mount" { return event }
+            return nil
+        }
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+
+        try await withStartApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+        await releaseDieObserver(nativeId: nativeId)
+        #expect(event == nil)
+    }
+
+    @Test("the exit observer broadcasts 'unmount' before 'die', and die carries execDuration")
+    func exitEmitsUnmountThenDieWithExecDuration() async throws {
+        let nativeId = "unmount-ctr-\(Int.random(in: 10000...99999))"
+        let snapshot = makeMountedSnapshot(nativeId: nativeId, readonly: false)
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<[DockerEvent], Never> {
+            var events: [DockerEvent] = []
+            for await event in stream where event.Action == "unmount" || event.Action == "die" {
+                events.append(event)
+                if events.count == 2 { return events }
+            }
+            return events
+        }
+
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+
+        try await withStartApp(snapshot: snapshot, broadcaster: broadcaster) { app in
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        await ContainerExitCodeStore.shared.set(id: nativeId, code: 7)
+
+        let events = await withTimeout(captureTask)
+        captureTask.cancel()
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+
+        #expect(events.count == 2)
+        #expect(events.first?.Action == "unmount")
+        #expect(events.first?.Type == "volume")
+        #expect(events.first?.Actor.ID == "pgdata")
+        #expect(events.first?.Actor.Attributes["driver"] == "local")
+        #expect(events.first?.Actor.Attributes["container"] == DockerContainerID.hexId(for: snapshot))
+
+        let die = events.last
+        #expect(die?.Action == "die")
+        #expect(die?.Actor.Attributes["exitCode"] == "7")
+        let execDuration = die?.Actor.Attributes["execDuration"].flatMap(Int.init)
+        #expect(execDuration != nil && execDuration! >= 0)
+    }
+}
+
+// MARK: - Helpers
+
+private func withStartApp(
+    snapshot: ContainerSnapshot,
+    broadcaster: EventBroadcaster,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = broadcaster
+        try app.register(collection: ContainerStartRoute(client: StaticSnapshotClientMock(snapshot: snapshot)))
+        try await test(app)
+    }
+}
+
+/// Releases the detached die observer /start armed for this container so its
+/// waiter does not leak into later tests.
+private func releaseDieObserver(nativeId: String) async {
+    await ContainerExitCodeStore.shared.set(id: nativeId, code: 0)
+    await ContainerExitCodeStore.shared.remove(id: nativeId)
+}
+
+private func withTimeout<T>(_ task: Task<T, Never>) async -> T {
+    let timeout = Task {
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        task.cancel()
+    }
+    let value = await task.value
+    timeout.cancel()
+    return value
+}
+
+private func makeMountedSnapshot(nativeId: String, readonly: Bool, includeVolume: Bool = true) -> ContainerSnapshot {
+    let proc = ProcessConfiguration(
+        executable: "/bin/sh", arguments: [], environment: [],
+        workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+    )
+    let img = ImageDescription(
+        reference: "postgres:16",
+        descriptor: Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+    )
+    var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
+    var mounts: [Filesystem] = [
+        .virtiofs(source: "/tmp/host-dir", destination: "/mnt/host", options: [])
+    ]
+    if includeVolume {
+        mounts.append(
+            .volume(
+                name: "pgdata",
+                format: "ext4",
+                source: "/var/lib/volumes/pgdata",
+                destination: "/var/lib/postgresql/data",
+                options: readonly ? ["ro"] : []
+            ))
+    }
+    config.mounts = mounts
+    return ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+}


### PR DESCRIPTION
## Summary

Wires the Docker events socktainer was missing relative to moby v28.5.2, verified against the daemon source and live-checked against the real Apple Container 1.1.0 runtime.

## Changes

- **attach / detach** (container): `attach` on every attach path (running, logs-only, TCP-upgrade, WS) before streaming; `detach` only when the client disconnects while the process is still running, never on container exit (`daemon/attach.go`).
- **resize** (container): after a successful resize, carrying `height`/`width`. Exec resize stays silent, matching moby.
- **archive-path / extract-to-dir** (container): `GET`/`PUT /containers/{id}/archive` on success; `HEAD` stays silent. The deprecated Windows-only `copy` event is not implemented.
- **push / save / load** (image): `push` on successful push; `save`/`load` emit one event per image, Actor.ID the resolved digest when the store can resolve it, else the reference.
- **exec_detach** (container): plain action, `execID` attribute, only when the exec's TCP-upgrade channel dies while the process is still running.
- **mount / unmount** (volume): per named volume, at container start and at exit cleanup (before `die`), matching moby's ordering and attributes (`driver`, `container`, `destination`, `read/write`).
- **die** now carries `execDuration` in whole seconds.
- `kill`'s `signal` attribute and container `export`'s event were already present — no change needed.

`DockerEvent.containerEvent(_:container:extraAttributes:)` centralizes the snapshot-derived fields every new call site needs. Attach/detach/exec_detach decisions are isolated into small functions on `ContainerAttachRoute`/`ExecRoute` so their gating (container status, channel liveness, recorded exit code) is unit-testable without touching the streaming/NIO plumbing.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (724 tests, 30 new)
- [x] Unit tests added for resize, archive, image push/save/load, volume mount/unmount, die's execDuration, and attach/detach/exec_detach gating (via extracted decision functions with a recording broadcaster — each test fails if the gate is dropped or inverted, e.g. detach firing after container exit, or exec_detach firing after normal process exit)
- [x] Live-verified against a release build on the real 1.1.0 runtime: `docker attach --no-stdin` + client kill → `attach`→`detach` (log-streaming path); stdin-attach + client kill → `attach`→`detach` (TCP-upgrade path); `-v` volume start/stop → `mount` before `start`, `unmount` before `die {execDuration, exitCode}` in moby's order

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)