### PR TITLE
feat(images): implement docker import (fromSrc)

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -781,17 +781,34 @@ struct ClientImageService: ClientImageProtocol {
     /// `docker import` produces a new image, it cannot target an existing digest.
     private func resolveImportReference(repo: String?, tag: String?) throws -> String? {
         guard let repo, !repo.isEmpty else { return nil }
-        guard !Self.isDigestReference(repo) else {
+        if case .digestNotAllowed = Self.validateImportReference(repo: repo, tag: tag ?? "") {
             throw ClientImageError.digestReferenceNotAllowed(repo: repo)
         }
         let raw = (tag?.isEmpty == false) ? "\(repo):\(tag!)" : repo
         return try ClientImage.normalizeReference(raw, containerSystemConfig: containerSystemConfig)
     }
 
-    /// A Docker reference's grammar reserves `@` exclusively for introducing a
-    /// digest (`name@algorithm:hex`), so its presence alone is unambiguous —
-    /// matching moby's `reference.Digested` check, which isn't sha256-specific.
-    static func isDigestReference(_ repo: String) -> Bool {
-        repo.range(of: #"@[a-z0-9]+:[0-9a-f]+$"#, options: .regularExpression) != nil
+    enum ImportReferenceValidation: Equatable {
+        case valid
+        case digestNotAllowed
+        case malformed(reason: String)
+    }
+
+    /// Mirrors moby's early `httputils.RepoTagReference` validation
+    /// (api/server/router/image/image_routes.go's `postImagesCreate` validates
+    /// before the layer reader is even constructed): parses `repo`/`tag`
+    /// through the same reference grammar `normalizeReference` uses, so any
+    /// malformed reference — not just a digest — is rejected before the
+    /// request body is read, and both callers of this check (the route's
+    /// fail-fast and this file's own `resolveImportReference`) agree.
+    static func validateImportReference(repo: String, tag: String) -> ImportReferenceValidation {
+        guard !repo.isEmpty else { return .valid }
+        let raw = tag.isEmpty ? repo : "\(repo):\(tag)"
+        do {
+            let parsed = try Reference.parse(raw)
+            return parsed.digest != nil ? .digestNotAllowed : .valid
+        } catch {
+            return .malformed(reason: String(describing: error))
+        }
     }
 }

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -30,6 +30,16 @@ protocol ClientImageProtocol: Sendable {
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64)
     func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String]
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL
+    func importImage(
+        tarPath: URL,
+        repo: String?,
+        tag: String?,
+        message: String?,
+        changes: [String],
+        platform: Platform,
+        appleContainerAppSupportUrl: URL,
+        logger: Logger
+    ) async throws -> (reference: String?, digest: String)
 }
 
 extension ClientImageProtocol {
@@ -40,6 +50,7 @@ extension ClientImageProtocol {
 
 enum ClientImageError: Error {
     case notFound(id: String)
+    case digestReferenceNotAllowed(repo: String)
 }
 
 enum PullProgress: Sendable {
@@ -715,5 +726,72 @@ struct ClientImageService: ClientImageProtocol {
         logger.info("Successfully exported \(resolvedReferences.count) image(s) to tarball in Docker format")
 
         return tarballPath
+    }
+
+    /// `docker import`: synthesizes a single-layer OCI image from `tarPath` (the
+    /// raw `fromSrc=-` request body) and loads it into the image store the same
+    /// way `load()` does. Returns the registered reference (nil if untagged) and
+    /// the digest `imageStore.load` assigned — the same "id" concept `list`/
+    /// `delete`/`load` already use elsewhere in this file.
+    func importImage(
+        tarPath: URL,
+        repo: String?,
+        tag: String?,
+        message: String?,
+        changes: [String],
+        platform: Platform,
+        appleContainerAppSupportUrl: URL,
+        logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        let reference = try resolveImportReference(repo: repo, tag: tag)
+
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(changes, to: &config)
+
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let ociLayoutPath = tempDir.appendingPathComponent("oci-layout")
+        try FileManager.default.createDirectory(at: ociLayoutPath, withIntermediateDirectories: true)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: ociLayoutPath,
+            platform: platform,
+            config: config,
+            message: message,
+            reference: reference,
+            logger: logger
+        )
+
+        let imageStore = try ImageStore(path: appleContainerAppSupportUrl)
+        let images = try await imageStore.load(from: ociLayoutPath, progress: nil)
+        guard let image = images.first else {
+            throw ClientImageError.notFound(id: reference ?? "imported image")
+        }
+
+        logger.info("Imported image \(image.reference) (\(image.digest))")
+        return (reference, image.digest)
+    }
+
+    /// Mirrors moby's `httputils.RepoTagReference`: empty repo means an
+    /// untagged import; an empty tag defaults to "latest" (via
+    /// `normalizeReference`'s `.normalize()`); a digest reference is rejected —
+    /// `docker import` produces a new image, it cannot target an existing digest.
+    private func resolveImportReference(repo: String?, tag: String?) throws -> String? {
+        guard let repo, !repo.isEmpty else { return nil }
+        guard !Self.isDigestReference(repo) else {
+            throw ClientImageError.digestReferenceNotAllowed(repo: repo)
+        }
+        let raw = (tag?.isEmpty == false) ? "\(repo):\(tag!)" : repo
+        return try ClientImage.normalizeReference(raw, containerSystemConfig: containerSystemConfig)
+    }
+
+    /// A Docker reference's grammar reserves `@` exclusively for introducing a
+    /// digest (`name@algorithm:hex`), so its presence alone is unambiguous —
+    /// matching moby's `reference.Digested` check, which isn't sha256-specific.
+    static func isDigestReference(_ repo: String) -> Bool {
+        repo.range(of: #"@[a-z0-9]+:[0-9a-f]+$"#, options: .regularExpression) != nil
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
@@ -13,12 +13,10 @@ struct RESTImageCreateQuery: Content {
     let fromImage: String?
     let tag: String?
     let platform: String?
-    // TODO: Revisit it later
-    // let fromSrc: String?
-    // let repo: String?
-    // let message: String?
-    // let inputImage: String?
-    // let changes: [String]?
+    let fromSrc: String?
+    let repo: String?
+    let message: String?
+    let changes: [String]?
 }
 
 extension ImageCreateRoute {
@@ -26,6 +24,11 @@ extension ImageCreateRoute {
         { req in
             let query = try req.query.decode(RESTImageCreateQuery.self)
             let image = query.fromImage ?? ""
+
+            guard !image.isEmpty else {
+                return try await handleImport(req, query: query, client: client)
+            }
+
             let tag = query.tag ?? ""
             let decodedTag = tag.removingPercentEncoding ?? tag
             let platformString = query.platform
@@ -68,5 +71,96 @@ extension ImageCreateRoute {
             })
             return response
         }
+    }
+
+    /// `docker import`: only `fromSrc=-` (the tar streamed in the request body)
+    /// is implemented. A URL `fromSrc` would require fetching a remote tarball
+    /// or plain file — no outbound HTTP client is wired up for that anywhere in
+    /// this codebase yet, so it is rejected rather than half-implemented.
+    private static func handleImport(_ req: Request, query: RESTImageCreateQuery, client: ClientImageProtocol) async throws -> Response {
+        guard let fromSrc = query.fromSrc, !fromSrc.isEmpty else {
+            throw Abort(.badRequest, reason: "fromImage or fromSrc is required")
+        }
+        guard fromSrc == "-" else {
+            throw Abort(.notImplemented, reason: "docker import with a URL fromSrc is not supported; only fromSrc=- (request body) is implemented")
+        }
+        let repo = query.repo ?? ""
+        let tag = query.tag ?? ""
+        // Matches moby: repo/tag is validated before the layer reader is even set
+        // up, so a bad reference is rejected without reading the request body.
+        if ClientImageService.isDigestReference(repo) {
+            throw Abort(.badRequest, reason: "cannot reference \(repo) by digest")
+        }
+
+        let platform: Platform
+        if let platformString = query.platform, !platformString.isEmpty {
+            do {
+                platform = try platformOrThrow(platformString)
+            } catch {
+                throw Abort(.badRequest, reason: "invalid platform: \(platformString)")
+            }
+        } else {
+            platform = currentPlatform()
+        }
+
+        guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
+            throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
+        }
+
+        let bodyBuffer: ByteBuffer
+        if let data = req.body.data {
+            bodyBuffer = data
+        } else {
+            var collectedBuffer = ByteBufferAllocator().buffer(capacity: 0)
+            for try await chunk in req.body {
+                var chunkBuffer = chunk
+                collectedBuffer.writeBuffer(&chunkBuffer)
+            }
+            bodyBuffer = collectedBuffer
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tarPath = tempDir.appendingPathComponent("import.tar")
+        try Data(buffer: bodyBuffer).write(to: tarPath)
+
+        // moby defaults an empty message to "Imported from <src>".
+        let message = (query.message?.isEmpty ?? true) ? "Imported from \(fromSrc)" : query.message!
+        let changes = query.changes ?? []
+
+        let app = req.application
+        let response = Response()
+        response.headers.add(name: .contentType, value: "application/json")
+        response.body = .init(stream: { writer in
+            Task {
+                defer { try? FileManager.default.removeItem(at: tempDir) }
+                do {
+                    let (_, digest) = try await client.importImage(
+                        tarPath: tarPath,
+                        repo: repo.isEmpty ? nil : repo,
+                        tag: tag.isEmpty ? nil : tag,
+                        message: message,
+                        changes: changes,
+                        platform: platform,
+                        appleContainerAppSupportUrl: appleContainerAppSupportUrl,
+                        logger: req.logger
+                    )
+                    DockerProgressFrame.write(DockerProgressFrame.status(digest), to: writer)
+                    _ = writer.write(.end)
+
+                    guard let broadcaster = app.storage[EventBroadcasterKey.self] else { return }
+                    // moby's import event uses the image digest as both Actor.ID and
+                    // the `name` attribute — unlike pull/tag, the human-readable
+                    // reference never appears in this event.
+                    await broadcaster.broadcast(
+                        DockerEvent.make(type: "image", action: "import", actorID: digest, attributes: ["name": digest]))
+                } catch {
+                    req.logger.error("Failed to import image: \(error)")
+                    DockerProgressFrame.write(DockerProgressFrame.error(String(describing: error)), to: writer)
+                    _ = writer.write(.end)
+                }
+            }
+        })
+        return response
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
@@ -87,9 +87,15 @@ extension ImageCreateRoute {
         let repo = query.repo ?? ""
         let tag = query.tag ?? ""
         // Matches moby: repo/tag is validated before the layer reader is even set
-        // up, so a bad reference is rejected without reading the request body.
-        if ClientImageService.isDigestReference(repo) {
+        // up, so any malformed reference — not just a digest — is rejected
+        // without reading the request body.
+        switch ClientImageService.validateImportReference(repo: repo, tag: tag) {
+        case .valid:
+            break
+        case .digestNotAllowed:
             throw Abort(.badRequest, reason: "cannot reference \(repo) by digest")
+        case .malformed(let reason):
+            throw Abort(.badRequest, reason: "invalid reference format: \(reason)")
         }
 
         let platform: Platform
@@ -107,22 +113,15 @@ extension ImageCreateRoute {
             throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
         }
 
-        let bodyBuffer: ByteBuffer
-        if let data = req.body.data {
-            bodyBuffer = data
-        } else {
-            var collectedBuffer = ByteBufferAllocator().buffer(capacity: 0)
-            for try await chunk in req.body {
-                var chunkBuffer = chunk
-                collectedBuffer.writeBuffer(&chunkBuffer)
-            }
-            bodyBuffer = collectedBuffer
-        }
-
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let tarPath = tempDir.appendingPathComponent("import.tar")
-        try Data(buffer: bodyBuffer).write(to: tarPath)
+        do {
+            try await writeBodyToFile(req.body, at: tarPath)
+        } catch {
+            try? FileManager.default.removeItem(at: tempDir)
+            throw error
+        }
 
         // moby defaults an empty message to "Imported from <src>".
         let message = (query.message?.isEmpty ?? true) ? "Imported from \(fromSrc)" : query.message!
@@ -162,5 +161,37 @@ extension ImageCreateRoute {
             }
         })
         return response
+    }
+
+    /// Import bodies are single-layer tarballs and can legitimately be several
+    /// GB; this bounds them well above any real use while still rejecting a
+    /// runaway or malicious upload before it fills disk.
+    private static let maxImportBodySize = 8 * 1024 * 1024 * 1024
+
+    /// Streams the request body to disk in chunks rather than buffering the
+    /// whole tarball in memory first, enforcing `maxImportBodySize` as it goes.
+    private static func writeBodyToFile(_ body: Request.Body, at destination: URL) async throws {
+        guard FileManager.default.createFile(atPath: destination.path, contents: nil) else {
+            throw Abort(.internalServerError, reason: "failed to create temporary file for import")
+        }
+        let handle = try FileHandle(forWritingTo: destination)
+        defer { try? handle.close() }
+
+        var totalBytes = 0
+        func writeAndCheckLimit(_ buffer: ByteBuffer) throws {
+            totalBytes += buffer.readableBytes
+            guard totalBytes <= maxImportBodySize else {
+                throw Abort(.payloadTooLarge, reason: "import body exceeds the \(maxImportBodySize)-byte limit")
+            }
+            try handle.write(contentsOf: Data(buffer: buffer))
+        }
+
+        if let data = body.data {
+            try writeAndCheckLimit(data)
+            return
+        }
+        for try await chunk in body {
+            try writeAndCheckLimit(chunk)
+        }
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageDeleteRoute.swift
@@ -28,6 +28,8 @@ extension ImageDeleteRoute {
                 switch error {
                 case .notFound(let id):
                     throw Abort(.notFound, reason: "No such image: \(id)")
+                case .digestReferenceNotAllowed(let repo):
+                    throw Abort(.badRequest, reason: "cannot reference \(repo) by digest")
                 }
             }
 

--- a/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
@@ -50,6 +50,8 @@ struct ImagesGetRoute: RouteCollection {
             switch error {
             case .notFound(let id):
                 throw Abort(.notFound, reason: id)
+            case .digestReferenceNotAllowed(let repo):
+                throw Abort(.badRequest, reason: "cannot reference \(repo) by digest")
             }
         }
         let tempDir = tarballPath.deletingLastPathComponent()

--- a/Sources/socktainer/Utilities/CRC32.swift
+++ b/Sources/socktainer/Utilities/CRC32.swift
@@ -1,0 +1,25 @@
+/// CRC-32/ISO-HDLC — the checksum variant gzip's trailer requires (RFC 1952 §2.3).
+enum CRC32 {
+    private static let polynomial: UInt32 = 0xEDB8_8320
+    private static let initialAndFinalXOR: UInt32 = 0xFFFF_FFFF
+
+    private static let table: [UInt32] = (0..<256).map { byte in
+        var remainder = UInt32(byte)
+        for _ in 0..<8 {
+            remainder = (remainder & 1 != 0) ? (polynomial ^ (remainder >> 1)) : (remainder >> 1)
+        }
+        return remainder
+    }
+
+    struct Incremental {
+        private var crc: UInt32 = CRC32.initialAndFinalXOR
+
+        mutating func update(_ bytes: UnsafeRawBufferPointer) {
+            for byte in bytes {
+                crc = CRC32.table[Int((crc ^ UInt32(byte)) & 0xFF)] ^ (crc >> 8)
+            }
+        }
+
+        var value: UInt32 { crc ^ CRC32.initialAndFinalXOR }
+    }
+}

--- a/Sources/socktainer/Utilities/CompressionStream.swift
+++ b/Sources/socktainer/Utilities/CompressionStream.swift
@@ -1,0 +1,63 @@
+import Compression
+import Foundation
+
+/// Shared low-level driver for Apple's system `compression_stream` API, used
+/// by both `GzipStreamDecoder` and `GzipStreamEncoder` so the one genuinely
+/// tricky part — knowing when to stop calling `compression_stream_process`
+/// — is written and verified once.
+enum CompressionStreamDriver {
+    private static let chunkSize = 1 << 20
+
+    static var defaultChunkSize: Int { chunkSize }
+
+    /// `compression_stream`'s pointer fields are non-optional, so `init`
+    /// needs *some* valid value before `process` ever assigns a real buffer;
+    /// centralizing setup/teardown here means a stream can never outlive its
+    /// placeholder or leak either one.
+    static func withStream<T>(
+        operation: compression_stream_operation, onError: () -> Swift.Error,
+        _ body: (inout compression_stream, UnsafeMutablePointer<UInt8>) throws -> T
+    ) throws -> T {
+        let placeholder = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
+        defer { placeholder.deallocate() }
+        var stream = compression_stream(dst_ptr: placeholder, dst_size: 0, src_ptr: placeholder, src_size: 0, state: nil)
+        guard compression_stream_init(&stream, operation, COMPRESSION_ZLIB) == COMPRESSION_STATUS_OK else {
+            throw onError()
+        }
+        defer { compression_stream_destroy(&stream) }
+        return try body(&stream, placeholder)
+    }
+
+    /// Feeds `input` into `stream`, invoking `onOutput` with each produced
+    /// chunk (never accumulated), and returns the resulting status.
+    static func process(
+        _ stream: inout compression_stream, input: Data, finalize: Bool, outputBuffer: inout [UInt8],
+        placeholder: UnsafeMutablePointer<UInt8>, onError: () -> Swift.Error, onOutput: (UnsafeRawBufferPointer) throws -> Void
+    ) throws -> compression_status {
+        var status: compression_status = COMPRESSION_STATUS_OK
+        try input.withUnsafeBytes { (sourceRaw: UnsafeRawBufferPointer) in
+            stream.src_ptr = sourceRaw.bindMemory(to: UInt8.self).baseAddress ?? UnsafePointer(placeholder)
+            stream.src_size = input.count
+
+            var producedFullBuffer = false
+            repeat {
+                try outputBuffer.withUnsafeMutableBufferPointer { outputPtr in
+                    stream.dst_ptr = outputPtr.baseAddress!
+                    stream.dst_size = outputPtr.count
+                    let flags: Int32 = finalize ? Int32(COMPRESSION_STREAM_FINALIZE.rawValue) : 0
+                    status = compression_stream_process(&stream, flags)
+                    guard status != COMPRESSION_STATUS_ERROR else { throw onError() }
+
+                    let produced = outputPtr.count - stream.dst_size
+                    producedFullBuffer = produced == outputPtr.count
+                    guard produced > 0 else { return }
+                    try onOutput(UnsafeRawBufferPointer(start: outputPtr.baseAddress, count: produced))
+                }
+                // `finalize` forces another pass even with zero input left: the
+                // trailing flush takes several such calls to reach END, and
+                // stopping at the first would leave `status` stuck at OK.
+            } while status == COMPRESSION_STATUS_OK && (finalize || stream.src_size > 0 || producedFullBuffer)
+        }
+        return status
+    }
+}

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -11,6 +11,11 @@ enum ContainerImageUtility {
         case invalidTarball(reason: String)
     }
 
+    /// Bounds decompressed gzip content the same way `maxImportBodySize`
+    /// bounds the upload itself, so a small, extreme-ratio malicious layer
+    /// can't expand past a reasonable ceiling before being rejected.
+    private static let maxExpandedLayerSize = 8 * 1024 * 1024 * 1024
+
     static func convertDockerTarToOCI(
         dockerFormatPath: URL,
         ociLayoutPath: URL,
@@ -396,23 +401,27 @@ enum ContainerImageUtility {
         switch try classifyLayerSource(at: tarPath) {
         case .gzip:
             // Stored as-is (unchanged from the request body): copied straight
-            // from `tarPath` rather than re-written from an in-memory buffer.
-            // The compressed bytes still need one full-buffer pass — decoding
-            // them (for the diff_id) requires it, and `DataCompression`, the
-            // only gzip codec available here, exposes no streaming API — so
-            // the digest is hashed from that already-loaded buffer rather than
-            // re-reading the file a second time.
-            let compressed = try Data(contentsOf: tarPath)
-            guard let decompressed = compressed.gunzip() else {
+            // from `tarPath` and hashed by streaming the file in chunks. The
+            // diff_id is the decompressed content's hash — decompressed via
+            // `GzipStreamDecoder`, which never materializes the expanded
+            // content in memory, unlike `DataCompression.gunzip()`, so a
+            // small, highly-compressible malicious layer can't exhaust memory
+            // before `maxExpandedLayerSize` catches it mid-stream.
+            let (digest, size) = try sha256OfFile(at: tarPath)
+            let diffID: String
+            do {
+                diffID = try GzipStreamDecoder.sha256OfDecompressedContent(at: tarPath, cap: maxExpandedLayerSize)
+            } catch GzipStreamDecoder.Error.exceedsCap {
+                throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
+            } catch {
                 throw Error.invalidTarball(reason: "failed to decompress gzip layer")
             }
-            let digest = compressed.sha256Hex()
             let destination = blobsDir.appendingPathComponent(digest)
             if !FileManager.default.fileExists(atPath: destination.path) {
                 try FileManager.default.copyItem(at: tarPath, to: destination)
             }
             return ImportedLayerBlob(
-                digest: digest, size: compressed.count, diffID: decompressed.sha256Hex(),
+                digest: digest, size: size, diffID: diffID,
                 mediaType: "application/vnd.oci.image.layer.v1.tar+gzip")
 
         case .zstd:

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -1,4 +1,7 @@
+import ContainerizationArchive
+import ContainerizationOCI
 import CryptoKit
+import DataCompression
 import Foundation
 import Logging
 
@@ -111,6 +114,292 @@ enum ContainerImageUtility {
         }
 
         return loadedImages
+    }
+
+    /// Builds a single-layer OCI image layout from an on-disk tar (the raw
+    /// `docker import fromSrc=-` request body). Mirrors `convertDockerTarToOCI`'s
+    /// digest/blob/manifest/index construction, but for a synthesized image
+    /// rather than one converted from an existing docker-archive.
+    ///
+    /// A gzip-compressed body (detected by magic bytes) is stored as-is with the
+    /// gzip layer media type; its diff_id is the digest of the decompressed
+    /// content, matching moby's passthrough-if-already-compressed behavior.
+    /// Anything else is treated as an uncompressed tar: the stored blob's own
+    /// digest doubles as its diff_id. bzip2/xz bodies are not decompressed —
+    /// they fall into the uncompressed path, so their diff_id would not match
+    /// the true uncompressed content (see PR description: deferred).
+    ///
+    /// Returns the manifest digest (without the `sha256:` prefix).
+    static func buildSingleLayerOCILayout(
+        tarPath: URL,
+        ociLayoutPath: URL,
+        platform: Platform,
+        config: SynthesizedImageConfig,
+        message: String?,
+        reference: String?,
+        logger: Logger
+    ) throws -> String {
+        try rejectForeignFormat(at: tarPath)
+        try validateTar(at: tarPath)
+
+        let blobsDir = ociLayoutPath.appendingPathComponent("blobs/sha256")
+        try FileManager.default.createDirectory(at: blobsDir, withIntermediateDirectories: true)
+
+        let ociLayout = "{\"imageLayoutVersion\": \"1.0.0\"}"
+        try ociLayout.write(to: ociLayoutPath.appendingPathComponent("oci-layout"), atomically: true, encoding: .utf8)
+
+        let layer = try writeImportedLayerBlob(tarPath: tarPath, into: blobsDir)
+
+        let createdAt = ISO8601DateFormatter().string(from: Date())
+        var imageConfigDict: [String: Any] = [
+            "created": createdAt,
+            "architecture": platform.architecture,
+            "os": platform.os,
+            "config": config.toDict(),
+            "rootfs": [
+                "type": "layers",
+                "diff_ids": ["sha256:\(layer.diffID)"],
+            ],
+            "history": [
+                [
+                    "created": createdAt,
+                    "comment": message ?? "",
+                ]
+            ],
+        ]
+        if let variant = platform.variant {
+            imageConfigDict["variant"] = variant
+        }
+
+        let configData = try JSONSerialization.data(withJSONObject: imageConfigDict, options: [])
+        let configDigest = configData.sha256Hex()
+        try configData.write(to: blobsDir.appendingPathComponent(configDigest))
+
+        let manifest: [String: Any] = [
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": [
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": "sha256:\(configDigest)",
+                "size": configData.count,
+            ],
+            "layers": [
+                [
+                    "mediaType": layer.mediaType,
+                    "digest": "sha256:\(layer.digest)",
+                    "size": layer.size,
+                ]
+            ],
+        ]
+        let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [])
+        let manifestDigest = manifestData.sha256Hex()
+        try manifestData.write(to: blobsDir.appendingPathComponent(manifestDigest))
+
+        var manifestDescriptor: [String: Any] = [
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:\(manifestDigest)",
+            "size": manifestData.count,
+        ]
+        if let reference {
+            manifestDescriptor["annotations"] = ["org.opencontainers.image.ref.name": reference]
+        }
+
+        let index: [String: Any] = [
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [manifestDescriptor],
+        ]
+        let indexData = try JSONSerialization.data(withJSONObject: index, options: [.prettyPrinted])
+        try indexData.write(to: ociLayoutPath.appendingPathComponent("index.json"))
+
+        logger.info("Synthesized single-layer OCI image sha256:\(manifestDigest) from an imported tarball")
+
+        return manifestDigest
+    }
+
+    /// moby's own `docker import` only ever decompresses via a compression-filter
+    /// detector (gzip/bzip2/xz/zstd), never a general archive-format detector —
+    /// so a zip/7z/rar/etc. body isn't "unwrapped" by it either; it just fails
+    /// tar parsing downstream. `ArchiveReader(file:)` is broader (it recognizes
+    /// every libarchive container format, not just tar), so without this check
+    /// those foreign formats would pass structural validation here and then get
+    /// hashed as raw bytes in `writeImportedLayerBlob`, silently producing a
+    /// corrupt, unrunnable image instead of the rejection moby would also reach.
+    private enum LayerSource: Equatable {
+        case gzip
+        case zstd
+        case plainOrUnknown
+        case reserializeRequired
+        case foreignFormat(String)
+    }
+
+    private static func classifyLayerSource(at tarPath: URL) throws -> LayerSource {
+        let magic = try readMagic(at: tarPath, length: 8)
+        if magic.starts(with: [0x1f, 0x8b]) { return .gzip }
+        if magic.starts(with: [0x28, 0xb5, 0x2f, 0xfd]) { return .zstd }
+        if magic.starts(with: [0x42, 0x5a, 0x68]) { return .reserializeRequired }  // bzip2
+        if magic.starts(with: [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]) { return .reserializeRequired }  // xz
+        if magic.starts(with: [0x50, 0x4b, 0x03, 0x04]) { return .foreignFormat("zip") }
+        if magic.starts(with: [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]) { return .foreignFormat("7z") }
+        if magic.starts(with: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07]) { return .foreignFormat("rar") }
+        if magic.starts(with: Array("!<arch>\n".utf8)) { return .foreignFormat("ar") }
+        if let leading6 = String(data: magic.prefix(6), encoding: .ascii), ["070701", "070702", "070707"].contains(leading6) {
+            return .foreignFormat("cpio")
+        }
+        if try isISO9660(at: tarPath) { return .foreignFormat("iso9660") }
+        return .plainOrUnknown
+    }
+
+    private static func readMagic(at tarPath: URL, length: Int) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: tarPath)
+        defer { try? handle.close() }
+        return try handle.read(upToCount: length) ?? Data()
+    }
+
+    /// The "CD001" standard identifier sits at a fixed offset into the Primary
+    /// Volume Descriptor, not at the start of the file.
+    private static func isISO9660(at tarPath: URL) throws -> Bool {
+        let handle = try FileHandle(forReadingFrom: tarPath)
+        defer { try? handle.close() }
+        handle.seek(toFileOffset: 32769)
+        return try handle.read(upToCount: 5) == Data("CD001".utf8)
+    }
+
+    private static func rejectForeignFormat(at tarPath: URL) throws {
+        guard case .foreignFormat(let format) = try classifyLayerSource(at: tarPath) else { return }
+        throw Error.invalidTarball(reason: "\(format) is not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
+    }
+
+    /// Repackages an archive whose compression `ArchiveReader` can decompress
+    /// but `DataCompression` cannot (bzip2/xz/zstd) into a canonical
+    /// uncompressed tar, so the diff_id and stored blob reflect the real
+    /// content instead of the still-compressed bytes.
+    private static func reserializeToPlainTar(from source: URL, to destination: URL) throws {
+        let reader = try ArchiveReader(file: source)
+        let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: destination)
+        for (entry, entryReader) in reader.makeStreamingIterator() {
+            let transaction = writer.makeTransactionWriter()
+            try transaction.writeHeader(entry: entry)
+            var buffer = [UInt8](repeating: 0, count: 1 << 20)
+            while true {
+                let read = buffer.withUnsafeMutableBufferPointer { entryReader.read($0.baseAddress!, maxLength: $0.count) }
+                guard read > 0 else {
+                    if read < 0 { throw Error.invalidTarball(reason: "failed to read archive entry while repackaging") }
+                    break
+                }
+                try buffer.withUnsafeBytes { try transaction.writeChunk(data: UnsafeRawBufferPointer(rebasing: $0.prefix(read))) }
+            }
+            try transaction.finish()
+        }
+        try writer.finishEncoding()
+    }
+
+    /// Rejects an empty body outright (a 0-byte "tar" would otherwise read back
+    /// as zero archive entries — not an error `ArchiveReader` surfaces on its
+    /// own) and confirms the remainder actually parses as an archive, so
+    /// `docker import` of a non-tar or empty file fails cleanly instead of
+    /// silently registering an unusable image.
+    private static func validateTar(at tarPath: URL) throws {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: tarPath.path)
+        guard let size = attributes?[.size] as? UInt64, size > 0 else {
+            throw Error.invalidTarball(reason: "empty request body")
+        }
+
+        let reader: ArchiveReader
+        do {
+            reader = try ArchiveReader(file: tarPath)
+        } catch {
+            throw Error.invalidTarball(reason: "not a valid tar archive: \(error.localizedDescription)")
+        }
+        do {
+            for (_, entryReader) in reader.makeStreamingIterator() {
+                var buffer = [UInt8](repeating: 0, count: 1 << 16)
+                while true {
+                    let read = buffer.withUnsafeMutableBufferPointer { entryReader.read($0.baseAddress!, maxLength: $0.count) }
+                    guard read > 0 else {
+                        if read < 0 {
+                            throw Error.invalidTarball(reason: "not a valid tar archive")
+                        }
+                        break
+                    }
+                }
+            }
+        } catch let error as Error {
+            throw error
+        } catch {
+            throw Error.invalidTarball(reason: "not a valid tar archive: \(error.localizedDescription)")
+        }
+    }
+
+    private struct ImportedLayerBlob {
+        let digest: String
+        let size: Int
+        let diffID: String
+        let mediaType: String
+    }
+
+    private static func writeImportedLayerBlob(tarPath: URL, into blobsDir: URL) throws -> ImportedLayerBlob {
+        switch try classifyLayerSource(at: tarPath) {
+        case .gzip:
+            let compressed = try Data(contentsOf: tarPath)
+            guard let decompressed = compressed.gunzip() else {
+                throw Error.invalidTarball(reason: "failed to decompress gzip layer")
+            }
+            let digest = compressed.sha256Hex()
+            let destination = blobsDir.appendingPathComponent(digest)
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                try compressed.write(to: destination)
+            }
+            return ImportedLayerBlob(
+                digest: digest, size: compressed.count, diffID: decompressed.sha256Hex(),
+                mediaType: "application/vnd.oci.image.layer.v1.tar+gzip")
+
+        case .zstd:
+            let original = try Data(contentsOf: tarPath)
+            let decompressedPath = try ArchiveReader.decompressZstd(tarPath)
+            defer { ArchiveReader.cleanUpDecompressedZstd(decompressedPath) }
+            let (diffID, _) = try sha256OfFile(at: decompressedPath)
+            let digest = original.sha256Hex()
+            let destination = blobsDir.appendingPathComponent(digest)
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                try original.write(to: destination)
+            }
+            return ImportedLayerBlob(
+                digest: digest, size: original.count, diffID: diffID,
+                mediaType: "application/vnd.oci.image.layer.v1.tar+zstd")
+
+        case .plainOrUnknown:
+            return try gzipCompressAndStore(plainTarData: try Data(contentsOf: tarPath), into: blobsDir)
+
+        case .reserializeRequired:
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+            let plainPath = tempDir.appendingPathComponent("layer.tar")
+            try reserializeToPlainTar(from: tarPath, to: plainPath)
+            return try gzipCompressAndStore(plainTarData: try Data(contentsOf: plainPath), into: blobsDir)
+
+        case .foreignFormat(let format):
+            throw Error.invalidTarball(reason: "\(format) is not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
+        }
+    }
+
+    /// moby's `docker import` never stores a plain uncompressed layer — an
+    /// uncompressed or bzip2/xz input is always gzip-compressed before storage
+    /// (daemon/containerd/image_import.go's `saveArchive`). diff_id is the
+    /// pre-compression hash; the stored blob's digest is the compressed hash.
+    private static func gzipCompressAndStore(plainTarData: Data, into blobsDir: URL) throws -> ImportedLayerBlob {
+        guard let compressed = plainTarData.gzip() else {
+            throw Error.invalidTarball(reason: "failed to gzip-compress layer")
+        }
+        let digest = compressed.sha256Hex()
+        let destination = blobsDir.appendingPathComponent(digest)
+        if !FileManager.default.fileExists(atPath: destination.path) {
+            try compressed.write(to: destination)
+        }
+        return ImportedLayerBlob(
+            digest: digest, size: compressed.count, diffID: plainTarData.sha256Hex(),
+            mediaType: "application/vnd.oci.image.layer.v1.tar+gzip")
     }
 
     /// Hashes a blob in fixed-size chunks so a multi-GB layer never has to be held

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -15,6 +15,17 @@ enum ContainerImageUtility {
     /// can't expand past a reasonable ceiling before being rejected.
     private static let maxExpandedLayerSize = 8 * 1024 * 1024 * 1024
 
+    /// Tar pads every entry to a 512-byte boundary (a header block plus a
+    /// content block rounded up), so counting only the bytes `entryReader.read`
+    /// returns undercounts the real decompressed size — an archive of millions
+    /// of empty files would count as ~0 bytes despite the header-parsing and
+    /// (for `reserializeToPlainTar`) header-writing cost being real.
+    private static let tarBlockSize = 512
+
+    private static func tarBlockPadding(forContentSize contentSize: Int) -> Int {
+        (tarBlockSize - contentSize % tarBlockSize) % tarBlockSize
+    }
+
     static func convertDockerTarToOCI(
         dockerFormatPath: URL,
         ociLayoutPath: URL,
@@ -337,22 +348,31 @@ enum ContainerImageUtility {
         let reader = try ArchiveReader(file: source)
         let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: destination)
         var totalDecompressedBytes = 0
+        func enforceCap() throws {
+            guard totalDecompressedBytes <= maxExpandedLayerSize else {
+                throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
+            }
+        }
+        var buffer = [UInt8](repeating: 0, count: 1 << 20)
         for (entry, entryReader) in reader.makeStreamingIterator() {
+            totalDecompressedBytes += tarBlockSize
+            try enforceCap()
             let transaction = writer.makeTransactionWriter()
             try transaction.writeHeader(entry: entry)
-            var buffer = [UInt8](repeating: 0, count: 1 << 20)
+            var entryContentBytes = 0
             while true {
                 let read = buffer.withUnsafeMutableBufferPointer { entryReader.read($0.baseAddress!, maxLength: $0.count) }
                 guard read > 0 else {
                     if read < 0 { throw Error.invalidTarball(reason: "failed to read archive entry while repackaging") }
                     break
                 }
+                entryContentBytes += read
                 totalDecompressedBytes += read
-                guard totalDecompressedBytes <= maxExpandedLayerSize else {
-                    throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
-                }
+                try enforceCap()
                 try buffer.withUnsafeBytes { try transaction.writeChunk(data: UnsafeRawBufferPointer(rebasing: $0.prefix(read))) }
             }
+            totalDecompressedBytes += tarBlockPadding(forContentSize: entryContentBytes)
+            try enforceCap()
             try transaction.finish()
         }
         try writer.finishEncoding()
@@ -377,8 +397,16 @@ enum ContainerImageUtility {
         }
         do {
             var totalDecompressedBytes = 0
+            func enforceCap() throws {
+                guard totalDecompressedBytes <= maxExpandedLayerSize else {
+                    throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
+                }
+            }
+            var buffer = [UInt8](repeating: 0, count: 1 << 16)
             for (_, entryReader) in reader.makeStreamingIterator() {
-                var buffer = [UInt8](repeating: 0, count: 1 << 16)
+                totalDecompressedBytes += tarBlockSize
+                try enforceCap()
+                var entryContentBytes = 0
                 while true {
                     let read = buffer.withUnsafeMutableBufferPointer { entryReader.read($0.baseAddress!, maxLength: $0.count) }
                     guard read > 0 else {
@@ -387,11 +415,12 @@ enum ContainerImageUtility {
                         }
                         break
                     }
+                    entryContentBytes += read
                     totalDecompressedBytes += read
-                    guard totalDecompressedBytes <= maxExpandedLayerSize else {
-                        throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
-                    }
+                    try enforceCap()
                 }
+                totalDecompressedBytes += tarBlockPadding(forContentSize: entryContentBytes)
+                try enforceCap()
             }
         } catch let error as Error {
             throw error

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -1,7 +1,6 @@
 import ContainerizationArchive
 import ContainerizationOCI
 import CryptoKit
-import DataCompression
 import Foundation
 import Logging
 
@@ -407,7 +406,7 @@ enum ContainerImageUtility {
             // content in memory, unlike `DataCompression.gunzip()`, so a
             // small, highly-compressible malicious layer can't exhaust memory
             // before `maxExpandedLayerSize` catches it mid-stream.
-            let (digest, size) = try sha256OfFile(at: tarPath)
+            let (digest, size) = try FileHashing.sha256OfFile(at: tarPath)
             let diffID: String
             do {
                 diffID = try GzipStreamDecoder.sha256OfDecompressedContent(at: tarPath, cap: maxExpandedLayerSize)
@@ -428,10 +427,10 @@ enum ContainerImageUtility {
             // Unlike gzip, zstd needs no in-memory pass at all: both the stored
             // blob's digest and the decompressed diff_id are computed by
             // streaming files in chunks, and storage is a plain file copy.
-            let (digest, size) = try sha256OfFile(at: tarPath)
+            let (digest, size) = try FileHashing.sha256OfFile(at: tarPath)
             let decompressedPath = try ArchiveReader.decompressZstd(tarPath)
             defer { ArchiveReader.cleanUpDecompressedZstd(decompressedPath) }
-            let (diffID, _) = try sha256OfFile(at: decompressedPath)
+            let (diffID, _) = try FileHashing.sha256OfFile(at: decompressedPath)
             let destination = blobsDir.appendingPathComponent(digest)
             if !FileManager.default.fileExists(atPath: destination.path) {
                 try FileManager.default.copyItem(at: tarPath, to: destination)
@@ -441,7 +440,7 @@ enum ContainerImageUtility {
                 mediaType: "application/vnd.oci.image.layer.v1.tar+zstd")
 
         case .plainOrUnknown:
-            return try gzipCompressAndStore(plainTarData: try Data(contentsOf: tarPath), into: blobsDir)
+            return try gzipCompressAndStore(plainTarPath: tarPath, into: blobsDir)
 
         case .bzip2, .xz:
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -449,7 +448,7 @@ enum ContainerImageUtility {
             defer { try? FileManager.default.removeItem(at: tempDir) }
             let plainPath = tempDir.appendingPathComponent("layer.tar")
             try reserializeToPlainTar(from: tarPath, to: plainPath)
-            return try gzipCompressAndStore(plainTarData: try Data(contentsOf: plainPath), into: blobsDir)
+            return try gzipCompressAndStore(plainTarPath: plainPath, into: blobsDir)
 
         case .foreignFormat(let format):
             throw Error.invalidTarball(reason: "\(format) is not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
@@ -460,33 +459,19 @@ enum ContainerImageUtility {
     /// uncompressed or bzip2/xz input is always gzip-compressed before storage
     /// (daemon/containerd/image_import.go's `saveArchive`). diff_id is the
     /// pre-compression hash; the stored blob's digest is the compressed hash.
-    private static func gzipCompressAndStore(plainTarData: Data, into blobsDir: URL) throws -> ImportedLayerBlob {
-        guard let compressed = plainTarData.gzip() else {
+    private static func gzipCompressAndStore(plainTarPath: URL, into blobsDir: URL) throws -> ImportedLayerBlob {
+        let tempDestination = blobsDir.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDestination) }
+        let result: GzipStreamEncoder.Result
+        do {
+            result = try GzipStreamEncoder.compressFile(at: plainTarPath, to: tempDestination)
+        } catch {
             throw Error.invalidTarball(reason: "failed to gzip-compress layer")
         }
-        let digest = compressed.sha256Hex()
-        let destination = blobsDir.appendingPathComponent(digest)
-        if !FileManager.default.fileExists(atPath: destination.path) {
-            try compressed.write(to: destination)
-        }
+        try moveBlob(from: tempDestination, toDigest: result.compressedDigest, in: blobsDir)
         return ImportedLayerBlob(
-            digest: digest, size: compressed.count, diffID: plainTarData.sha256Hex(),
+            digest: result.compressedDigest, size: result.compressedSize, diffID: result.uncompressedDigest,
             mediaType: "application/vnd.oci.image.layer.v1.tar+gzip")
-    }
-
-    /// Hashes a blob in fixed-size chunks so a multi-GB layer never has to be held
-    /// in memory at once. Returns the digest and byte count for its descriptor.
-    private static func sha256OfFile(at url: URL) throws -> (digest: String, size: Int) {
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        var hasher = SHA256()
-        var size = 0
-        while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
-            hasher.update(data: chunk)
-            size += chunk.count
-        }
-        let digest = hasher.finalize().compactMap { String(format: "%02x", $0) }.joined()
-        return (digest, size)
     }
 
     /// Copies a docker-archive blob into the content-addressed store (skipping if already
@@ -499,7 +484,7 @@ enum ContainerImageUtility {
         if !FileManager.default.fileExists(atPath: destination.path) {
             try FileManager.default.copyItem(at: source, to: destination)
         }
-        let (realDigest, size) = try sha256OfFile(at: destination)
+        let (realDigest, size) = try FileHashing.sha256OfFile(at: destination)
         guard realDigest != claimedDigest else { return (claimedDigest, size) }
         logger.warning("Blob digest mismatch: expected \(claimedDigest), got \(realDigest)")
         try moveBlob(from: destination, toDigest: realDigest, in: blobsDir)

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -121,13 +121,18 @@ enum ContainerImageUtility {
     /// digest/blob/manifest/index construction, but for a synthesized image
     /// rather than one converted from an existing docker-archive.
     ///
-    /// A gzip-compressed body (detected by magic bytes) is stored as-is with the
-    /// gzip layer media type; its diff_id is the digest of the decompressed
-    /// content, matching moby's passthrough-if-already-compressed behavior.
-    /// Anything else is treated as an uncompressed tar: the stored blob's own
-    /// digest doubles as its diff_id. bzip2/xz bodies are not decompressed —
-    /// they fall into the uncompressed path, so their diff_id would not match
-    /// the true uncompressed content (see PR description: deferred).
+    /// A gzip/zstd-compressed body (detected by magic bytes) is stored as-is
+    /// with the matching layer media type; its diff_id is the digest of the
+    /// decompressed content, matching moby's passthrough-if-already-compressed
+    /// behavior. A plain tar is gzip-compressed before storage (moby never
+    /// stores an uncompressed layer). bzip2/xz bodies are reserialized to a
+    /// plain tar via `reserializeToPlainTar` and then gzip-compressed the same
+    /// way — content-faithful (round-trip verified against symlinks,
+    /// hardlinks, xattrs, and non-default permission bits), but the diff_id is
+    /// computed from the reserialized pax tar rather than moby's raw
+    /// decompressed byte stream, so it will not byte-match a real dockerd's
+    /// diff_id for the same bzip2/xz input even though the layer content is
+    /// identical.
     ///
     /// Returns the manifest digest (without the `sha256:` prefix).
     static func buildSingleLayerOCILayout(
@@ -228,8 +233,9 @@ enum ContainerImageUtility {
     private enum LayerSource: Equatable {
         case gzip
         case zstd
+        case bzip2
+        case xz
         case plainOrUnknown
-        case reserializeRequired
         case foreignFormat(String)
     }
 
@@ -237,8 +243,8 @@ enum ContainerImageUtility {
         let magic = try readMagic(at: tarPath, length: 8)
         if magic.starts(with: [0x1f, 0x8b]) { return .gzip }
         if magic.starts(with: [0x28, 0xb5, 0x2f, 0xfd]) { return .zstd }
-        if magic.starts(with: [0x42, 0x5a, 0x68]) { return .reserializeRequired }  // bzip2
-        if magic.starts(with: [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]) { return .reserializeRequired }  // xz
+        if magic.starts(with: [0x42, 0x5a, 0x68]) { return .bzip2 }
+        if magic.starts(with: [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]) { return .xz }
         if magic.starts(with: [0x50, 0x4b, 0x03, 0x04]) { return .foreignFormat("zip") }
         if magic.starts(with: [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]) { return .foreignFormat("7z") }
         if magic.starts(with: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07]) { return .foreignFormat("rar") }
@@ -266,8 +272,56 @@ enum ContainerImageUtility {
     }
 
     private static func rejectForeignFormat(at tarPath: URL) throws {
-        guard case .foreignFormat(let format) = try classifyLayerSource(at: tarPath) else { return }
-        throw Error.invalidTarball(reason: "\(format) is not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
+        let source = try classifyLayerSource(at: tarPath)
+        if case .foreignFormat(let format) = source {
+            throw Error.invalidTarball(reason: "\(format) is not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
+        }
+        // The magic-byte blacklist above only catches formats libarchive itself
+        // recognizes as non-tar containers; it can't cover formats moby also
+        // wouldn't unwrap (mtree, xar, lha, shar, ...) or any other content that
+        // merely fails to look like tar. Positively confirm the (decompressed)
+        // bytes parse as one of the tar sub-formats libarchive knows about
+        // before accepting it — verified against real GNU/PAX/ustar tars
+        // (including a genuine `docker export` tarball) and against zip/cpio/ar
+        // bodies to confirm this neither rejects a real tar nor accepts a
+        // foreign one.
+        let filter: Filter
+        switch source {
+        case .gzip: filter = .gzip
+        case .zstd: filter = .zstd
+        case .bzip2: filter = .bzip2
+        case .xz: filter = .xz
+        case .plainOrUnknown: filter = .none
+        case .foreignFormat: return  // unreachable: handled above
+        }
+        guard isRecognizedTarFamily(at: tarPath, filter: filter) else {
+            throw Error.invalidTarball(reason: "not a supported docker import source; only a tar, optionally gzip/bzip2/xz/zstd-compressed, is supported")
+        }
+    }
+
+    /// Tries every tar sub-format libarchive supports rather than pinning one:
+    /// `archive_read_set_format` doesn't restrict which tar variant is actually
+    /// parsed (a real GNU or PAX tar reads successfully under any of the four
+    /// constants below), so the loop exists only to force header validation —
+    /// something the auto-detecting reader used elsewhere never surfaces as an
+    /// error even when it's parsing raw garbage. A real tar entry always has a
+    /// non-empty path; garbage forced through the tar parser produces an entry
+    /// with no path instead. A tar with zero entries (`tar cf x -T /dev/null`,
+    /// the standard way to build a "scratch" image, and something real `docker
+    /// import` accepts) cleanly hits EOF with no entry at all on every format —
+    /// that has to be accepted too, so only a path-less entry counts as proof
+    /// of a foreign format; a clean EOF is neutral, not a rejection.
+    private static func isRecognizedTarFamily(at tarPath: URL, filter: Filter) -> Bool {
+        var attempted = false
+        for format: ContainerizationArchive.Format in [.ustar, .gnutar, .pax, .paxRestricted] {
+            guard let reader = try? ArchiveReader(format: format, filter: filter, file: tarPath) else { continue }
+            attempted = true
+            var iterator = reader.makeStreamingIterator()
+            guard let (entry, _) = iterator.next() else { continue }
+            guard let path = entry.path, !path.isEmpty else { return false }
+            return true
+        }
+        return attempted
     }
 
     /// Repackages an archive whose compression `ArchiveReader` can decompress
@@ -341,6 +395,13 @@ enum ContainerImageUtility {
     private static func writeImportedLayerBlob(tarPath: URL, into blobsDir: URL) throws -> ImportedLayerBlob {
         switch try classifyLayerSource(at: tarPath) {
         case .gzip:
+            // Stored as-is (unchanged from the request body): copied straight
+            // from `tarPath` rather than re-written from an in-memory buffer.
+            // The compressed bytes still need one full-buffer pass — decoding
+            // them (for the diff_id) requires it, and `DataCompression`, the
+            // only gzip codec available here, exposes no streaming API — so
+            // the digest is hashed from that already-loaded buffer rather than
+            // re-reading the file a second time.
             let compressed = try Data(contentsOf: tarPath)
             guard let decompressed = compressed.gunzip() else {
                 throw Error.invalidTarball(reason: "failed to decompress gzip layer")
@@ -348,30 +409,32 @@ enum ContainerImageUtility {
             let digest = compressed.sha256Hex()
             let destination = blobsDir.appendingPathComponent(digest)
             if !FileManager.default.fileExists(atPath: destination.path) {
-                try compressed.write(to: destination)
+                try FileManager.default.copyItem(at: tarPath, to: destination)
             }
             return ImportedLayerBlob(
                 digest: digest, size: compressed.count, diffID: decompressed.sha256Hex(),
                 mediaType: "application/vnd.oci.image.layer.v1.tar+gzip")
 
         case .zstd:
-            let original = try Data(contentsOf: tarPath)
+            // Unlike gzip, zstd needs no in-memory pass at all: both the stored
+            // blob's digest and the decompressed diff_id are computed by
+            // streaming files in chunks, and storage is a plain file copy.
+            let (digest, size) = try sha256OfFile(at: tarPath)
             let decompressedPath = try ArchiveReader.decompressZstd(tarPath)
             defer { ArchiveReader.cleanUpDecompressedZstd(decompressedPath) }
             let (diffID, _) = try sha256OfFile(at: decompressedPath)
-            let digest = original.sha256Hex()
             let destination = blobsDir.appendingPathComponent(digest)
             if !FileManager.default.fileExists(atPath: destination.path) {
-                try original.write(to: destination)
+                try FileManager.default.copyItem(at: tarPath, to: destination)
             }
             return ImportedLayerBlob(
-                digest: digest, size: original.count, diffID: diffID,
+                digest: digest, size: size, diffID: diffID,
                 mediaType: "application/vnd.oci.image.layer.v1.tar+zstd")
 
         case .plainOrUnknown:
             return try gzipCompressAndStore(plainTarData: try Data(contentsOf: tarPath), into: blobsDir)
 
-        case .reserializeRequired:
+        case .bzip2, .xz:
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Sources/socktainer/Utilities/ContainerImageUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerImageUtility.swift
@@ -146,10 +146,11 @@ enum ContainerImageUtility {
         config: SynthesizedImageConfig,
         message: String?,
         reference: String?,
-        logger: Logger
+        logger: Logger,
+        maxExpandedLayerSize: Int = ContainerImageUtility.maxExpandedLayerSize
     ) throws -> String {
         try rejectForeignFormat(at: tarPath)
-        try validateTar(at: tarPath)
+        try validateTar(at: tarPath, maxExpandedLayerSize: maxExpandedLayerSize)
 
         let blobsDir = ociLayoutPath.appendingPathComponent("blobs/sha256")
         try FileManager.default.createDirectory(at: blobsDir, withIntermediateDirectories: true)
@@ -157,7 +158,7 @@ enum ContainerImageUtility {
         let ociLayout = "{\"imageLayoutVersion\": \"1.0.0\"}"
         try ociLayout.write(to: ociLayoutPath.appendingPathComponent("oci-layout"), atomically: true, encoding: .utf8)
 
-        let layer = try writeImportedLayerBlob(tarPath: tarPath, into: blobsDir)
+        let layer = try writeImportedLayerBlob(tarPath: tarPath, into: blobsDir, maxExpandedLayerSize: maxExpandedLayerSize)
 
         let createdAt = ISO8601DateFormatter().string(from: Date())
         var imageConfigDict: [String: Any] = [
@@ -332,9 +333,10 @@ enum ContainerImageUtility {
     /// but `DataCompression` cannot (bzip2/xz/zstd) into a canonical
     /// uncompressed tar, so the diff_id and stored blob reflect the real
     /// content instead of the still-compressed bytes.
-    private static func reserializeToPlainTar(from source: URL, to destination: URL) throws {
+    private static func reserializeToPlainTar(from source: URL, to destination: URL, maxExpandedLayerSize: Int) throws {
         let reader = try ArchiveReader(file: source)
         let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: destination)
+        var totalDecompressedBytes = 0
         for (entry, entryReader) in reader.makeStreamingIterator() {
             let transaction = writer.makeTransactionWriter()
             try transaction.writeHeader(entry: entry)
@@ -344,6 +346,10 @@ enum ContainerImageUtility {
                 guard read > 0 else {
                     if read < 0 { throw Error.invalidTarball(reason: "failed to read archive entry while repackaging") }
                     break
+                }
+                totalDecompressedBytes += read
+                guard totalDecompressedBytes <= maxExpandedLayerSize else {
+                    throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
                 }
                 try buffer.withUnsafeBytes { try transaction.writeChunk(data: UnsafeRawBufferPointer(rebasing: $0.prefix(read))) }
             }
@@ -357,7 +363,7 @@ enum ContainerImageUtility {
     /// own) and confirms the remainder actually parses as an archive, so
     /// `docker import` of a non-tar or empty file fails cleanly instead of
     /// silently registering an unusable image.
-    private static func validateTar(at tarPath: URL) throws {
+    private static func validateTar(at tarPath: URL, maxExpandedLayerSize: Int) throws {
         let attributes = try? FileManager.default.attributesOfItem(atPath: tarPath.path)
         guard let size = attributes?[.size] as? UInt64, size > 0 else {
             throw Error.invalidTarball(reason: "empty request body")
@@ -370,6 +376,7 @@ enum ContainerImageUtility {
             throw Error.invalidTarball(reason: "not a valid tar archive: \(error.localizedDescription)")
         }
         do {
+            var totalDecompressedBytes = 0
             for (_, entryReader) in reader.makeStreamingIterator() {
                 var buffer = [UInt8](repeating: 0, count: 1 << 16)
                 while true {
@@ -379,6 +386,10 @@ enum ContainerImageUtility {
                             throw Error.invalidTarball(reason: "not a valid tar archive")
                         }
                         break
+                    }
+                    totalDecompressedBytes += read
+                    guard totalDecompressedBytes <= maxExpandedLayerSize else {
+                        throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
                     }
                 }
             }
@@ -396,7 +407,7 @@ enum ContainerImageUtility {
         let mediaType: String
     }
 
-    private static func writeImportedLayerBlob(tarPath: URL, into blobsDir: URL) throws -> ImportedLayerBlob {
+    private static func writeImportedLayerBlob(tarPath: URL, into blobsDir: URL, maxExpandedLayerSize: Int) throws -> ImportedLayerBlob {
         switch try classifyLayerSource(at: tarPath) {
         case .gzip:
             // Stored as-is (unchanged from the request body): copied straight
@@ -430,6 +441,10 @@ enum ContainerImageUtility {
             let (digest, size) = try FileHashing.sha256OfFile(at: tarPath)
             let decompressedPath = try ArchiveReader.decompressZstd(tarPath)
             defer { ArchiveReader.cleanUpDecompressedZstd(decompressedPath) }
+            let decompressedAttributes = try? FileManager.default.attributesOfItem(atPath: decompressedPath.path)
+            guard let decompressedSize = decompressedAttributes?[.size] as? UInt64, decompressedSize <= UInt64(maxExpandedLayerSize) else {
+                throw Error.invalidTarball(reason: "decompressed layer exceeds the \(maxExpandedLayerSize)-byte limit")
+            }
             let (diffID, _) = try FileHashing.sha256OfFile(at: decompressedPath)
             let destination = blobsDir.appendingPathComponent(digest)
             if !FileManager.default.fileExists(atPath: destination.path) {
@@ -447,7 +462,7 @@ enum ContainerImageUtility {
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             defer { try? FileManager.default.removeItem(at: tempDir) }
             let plainPath = tempDir.appendingPathComponent("layer.tar")
-            try reserializeToPlainTar(from: tarPath, to: plainPath)
+            try reserializeToPlainTar(from: tarPath, to: plainPath, maxExpandedLayerSize: maxExpandedLayerSize)
             return try gzipCompressAndStore(plainTarPath: plainPath, into: blobsDir)
 
         case .foreignFormat(let format):

--- a/Sources/socktainer/Utilities/DockerfileChanges.swift
+++ b/Sources/socktainer/Utilities/DockerfileChanges.swift
@@ -114,37 +114,48 @@ enum DockerfileChangeApplier {
 
     /// `ENV KEY=VALUE ...` (one or more pairs) or the legacy `ENV KEY VALUE` form.
     private static func applyEnv(_ rest: String, to config: inout SynthesizedImageConfig) throws {
-        let tokens = splitRespectingQuotes(rest)
-        guard !tokens.isEmpty else {
-            throw DockerfileChangeError.invalidValue(instruction: "ENV", value: rest)
-        }
-        if tokens.count == 2, !tokens[0].contains("=") {
-            config.setEnv(key: tokens[0], value: tokens[1])
-            return
-        }
-        for token in tokens {
-            guard let equalsIndex = token.firstIndex(of: "=") else {
-                throw DockerfileChangeError.invalidValue(instruction: "ENV", value: token)
-            }
-            let key = String(token[..<equalsIndex])
-            let value = String(token[token.index(after: equalsIndex)...])
+        try applyKeyValuePairs(rest, instruction: "ENV") { key, value in
             config.setEnv(key: key, value: value)
         }
     }
 
     /// `LABEL KEY=VALUE ...`, quoting allowed for values containing spaces.
     private static func applyLabels(_ rest: String, to config: inout SynthesizedImageConfig) throws {
-        let tokens = splitRespectingQuotes(rest)
-        guard !tokens.isEmpty else {
-            throw DockerfileChangeError.invalidValue(instruction: "LABEL", value: rest)
+        try applyKeyValuePairs(rest, instruction: "LABEL") { key, value in
+            config.labels[key] = value
         }
-        for token in tokens {
-            guard let equalsIndex = token.firstIndex(of: "=") else {
-                throw DockerfileChangeError.invalidValue(instruction: "LABEL", value: token)
+    }
+
+    /// Shared `ENV`/`LABEL` grammar: one or more `KEY=VALUE` pairs (quoting and
+    /// backslash-escaping honored per pair), or the legacy `KEY VALUE` form —
+    /// used only when the first word has no `=`, in which case the ENTIRE
+    /// remainder of the line (internal whitespace preserved, not re-split into
+    /// further words) becomes the single value. Verified against real
+    /// `docker build` (BuildKit) output: `ENV FOO bar=1 baz=2` sets one
+    /// variable `FOO="bar=1 baz=2"`, and `ENV NAME   spaced   out` preserves
+    /// the internal run of spaces — both are legacy form, decided solely by
+    /// whether the first word contains `=`.
+    private static func applyKeyValuePairs(_ rest: String, instruction: String, set: (String, String) -> Void) throws {
+        let (firstRaw, remainder) = splitFirstToken(Substring(rest))
+        let firstKey = dequote(firstRaw)
+        if !firstKey.contains("="), let remainder {
+            set(firstKey, dequote(remainder))
+            return
+        }
+        guard firstKey.contains("=") else {
+            throw DockerfileChangeError.invalidValue(instruction: instruction, value: rest)
+        }
+        for token in tokenize(rest) {
+            // A blank name is only rejected in this `KEY=VALUE` form — real
+            // docker build accepts a blank name from the legacy branch above
+            // (`ENV "" value` sets "" to "value"); the two forms are not
+            // symmetric, verified against real `docker build` output.
+            guard let equalsIndex = token.firstIndex(of: "="), equalsIndex > token.startIndex else {
+                throw DockerfileChangeError.invalidValue(instruction: instruction, value: token)
             }
             let key = String(token[..<equalsIndex])
             let value = String(token[token.index(after: equalsIndex)...])
-            config.labels[key] = value
+            set(key, value)
         }
     }
 
@@ -165,35 +176,87 @@ enum DockerfileChangeApplier {
             }
             return array
         }
-        return splitRespectingQuotes(rest)
+        return tokenize(rest)
     }
 
-    /// Splits on whitespace, treating a `"..."`/`'...'` span as one token and
-    /// dropping its quotes (enough for `LABEL desc="two words"`-style values;
-    /// no backslash-escape support).
-    private static func splitRespectingQuotes(_ value: String) -> [String] {
+    /// Splits `value` on unquoted, unescaped whitespace into raw (not yet
+    /// dequoted) tokens.
+    private static func tokenize(_ value: String) -> [String] {
         var tokens: [String] = []
-        var current = ""
-        var quoteChar: Character?
+        var remainder: Substring? = Substring(value)
+        while let current = remainder, !current.isEmpty {
+            let (rawToken, rest) = splitFirstToken(current)
+            if !rawToken.isEmpty { tokens.append(dequote(rawToken)) }
+            remainder = rest
+        }
+        return tokens
+    }
+
+    /// Splits off the first whitespace-delimited raw token, honoring
+    /// `"..."`/`'...'` quoting and backslash-escaping so an escaped or quoted
+    /// space doesn't end the token early. Returns the raw (not yet dequoted)
+    /// token and everything after the whitespace that follows it — `nil` if
+    /// nothing follows.
+    private static func splitFirstToken(_ value: Substring) -> (first: Substring, remainder: Substring?) {
+        var start = value.startIndex
+        while start < value.endIndex, value[start] == " " || value[start] == "\t" {
+            start = value.index(after: start)
+        }
+        var index = start
+        var escaped = false
+        var quote: Character?
+        while index < value.endIndex {
+            let char = value[index]
+            if escaped {
+                escaped = false
+            } else if char == "\\" {
+                escaped = true
+            } else if let openQuote = quote {
+                if char == openQuote { quote = nil }
+            } else if char == "\"" || char == "'" {
+                quote = char
+            } else if char == " " || char == "\t" {
+                break
+            }
+            index = value.index(after: index)
+        }
+        let first = value[start..<index]
+        guard index < value.endIndex else { return (first, nil) }
+        var remainderStart = index
+        while remainderStart < value.endIndex, value[remainderStart] == " " || value[remainderStart] == "\t" {
+            remainderStart = value.index(after: remainderStart)
+        }
+        return (first, remainderStart < value.endIndex ? value[remainderStart...] : "")
+    }
+
+    /// Removes backslash-escapes (`\X` -> literal `X`) and strips a matching
+    /// pair of enclosing `"`/`'` quote characters, honoring escapes even
+    /// inside a quoted span (`"a\"b"` -> `a"b"`). Whitespace outside of an
+    /// escape or quote is preserved literally — this is applied to the WHOLE
+    /// remainder for the legacy `KEY VALUE` form, not per-word, which is why
+    /// internal spacing in the value survives untouched.
+    private static func dequote<S: StringProtocol>(_ value: S) -> String {
+        var result = ""
+        var escaped = false
+        var quote: Character?
         for char in value {
-            if let openQuote = quoteChar {
+            if escaped {
+                result.append(char)
+                escaped = false
+            } else if char == "\\" {
+                escaped = true
+            } else if let openQuote = quote {
                 if char == openQuote {
-                    quoteChar = nil
+                    quote = nil
                 } else {
-                    current.append(char)
+                    result.append(char)
                 }
             } else if char == "\"" || char == "'" {
-                quoteChar = char
-            } else if char == " " || char == "\t" {
-                if !current.isEmpty {
-                    tokens.append(current)
-                    current = ""
-                }
+                quote = char
             } else {
-                current.append(char)
+                result.append(char)
             }
         }
-        if !current.isEmpty { tokens.append(current) }
-        return tokens
+        return result
     }
 }

--- a/Sources/socktainer/Utilities/DockerfileChanges.swift
+++ b/Sources/socktainer/Utilities/DockerfileChanges.swift
@@ -137,15 +137,15 @@ enum DockerfileChangeApplier {
     /// whether the first word contains `=`.
     private static func applyKeyValuePairs(_ rest: String, instruction: String, set: (String, String) -> Void) throws {
         let (firstRaw, remainder) = splitFirstToken(Substring(rest))
-        let firstKey = dequote(firstRaw)
+        let firstKey = try dequote(firstRaw, instruction: instruction)
         if !firstKey.contains("="), let remainder {
-            set(firstKey, dequote(remainder))
+            set(firstKey, try dequote(remainder, instruction: instruction))
             return
         }
         guard firstKey.contains("=") else {
             throw DockerfileChangeError.invalidValue(instruction: instruction, value: rest)
         }
-        for token in tokenize(rest) {
+        for token in try tokenize(rest, instruction: instruction) {
             // A blank name is only rejected in this `KEY=VALUE` form — real
             // docker build accepts a blank name from the legacy branch above
             // (`ENV "" value` sets "" to "value"); the two forms are not
@@ -176,17 +176,16 @@ enum DockerfileChangeApplier {
             }
             return array
         }
-        return tokenize(rest)
+        return try tokenize(rest, instruction: instruction)
     }
 
-    /// Splits `value` on unquoted, unescaped whitespace into raw (not yet
-    /// dequoted) tokens.
-    private static func tokenize(_ value: String) -> [String] {
+    /// Splits `value` on unquoted, unescaped whitespace into dequoted tokens.
+    private static func tokenize(_ value: String, instruction: String) throws -> [String] {
         var tokens: [String] = []
         var remainder: Substring? = Substring(value)
         while let current = remainder, !current.isEmpty {
             let (rawToken, rest) = splitFirstToken(current)
-            if !rawToken.isEmpty { tokens.append(dequote(rawToken)) }
+            if !rawToken.isEmpty { tokens.append(try dequote(rawToken, instruction: instruction)) }
             remainder = rest
         }
         return tokens
@@ -235,7 +234,14 @@ enum DockerfileChangeApplier {
     /// escape or quote is preserved literally — this is applied to the WHOLE
     /// remainder for the legacy `KEY VALUE` form, not per-word, which is why
     /// internal spacing in the value survives untouched.
-    private static func dequote<S: StringProtocol>(_ value: S) -> String {
+    ///
+    /// A quote left open at the end (`FOO="bar`) is rejected — real `docker
+    /// build` does the same ("unexpected end of statement ... looking for
+    /// matching double-quote"). A trailing, unconsumed backslash is NOT
+    /// rejected: real `docker build` silently drops it (`FOO=bar\` -> `bar`),
+    /// since a Dockerfile's line-continuation backslash has nothing left to
+    /// continue onto at the end of a single `--change` entry.
+    private static func dequote<S: StringProtocol>(_ value: S, instruction: String) throws -> String {
         var result = ""
         var escaped = false
         var quote: Character?
@@ -256,6 +262,9 @@ enum DockerfileChangeApplier {
             } else {
                 result.append(char)
             }
+        }
+        guard quote == nil else {
+            throw DockerfileChangeError.invalidValue(instruction: instruction, value: String(value))
         }
         return result
     }

--- a/Sources/socktainer/Utilities/DockerfileChanges.swift
+++ b/Sources/socktainer/Utilities/DockerfileChanges.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// Errors raised while applying `docker import --change` (Dockerfile-instruction-like)
+/// directives to a synthesized image config.
+enum DockerfileChangeError: Error, LocalizedError {
+    case invalidInstruction(String)
+    case invalidValue(instruction: String, value: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidInstruction(let instruction):
+            return "\(instruction) is not a supported --change instruction"
+        case .invalidValue(let instruction, let value):
+            return "invalid value for \(instruction): \(value)"
+        }
+    }
+}
+
+/// Accumulates the subset of `container_config`/OCI image config fields that
+/// `docker import --change` can set. Serialized by `ContainerImageUtility` as the
+/// image config's `config` object, matching Docker's PascalCase field names —
+/// including `ExposedPorts`/`Volumes`, which `ContainerizationOCI.ImageConfig`
+/// does not model but which `ImageStore.load` decodes past without error (extra
+/// JSON keys are simply ignored), so they still round-trip through the store.
+struct SynthesizedImageConfig {
+    var user: String?
+    var exposedPorts: Set<String> = []
+    var env: [String] = []
+    var entrypoint: [String]?
+    var cmd: [String]?
+    var volumes: Set<String> = []
+    var workingDir: String?
+    var labels: [String: String] = [:]
+
+    mutating func setEnv(key: String, value: String) {
+        let prefix = "\(key)="
+        if let index = env.firstIndex(where: { $0.hasPrefix(prefix) }) {
+            env[index] = "\(key)=\(value)"
+        } else {
+            env.append("\(key)=\(value)")
+        }
+    }
+
+    func toDict() -> [String: Any] {
+        var dict: [String: Any] = [:]
+        if let user, !user.isEmpty { dict["User"] = user }
+        if !exposedPorts.isEmpty { dict["ExposedPorts"] = emptyObjectMap(for: exposedPorts) }
+        if !env.isEmpty { dict["Env"] = env }
+        if let entrypoint { dict["Entrypoint"] = entrypoint }
+        if let cmd { dict["Cmd"] = cmd }
+        if !volumes.isEmpty { dict["Volumes"] = emptyObjectMap(for: volumes) }
+        if let workingDir, !workingDir.isEmpty { dict["WorkingDir"] = workingDir }
+        if !labels.isEmpty { dict["Labels"] = labels }
+        return dict
+    }
+
+    private func emptyObjectMap(for keys: Set<String>) -> [String: [String: String]] {
+        Dictionary(uniqueKeysWithValues: keys.map { ($0, [:]) })
+    }
+}
+
+/// Applies `docker import --change` directives (one Dockerfile instruction per
+/// entry) to a `SynthesizedImageConfig`. Supports the instructions the
+/// import route offers: CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, USER, VOLUME, WORKDIR.
+/// Anything else (ONBUILD, STOPSIGNAL, HEALTHCHECK, or a genuinely unknown
+/// instruction) is rejected rather than silently dropped.
+enum DockerfileChangeApplier {
+    static func apply(_ changes: [String], to config: inout SynthesizedImageConfig) throws {
+        for change in changes {
+            try applyOne(change, to: &config)
+        }
+    }
+
+    private static func applyOne(_ change: String, to config: inout SynthesizedImageConfig) throws {
+        let trimmed = change.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        guard let separatorIndex = trimmed.firstIndex(where: { $0 == " " || $0 == "\t" }) else {
+            throw DockerfileChangeError.invalidInstruction(trimmed)
+        }
+        let instruction = trimmed[..<separatorIndex].uppercased()
+        let rest = trimmed[trimmed.index(after: separatorIndex)...].trimmingCharacters(in: .whitespaces)
+        guard !rest.isEmpty else {
+            throw DockerfileChangeError.invalidValue(instruction: instruction, value: "")
+        }
+
+        switch instruction {
+        case "CMD": config.cmd = try parseExecOrShellForm(instruction: instruction, rest)
+        case "ENTRYPOINT": config.entrypoint = try parseExecOrShellForm(instruction: instruction, rest)
+        case "ENV": try applyEnv(rest, to: &config)
+        case "LABEL": try applyLabels(rest, to: &config)
+        case "USER": config.user = rest
+        case "WORKDIR": config.workingDir = rest
+        case "EXPOSE": config.exposedPorts.formUnion(parsePorts(rest))
+        case "VOLUME": config.volumes.formUnion(try parseVolumes(instruction: instruction, rest))
+        default:
+            throw DockerfileChangeError.invalidInstruction(instruction)
+        }
+    }
+
+    /// CMD/ENTRYPOINT accept either JSON exec form (`["a", "b"]`) or shell form,
+    /// which Docker wraps as `["/bin/sh", "-c", <rest>]`.
+    private static func parseExecOrShellForm(instruction: String, _ rest: String) throws -> [String] {
+        if rest.hasPrefix("[") {
+            guard let data = rest.data(using: .utf8),
+                let array = try? JSONDecoder().decode([String].self, from: data)
+            else {
+                throw DockerfileChangeError.invalidValue(instruction: instruction, value: rest)
+            }
+            return array
+        }
+        return ["/bin/sh", "-c", rest]
+    }
+
+    /// `ENV KEY=VALUE ...` (one or more pairs) or the legacy `ENV KEY VALUE` form.
+    private static func applyEnv(_ rest: String, to config: inout SynthesizedImageConfig) throws {
+        let tokens = splitRespectingQuotes(rest)
+        guard !tokens.isEmpty else {
+            throw DockerfileChangeError.invalidValue(instruction: "ENV", value: rest)
+        }
+        if tokens.count == 2, !tokens[0].contains("=") {
+            config.setEnv(key: tokens[0], value: tokens[1])
+            return
+        }
+        for token in tokens {
+            guard let equalsIndex = token.firstIndex(of: "=") else {
+                throw DockerfileChangeError.invalidValue(instruction: "ENV", value: token)
+            }
+            let key = String(token[..<equalsIndex])
+            let value = String(token[token.index(after: equalsIndex)...])
+            config.setEnv(key: key, value: value)
+        }
+    }
+
+    /// `LABEL KEY=VALUE ...`, quoting allowed for values containing spaces.
+    private static func applyLabels(_ rest: String, to config: inout SynthesizedImageConfig) throws {
+        let tokens = splitRespectingQuotes(rest)
+        guard !tokens.isEmpty else {
+            throw DockerfileChangeError.invalidValue(instruction: "LABEL", value: rest)
+        }
+        for token in tokens {
+            guard let equalsIndex = token.firstIndex(of: "=") else {
+                throw DockerfileChangeError.invalidValue(instruction: "LABEL", value: token)
+            }
+            let key = String(token[..<equalsIndex])
+            let value = String(token[token.index(after: equalsIndex)...])
+            config.labels[key] = value
+        }
+    }
+
+    /// `EXPOSE <port>[/<proto>] ...`, defaulting to `/tcp`.
+    private static func parsePorts(_ rest: String) -> [String] {
+        rest.split(whereSeparator: { $0 == " " || $0 == "\t" }).map { token in
+            token.contains("/") ? String(token) : "\(token)/tcp"
+        }
+    }
+
+    /// `VOLUME ["/data", ...]` (JSON form) or `VOLUME /data /data2` (shell form).
+    private static func parseVolumes(instruction: String, _ rest: String) throws -> [String] {
+        if rest.hasPrefix("[") {
+            guard let data = rest.data(using: .utf8),
+                let array = try? JSONDecoder().decode([String].self, from: data)
+            else {
+                throw DockerfileChangeError.invalidValue(instruction: instruction, value: rest)
+            }
+            return array
+        }
+        return splitRespectingQuotes(rest)
+    }
+
+    /// Splits on whitespace, treating a `"..."`/`'...'` span as one token and
+    /// dropping its quotes (enough for `LABEL desc="two words"`-style values;
+    /// no backslash-escape support).
+    private static func splitRespectingQuotes(_ value: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var quoteChar: Character?
+        for char in value {
+            if let openQuote = quoteChar {
+                if char == openQuote {
+                    quoteChar = nil
+                } else {
+                    current.append(char)
+                }
+            } else if char == "\"" || char == "'" {
+                quoteChar = char
+            } else if char == " " || char == "\t" {
+                if !current.isEmpty {
+                    tokens.append(current)
+                    current = ""
+                }
+            } else {
+                current.append(char)
+            }
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens
+    }
+}

--- a/Sources/socktainer/Utilities/FileHashing.swift
+++ b/Sources/socktainer/Utilities/FileHashing.swift
@@ -1,0 +1,24 @@
+import CryptoKit
+import Foundation
+
+enum FileHashing {
+    private static let chunkSize = 1 << 20
+
+    static func sha256OfFile(at url: URL) throws -> (digest: String, size: Int) {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        var size = 0
+        while let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty {
+            hasher.update(data: chunk)
+            size += chunk.count
+        }
+        return (hasher.finalize().hexString, size)
+    }
+}
+
+extension SHA256Digest {
+    var hexString: String {
+        compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/socktainer/Utilities/GzipStreamDecoder.swift
+++ b/Sources/socktainer/Utilities/GzipStreamDecoder.swift
@@ -10,6 +10,11 @@ import Foundation
 /// before anything could check its size. Both the compressed input and the
 /// decompressed output are read/produced in fixed-size chunks; exceeding
 /// `cap` aborts mid-stream instead of after the fact.
+///
+/// Concatenated gzip members (`cat a.gz b.gz > combined.gz`, valid per RFC
+/// 1952 §2.2) are decompressed as one continuous logical stream, matching
+/// both real `gunzip` and Go's `compress/gzip` (which defaults
+/// `Multistream: true`) — moby's own decompression path this mirrors.
 enum GzipStreamDecoder {
     enum Error: Swift.Error, Equatable {
         case invalidHeader
@@ -17,86 +22,171 @@ enum GzipStreamDecoder {
         case exceedsCap
     }
 
-    private static let chunkSize = 1 << 20
+    private static let chunkSize = CompressionStreamDriver.defaultChunkSize
+    private static let trailerSize = 8  // CRC32 + ISIZE, per member
 
     static func sha256OfDecompressedContent(at path: URL, cap: Int) throws -> String {
-        let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
-        guard let fileSize = attributes[.size] as? UInt64 else {
-            throw Error.invalidHeader
-        }
-
         let handle = try FileHandle(forReadingFrom: path)
         defer { try? handle.close() }
-
-        let headerLength = try readHeaderLength(handle)
-        // The final 8 bytes (CRC32 + ISIZE) are a trailer, not part of the
-        // DEFLATE stream Compression's decoder consumes.
-        let payloadEnd = fileSize - 8
-        guard payloadEnd >= headerLength else { throw Error.invalidHeader }
-        try handle.seek(toOffset: UInt64(headerLength))
-
-        let placeholder = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
-        defer { placeholder.deallocate() }
-        var stream = compression_stream(dst_ptr: placeholder, dst_size: 0, src_ptr: placeholder, src_size: 0, state: nil)
-        guard compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB) == COMPRESSION_STATUS_OK else {
-            throw Error.decodeFailed
-        }
-        defer { compression_stream_destroy(&stream) }
+        let source = ChunkedByteSource(handle: handle)
 
         var hasher = SHA256()
         var totalDecompressed = 0
-        var remaining = Int(payloadEnd) - headerLength
-        var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+        var decodedAnyMember = false
 
-        while true {
-            let wantedBytes = min(chunkSize, remaining)
-            let sourceChunk = wantedBytes > 0 ? (try handle.read(upToCount: wantedBytes) ?? Data()) : Data()
-            remaining -= sourceChunk.count
-            let isFinalChunk = remaining == 0
-
-            var status: compression_status = COMPRESSION_STATUS_OK
-            try sourceChunk.withUnsafeBytes { (sourceRaw: UnsafeRawBufferPointer) in
-                stream.src_ptr = sourceRaw.bindMemory(to: UInt8.self).baseAddress ?? UnsafePointer(placeholder)
-                stream.src_size = sourceChunk.count
-
-                repeat {
-                    try outputBuffer.withUnsafeMutableBufferPointer { outputPtr in
-                        stream.dst_ptr = outputPtr.baseAddress!
-                        stream.dst_size = chunkSize
-                        let flags: Int32 = isFinalChunk ? Int32(COMPRESSION_STREAM_FINALIZE.rawValue) : 0
-                        status = compression_stream_process(&stream, flags)
-                        guard status != COMPRESSION_STATUS_ERROR else { throw Error.decodeFailed }
-
-                        let produced = chunkSize - stream.dst_size
-                        guard produced > 0 else { return }
-                        hasher.update(bufferPointer: UnsafeRawBufferPointer(start: outputPtr.baseAddress, count: produced))
-                        totalDecompressed += produced
-                        guard totalDecompressed <= cap else { throw Error.exceedsCap }
-                    }
-                } while status == COMPRESSION_STATUS_OK && (stream.src_size > 0 || isFinalChunk)
-            }
-
-            if isFinalChunk { break }
+        while try source.hasMoreBytes() {
+            try decodeOneMember(path: path, source: source, into: &hasher, totalDecompressed: &totalDecompressed, cap: cap)
+            decodedAnyMember = true
+            try source.consume(trailerSize)  // CRC32 + ISIZE
         }
+        guard decodedAnyMember else { throw Error.invalidHeader }
 
         return hasher.finalize().compactMap { String(format: "%02x", $0) }.joined()
     }
 
-    /// Reads just enough of the file to find where the DEFLATE payload
-    /// starts, honoring the optional FEXTRA/FNAME/FCOMMENT/FHCRC fields
-    /// (RFC 1952 §2.3) rather than assuming the fixed 10-byte minimum.
-    private static func readHeaderLength(_ handle: FileHandle) throws -> Int {
-        // Comfortably covers a FNAME/FCOMMENT-bearing header in practice;
-        // re-read with a larger window in the rare case a name/comment
-        // field runs past it.
-        var probe = try handle.read(upToCount: 1024) ?? Data()
-        while true {
-            if let length = try? parseGzipHeaderLength(probe) { return length }
-            guard probe.count < (1 << 20) else { throw Error.invalidHeader }
-            guard let more = try handle.read(upToCount: probe.count), !more.isEmpty else {
-                throw Error.invalidHeader
+    private static func decodeOneMember(
+        path: URL, source: ChunkedByteSource, into hasher: inout SHA256, totalDecompressed: inout Int, cap: Int
+    ) throws {
+        let headerLength = try readHeaderLength(source)
+        try source.consume(headerLength)
+        let memberOffset = try source.currentFileOffset()
+
+        try CompressionStreamDriver.withStream(operation: COMPRESSION_STREAM_DECODE, onError: { Error.decodeFailed }) { stream, placeholder in
+            var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+            var status: compression_status = COMPRESSION_STATUS_OK
+
+            while status != COMPRESSION_STATUS_END {
+                let chunkStartOffset = try source.currentFileOffset()
+                let sourceChunk = try source.read(upTo: chunkSize)
+                let isLastAvailableChunk = try sourceChunk.count < chunkSize && !source.hasMoreBytes()
+
+                status = try CompressionStreamDriver.process(
+                    &stream, input: sourceChunk, finalize: isLastAvailableChunk, outputBuffer: &outputBuffer, placeholder: placeholder,
+                    onError: { Error.decodeFailed },
+                    onOutput: { produced in
+                        hasher.update(bufferPointer: produced)
+                        totalDecompressed += produced.count
+                        guard totalDecompressed <= cap else { throw Error.exceedsCap }
+                    })
+
+                if status == COMPRESSION_STATUS_END {
+                    // `compression_stream` reports the whole fed chunk as
+                    // consumed once it hits the DEFLATE end marker, even when
+                    // this chunk also holds bytes past it (this member's
+                    // trailer, and potentially a next member) — unlike
+                    // zlib's `inflate()`, which tracks the exact boundary via
+                    // `avail_in`. Resolving that ambiguity means re-decoding
+                    // everything fed to this member so far, once per
+                    // binary-search trial, so it's only worth doing when
+                    // there's a reason to suspect it's needed: either the
+                    // file still has more content after this chunk (an
+                    // unambiguous "there's definitely another member" —
+                    // cheap regardless of size, since a lone huge member has
+                    // nothing left to disambiguate), or this was the
+                    // member's very first read (several small members can
+                    // land in one chunk together, which `hasMoreBytes()`
+                    // alone would miss — but priorLength is 0 here, so
+                    // re-decoding is cheap too). A large member with nothing
+                    // after it skips this entirely.
+                    let priorLength = chunkStartOffset - memberOffset
+                    if try source.hasMoreBytes() || priorLength == 0 {
+                        let memberLength = try findMemberLength(
+                            path: path, memberOffset: memberOffset, priorLength: priorLength,
+                            finalChunkLength: sourceChunk.count, cap: cap)
+                        // The binary search's success signal (does decoding
+                        // reach END) is trustworthy once `process` no longer
+                        // exits early, but a corrupt or adversarial input is
+                        // still worth guarding against with an independent
+                        // check: what immediately follows the found
+                        // boundary's 8-byte trailer must be either true EOF
+                        // or another gzip header — never silently trust a
+                        // boundary that lands somewhere else.
+                        guard try boundaryLooksValid(path: path, at: memberOffset + memberLength + trailerSize) else {
+                            throw Error.decodeFailed
+                        }
+                        let boundaryWithinChunk = memberLength - priorLength
+                        source.unread(sourceChunk.suffix(from: sourceChunk.startIndex + boundaryWithinChunk))
+                    }
+                } else {
+                    guard !isLastAvailableChunk else { throw Error.decodeFailed }
+                }
             }
-            probe.append(more)
+        }
+    }
+
+    /// True when `offset` is at true end-of-file, or the two bytes there are
+    /// a gzip magic number — the only two shapes a genuine member boundary
+    /// can take.
+    private static func boundaryLooksValid(path: URL, at offset: Int) throws -> Bool {
+        let handle = try FileHandle(forReadingFrom: path)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(offset))
+        let magic = try handle.read(upToCount: 2) ?? Data()
+        return magic.isEmpty || magic.elementsEqual([0x1f, 0x8b])
+    }
+
+    /// Binary-searches for the shortest prefix of this member's compressed
+    /// bytes (starting at `memberOffset`) that decodes to completion —
+    /// re-reading from disk for each trial rather than keeping already-fed
+    /// chunks in memory, so a large ambiguous member can't reintroduce the
+    /// unbounded-memory problem this decoder exists to avoid (bounded,
+    /// if redundant, disk I/O instead).
+    private static func findMemberLength(path: URL, memberOffset: Int, priorLength: Int, finalChunkLength: Int, cap: Int) throws -> Int {
+        var lower = priorLength
+        var upper = priorLength + finalChunkLength
+        while lower < upper {
+            let mid = lower + (upper - lower) / 2
+            if try memberDecodes(path: path, memberOffset: memberOffset, length: mid, cap: cap) {
+                upper = mid
+            } else {
+                lower = mid + 1
+            }
+        }
+        return lower
+    }
+
+    private static func memberDecodes(path: URL, memberOffset: Int, length: Int, cap: Int) throws -> Bool {
+        let handle = try FileHandle(forReadingFrom: path)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(memberOffset))
+
+        return try CompressionStreamDriver.withStream(operation: COMPRESSION_STREAM_DECODE, onError: { Error.decodeFailed }) { stream, placeholder in
+            var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+            var status: compression_status = COMPRESSION_STATUS_OK
+            var remaining = length
+            var totalProduced = 0
+
+            while status == COMPRESSION_STATUS_OK {
+                let wanted = min(chunkSize, remaining)
+                let chunk = wanted > 0 ? (try handle.read(upToCount: wanted) ?? Data()) : Data()
+                remaining -= chunk.count
+                do {
+                    status = try CompressionStreamDriver.process(
+                        &stream, input: chunk, finalize: remaining == 0, outputBuffer: &outputBuffer, placeholder: placeholder,
+                        onError: { Error.decodeFailed },
+                        onOutput: { produced in
+                            totalProduced += produced.count
+                            guard totalProduced <= cap else { throw Error.exceedsCap }
+                        })
+                } catch {
+                    return false
+                }
+                if remaining == 0 { break }
+            }
+            return status == COMPRESSION_STATUS_END
+        }
+    }
+
+    /// Reads just enough to find where the DEFLATE payload starts, honoring
+    /// the optional FEXTRA/FNAME/FCOMMENT/FHCRC fields (RFC 1952 §2.3) rather
+    /// than assuming the fixed 10-byte minimum.
+    private static func readHeaderLength(_ source: ChunkedByteSource) throws -> Int {
+        var probeSize = 1024
+        while true {
+            let probe = try source.peek(upTo: probeSize)
+            if let length = try? parseGzipHeaderLength(probe) { return length }
+            guard probe.count == probeSize, probeSize < (1 << 20) else { throw Error.invalidHeader }
+            probeSize *= 2
         }
     }
 
@@ -126,6 +216,70 @@ enum GzipStreamDecoder {
             guard offset < data.count else { throw Error.invalidHeader }
             offset += 1
             if data[data.startIndex + offset - 1] == 0 { return offset }
+        }
+    }
+}
+
+/// A forward-only byte source backed by a `FileHandle`, supporting the
+/// look-ahead (`peek`) and give-back (`unread`) operations gzip's
+/// multi-member framing needs: the header parser must see bytes before
+/// committing to consuming them, and `compression_stream_process` routinely
+/// under-consumes a chunk (leaving the next member's trailer/header inside
+/// it) without ever reading the whole file into memory at once.
+private final class ChunkedByteSource {
+    private let handle: FileHandle
+    private var buffer = Data()
+    private var bufferStartOffset = 0
+
+    init(handle: FileHandle) {
+        self.handle = handle
+    }
+
+    func hasMoreBytes() throws -> Bool {
+        try fill(upTo: 1)
+        return !buffer.isEmpty
+    }
+
+    /// The absolute file offset of the next unread byte.
+    func currentFileOffset() throws -> Int {
+        bufferStartOffset
+    }
+
+    func peek(upTo count: Int) throws -> Data {
+        try fill(upTo: count)
+        return buffer.prefix(count)
+    }
+
+    func consume(_ count: Int) throws {
+        try fill(upTo: count)
+        let removed = min(count, buffer.count)
+        buffer.removeFirst(removed)
+        bufferStartOffset += removed
+    }
+
+    func read(upTo count: Int) throws -> Data {
+        try fill(upTo: count)
+        let chunk = buffer.prefix(count)
+        buffer.removeFirst(chunk.count)
+        bufferStartOffset += chunk.count
+        return chunk
+    }
+
+    /// Restores bytes `compression_stream_process` didn't consume — always
+    /// the unconsumed suffix of what was just handed to it via `read` — so
+    /// the trailer (and any following member's header) is seen again.
+    func unread(_ bytes: Data) {
+        guard !bytes.isEmpty else { return }
+        buffer = bytes + buffer
+        bufferStartOffset -= bytes.count
+    }
+
+    private func fill(upTo target: Int) throws {
+        while buffer.count < target {
+            guard let more = try handle.read(upToCount: max(target - buffer.count, 1 << 16)), !more.isEmpty else {
+                return
+            }
+            buffer.append(more)
         }
     }
 }

--- a/Sources/socktainer/Utilities/GzipStreamDecoder.swift
+++ b/Sources/socktainer/Utilities/GzipStreamDecoder.swift
@@ -1,0 +1,131 @@
+import Compression
+import CryptoKit
+import Foundation
+
+/// Streams a gzip file's decompressed content through Apple's system
+/// `Compression` framework rather than materializing it in memory —
+/// `DataCompression` (used for storing/producing gzip layers elsewhere in
+/// this codebase) only exposes whole-buffer `gzip()`/`gunzip()`, so a small,
+/// highly-compressible malicious file could otherwise expand to gigabytes
+/// before anything could check its size. Both the compressed input and the
+/// decompressed output are read/produced in fixed-size chunks; exceeding
+/// `cap` aborts mid-stream instead of after the fact.
+enum GzipStreamDecoder {
+    enum Error: Swift.Error, Equatable {
+        case invalidHeader
+        case decodeFailed
+        case exceedsCap
+    }
+
+    private static let chunkSize = 1 << 20
+
+    static func sha256OfDecompressedContent(at path: URL, cap: Int) throws -> String {
+        let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
+        guard let fileSize = attributes[.size] as? UInt64 else {
+            throw Error.invalidHeader
+        }
+
+        let handle = try FileHandle(forReadingFrom: path)
+        defer { try? handle.close() }
+
+        let headerLength = try readHeaderLength(handle)
+        // The final 8 bytes (CRC32 + ISIZE) are a trailer, not part of the
+        // DEFLATE stream Compression's decoder consumes.
+        let payloadEnd = fileSize - 8
+        guard payloadEnd >= headerLength else { throw Error.invalidHeader }
+        try handle.seek(toOffset: UInt64(headerLength))
+
+        let placeholder = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
+        defer { placeholder.deallocate() }
+        var stream = compression_stream(dst_ptr: placeholder, dst_size: 0, src_ptr: placeholder, src_size: 0, state: nil)
+        guard compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB) == COMPRESSION_STATUS_OK else {
+            throw Error.decodeFailed
+        }
+        defer { compression_stream_destroy(&stream) }
+
+        var hasher = SHA256()
+        var totalDecompressed = 0
+        var remaining = Int(payloadEnd) - headerLength
+        var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+
+        while true {
+            let wantedBytes = min(chunkSize, remaining)
+            let sourceChunk = wantedBytes > 0 ? (try handle.read(upToCount: wantedBytes) ?? Data()) : Data()
+            remaining -= sourceChunk.count
+            let isFinalChunk = remaining == 0
+
+            var status: compression_status = COMPRESSION_STATUS_OK
+            try sourceChunk.withUnsafeBytes { (sourceRaw: UnsafeRawBufferPointer) in
+                stream.src_ptr = sourceRaw.bindMemory(to: UInt8.self).baseAddress ?? UnsafePointer(placeholder)
+                stream.src_size = sourceChunk.count
+
+                repeat {
+                    try outputBuffer.withUnsafeMutableBufferPointer { outputPtr in
+                        stream.dst_ptr = outputPtr.baseAddress!
+                        stream.dst_size = chunkSize
+                        let flags: Int32 = isFinalChunk ? Int32(COMPRESSION_STREAM_FINALIZE.rawValue) : 0
+                        status = compression_stream_process(&stream, flags)
+                        guard status != COMPRESSION_STATUS_ERROR else { throw Error.decodeFailed }
+
+                        let produced = chunkSize - stream.dst_size
+                        guard produced > 0 else { return }
+                        hasher.update(bufferPointer: UnsafeRawBufferPointer(start: outputPtr.baseAddress, count: produced))
+                        totalDecompressed += produced
+                        guard totalDecompressed <= cap else { throw Error.exceedsCap }
+                    }
+                } while status == COMPRESSION_STATUS_OK && (stream.src_size > 0 || isFinalChunk)
+            }
+
+            if isFinalChunk { break }
+        }
+
+        return hasher.finalize().compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Reads just enough of the file to find where the DEFLATE payload
+    /// starts, honoring the optional FEXTRA/FNAME/FCOMMENT/FHCRC fields
+    /// (RFC 1952 §2.3) rather than assuming the fixed 10-byte minimum.
+    private static func readHeaderLength(_ handle: FileHandle) throws -> Int {
+        // Comfortably covers a FNAME/FCOMMENT-bearing header in practice;
+        // re-read with a larger window in the rare case a name/comment
+        // field runs past it.
+        var probe = try handle.read(upToCount: 1024) ?? Data()
+        while true {
+            if let length = try? parseGzipHeaderLength(probe) { return length }
+            guard probe.count < (1 << 20) else { throw Error.invalidHeader }
+            guard let more = try handle.read(upToCount: probe.count), !more.isEmpty else {
+                throw Error.invalidHeader
+            }
+            probe.append(more)
+        }
+    }
+
+    private static func parseGzipHeaderLength(_ data: Data) throws -> Int {
+        guard data.count >= 10, data[data.startIndex] == 0x1f, data[data.startIndex + 1] == 0x8b else {
+            throw Error.invalidHeader
+        }
+        let flags = data[data.startIndex + 3]
+        var offset = 10
+
+        if flags & 0x04 != 0 {  // FEXTRA
+            guard data.count >= offset + 2 else { throw Error.invalidHeader }
+            let extraLength = Int(data[data.startIndex + offset]) | (Int(data[data.startIndex + offset + 1]) << 8)
+            offset += 2 + extraLength
+        }
+        if flags & 0x08 != 0 { offset = try skipNullTerminated(data, from: offset) }  // FNAME
+        if flags & 0x10 != 0 { offset = try skipNullTerminated(data, from: offset) }  // FCOMMENT
+        if flags & 0x02 != 0 { offset += 2 }  // FHCRC
+
+        guard data.count > offset else { throw Error.invalidHeader }
+        return offset
+    }
+
+    private static func skipNullTerminated(_ data: Data, from start: Int) throws -> Int {
+        var offset = start
+        while true {
+            guard offset < data.count else { throw Error.invalidHeader }
+            offset += 1
+            if data[data.startIndex + offset - 1] == 0 { return offset }
+        }
+    }
+}

--- a/Sources/socktainer/Utilities/GzipStreamEncoder.swift
+++ b/Sources/socktainer/Utilities/GzipStreamEncoder.swift
@@ -1,0 +1,85 @@
+import Compression
+import CryptoKit
+import Foundation
+
+/// Streams a plain file into a gzip-compressed one. Apple's `Compression`
+/// framework only speaks raw DEFLATE, so this builds the gzip container
+/// (RFC 1952) by hand around it: a header, the DEFLATE stream, then a
+/// CRC-32 + ISIZE trailer.
+enum GzipStreamEncoder {
+    enum Error: Swift.Error {
+        case encodeFailed
+    }
+
+    struct Result {
+        let compressedDigest: String
+        let compressedSize: Int
+        let uncompressedDigest: String
+    }
+
+    private static let gzipMagic: [UInt8] = [0x1f, 0x8b]
+    private static let compressionMethodDeflate: UInt8 = 0x08
+    private static let unsetFlags: UInt8 = 0x00
+    private static let unsetModificationTime: [UInt8] = [0x00, 0x00, 0x00, 0x00]
+    private static let unsetExtraFlags: UInt8 = 0x00
+    private static let operatingSystemUnknown: UInt8 = 0xff
+    private static let header = Data(
+        gzipMagic + [compressionMethodDeflate, unsetFlags] + unsetModificationTime + [unsetExtraFlags, operatingSystemUnknown])
+
+    static func compressFile(at sourcePath: URL, to destinationPath: URL) throws -> Result {
+        guard FileManager.default.createFile(atPath: destinationPath.path, contents: nil) else {
+            throw Error.encodeFailed
+        }
+        let sourceHandle = try FileHandle(forReadingFrom: sourcePath)
+        defer { try? sourceHandle.close() }
+        let destinationHandle = try FileHandle(forWritingTo: destinationPath)
+        defer { try? destinationHandle.close() }
+
+        try destinationHandle.write(contentsOf: header)
+        let body = try encodeDeflateBody(from: sourceHandle, into: destinationHandle)
+        try destinationHandle.write(contentsOf: trailer(crc: body.crc, uncompressedSize: body.uncompressedSize))
+
+        let compressed = try FileHashing.sha256OfFile(at: destinationPath)
+        return Result(compressedDigest: compressed.digest, compressedSize: compressed.size, uncompressedDigest: body.uncompressedDigest)
+    }
+
+    private static func encodeDeflateBody(
+        from sourceHandle: FileHandle, into destinationHandle: FileHandle
+    ) throws -> (uncompressedDigest: String, crc: UInt32, uncompressedSize: Int) {
+        var uncompressedHasher = SHA256()
+        var crc = CRC32.Incremental()
+        var uncompressedSize = 0
+        let chunkSize = CompressionStreamDriver.defaultChunkSize
+
+        try CompressionStreamDriver.withStream(operation: COMPRESSION_STREAM_ENCODE, onError: { Error.encodeFailed }) { stream, placeholder in
+            var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+            var status: compression_status = COMPRESSION_STATUS_OK
+
+            while status != COMPRESSION_STATUS_END {
+                let chunk = try sourceHandle.read(upToCount: chunkSize) ?? Data()
+                let isFinalChunk = chunk.count < chunkSize
+                uncompressedHasher.update(data: chunk)
+                uncompressedSize += chunk.count
+                chunk.withUnsafeBytes { crc.update($0) }
+
+                status = try CompressionStreamDriver.process(
+                    &stream, input: chunk, finalize: isFinalChunk, outputBuffer: &outputBuffer, placeholder: placeholder,
+                    onError: { Error.encodeFailed },
+                    onOutput: { produced in try destinationHandle.write(contentsOf: Data(produced)) })
+
+                guard status == COMPRESSION_STATUS_OK || status == COMPRESSION_STATUS_END else {
+                    throw Error.encodeFailed
+                }
+            }
+        }
+
+        return (uncompressedHasher.finalize().hexString, crc.value, uncompressedSize)
+    }
+
+    private static func trailer(crc: UInt32, uncompressedSize: Int) -> Data {
+        var trailer = Data()
+        withUnsafeBytes(of: crc.littleEndian) { trailer.append(contentsOf: $0) }
+        withUnsafeBytes(of: UInt32(truncatingIfNeeded: uncompressedSize).littleEndian) { trailer.append(contentsOf: $0) }
+        return trailer
+    }
+}

--- a/Tests/socktainerTests/Clients/ClientImageServiceImportTests.swift
+++ b/Tests/socktainerTests/Clients/ClientImageServiceImportTests.swift
@@ -92,11 +92,12 @@ struct ClientImageServiceImportTests {
         defer { fixture.cleanUp() }
 
         let tarPath = try fixture.makeTar(contents: "content\n")
+        let digestRepo = "crafted-import@sha256:\(String(repeating: "a", count: 64))"
 
-        await #expect(throws: ClientImageError.self) {
+        do {
             _ = try await fixture.service.importImage(
                 tarPath: tarPath,
-                repo: "crafted-import@sha256:\(String(repeating: "a", count: 64))",
+                repo: digestRepo,
                 tag: nil,
                 message: nil,
                 changes: [],
@@ -104,6 +105,11 @@ struct ClientImageServiceImportTests {
                 appleContainerAppSupportUrl: fixture.storeDir,
                 logger: fixture.logger
             )
+            Issue.record("expected importImage to throw for a digest reference")
+        } catch ClientImageError.digestReferenceNotAllowed(let repo) {
+            #expect(repo == digestRepo)
+        } catch {
+            Issue.record("expected ClientImageError.digestReferenceNotAllowed, got \(error)")
         }
     }
 }

--- a/Tests/socktainerTests/Clients/ClientImageServiceImportTests.swift
+++ b/Tests/socktainerTests/Clients/ClientImageServiceImportTests.swift
@@ -1,0 +1,136 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Containerization
+import ContainerizationArchive
+import ContainerizationOCI
+import CryptoKit
+import Foundation
+import Logging
+import Testing
+
+@testable import socktainer
+
+@Suite("ClientImageService import")
+struct ClientImageServiceImportTests {
+
+    @Test("importing a tar with a repo:tag registers a queryable image with the right diff_id")
+    func importRegistersTaggedImage() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(contents: "hello from import\n")
+        let tarData = try Data(contentsOf: tarPath)
+
+        let (reference, digest) = try await fixture.service.importImage(
+            tarPath: tarPath,
+            repo: "crafted-import",
+            tag: "latest",
+            message: nil,
+            changes: [],
+            platform: Platform(arch: "arm64", os: "linux"),
+            appleContainerAppSupportUrl: fixture.storeDir,
+            logger: fixture.logger
+        )
+
+        #expect(reference == "docker.io/library/crafted-import:latest")
+        #expect(!digest.isEmpty)
+
+        let stored = try await ImageStore(path: fixture.storeDir).get(reference: "docker.io/library/crafted-import:latest")
+        let config = try await stored.config(for: Platform(arch: "arm64", os: "linux"))
+        #expect(config.rootfs.diffIDs == ["sha256:\(tarData.sha256Hex())"])
+    }
+
+    @Test("importing without a repo registers an untagged image")
+    func importWithoutRepoIsUntagged() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(contents: "untagged content\n")
+
+        let (reference, digest) = try await fixture.service.importImage(
+            tarPath: tarPath,
+            repo: nil,
+            tag: nil,
+            message: nil,
+            changes: [],
+            platform: Platform(arch: "arm64", os: "linux"),
+            appleContainerAppSupportUrl: fixture.storeDir,
+            logger: fixture.logger
+        )
+
+        #expect(reference == nil)
+        #expect(!digest.isEmpty)
+
+        let allImages = try await ImageStore(path: fixture.storeDir).list()
+        #expect(allImages.contains { $0.digest == digest })
+    }
+
+    @Test("an omitted tag defaults to latest")
+    func repoWithoutTagDefaultsToLatest() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(contents: "default tag content\n")
+
+        let (reference, _) = try await fixture.service.importImage(
+            tarPath: tarPath,
+            repo: "crafted-default-tag",
+            tag: nil,
+            message: nil,
+            changes: [],
+            platform: Platform(arch: "arm64", os: "linux"),
+            appleContainerAppSupportUrl: fixture.storeDir,
+            logger: fixture.logger
+        )
+
+        #expect(reference == "docker.io/library/crafted-default-tag:latest")
+    }
+
+    @Test("a digest reference as repo is rejected")
+    func digestRepoIsRejected() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(contents: "content\n")
+
+        await #expect(throws: ClientImageError.self) {
+            _ = try await fixture.service.importImage(
+                tarPath: tarPath,
+                repo: "crafted-import@sha256:\(String(repeating: "a", count: 64))",
+                tag: nil,
+                message: nil,
+                changes: [],
+                platform: Platform(arch: "arm64", os: "linux"),
+                appleContainerAppSupportUrl: fixture.storeDir,
+                logger: fixture.logger
+            )
+        }
+    }
+}
+
+private struct ImportFixture {
+    let workDir: URL
+    let rootfsDir: URL
+    let storeDir: URL
+    let service = ClientImageService(containerSystemConfig: ContainerSystemConfig())
+    let logger = Logger(label: "test")
+
+    init() throws {
+        workDir = FileManager.default.temporaryDirectory.appendingPathComponent("image-import-\(UUID().uuidString)")
+        rootfsDir = workDir.appendingPathComponent("rootfs")
+        storeDir = workDir.appendingPathComponent("store")
+        try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: workDir)
+    }
+
+    func makeTar(contents: String) throws -> URL {
+        try Data(contents.utf8).write(to: rootfsDir.appendingPathComponent("hello.txt"))
+        let tarPath = workDir.appendingPathComponent("import-\(UUID().uuidString).tar")
+        try ArchiveUtility.create(tarPath: tarPath, from: rootfsDir)
+        return tarPath
+    }
+}

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -144,6 +144,10 @@ private struct DanglingImageDeleteMock: ClientImageProtocol {
     ) { ([], 0) }
     func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL { URL(fileURLWithPath: "/tmp") }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) { (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000") }
 }
 
 private struct ImageDeleteMock: ClientImageProtocol {
@@ -173,4 +177,8 @@ private struct ImageDeleteMock: ClientImageProtocol {
     func save(
         references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger
     ) async throws -> URL { URL(fileURLWithPath: "/tmp") }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) { (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000") }
 }

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -455,6 +455,12 @@ private struct StubImageClient: ClientImageProtocol {
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
         URL(fileURLWithPath: "/tmp")
     }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    }
 }
 
 private struct StubNetworkClient: ClientNetworkProtocol {

--- a/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
+++ b/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
@@ -115,4 +115,10 @@ private struct FixedResultImageMock: ClientImageProtocol {
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
         URL(fileURLWithPath: "/dev/null")
     }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    }
 }

--- a/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
@@ -1,0 +1,68 @@
+import ContainerAPIClient
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// moby validates `repo`/`tag` (`httputils.RepoTagReference`) before the layer reader
+/// is even constructed (api/server/router/image/image_routes.go's `postImagesCreate`),
+/// so a digest reference is rejected without reading the request body at all.
+@Suite("ImageCreateRoute — docker import fail-fast")
+struct ImageCreateImportRouteTests {
+
+    @Test("a digest reference in repo is rejected without the body ever being read")
+    func digestReferenceRejectedBeforeBodyIsRead() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: ImageCreateRoute(client: client))
+
+            let hugeGarbageBody = ByteBuffer(repeating: 0xFF, count: 10_000_000)
+            try await app.testing().test(
+                .POST, "/v1.51/images/create?fromSrc=-&repo=foo@sha256:\(String(repeating: "a", count: 64))",
+                body: hugeGarbageBody
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("cannot reference"))
+            }
+        }
+
+        #expect(!(await client.importImageWasCalled), "importImage must not run when repo is a digest reference")
+    }
+}
+
+private actor SpyImageClient: ClientImageProtocol {
+    private(set) var importImageWasCalled = false
+
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws -> ImageDeletionResult {
+        ImageDeletionResult(untagged: id, digest: "sha256:abc", deletedDigest: nil)
+    }
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        FileManager.default.temporaryDirectory
+    }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String],
+        platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        importImageWasCalled = true
+        return (repo, "sha256:" + String(repeating: "b", count: 64))
+    }
+}

--- a/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
@@ -36,6 +36,33 @@ struct ImageCreateImportRouteTests {
 
         #expect(!(await client.importImageWasCalled), "importImage must not run when repo is a digest reference")
     }
+
+    @Test("a malformed (non-digest) reference in repo is also rejected without the body ever being read")
+    func malformedReferenceRejectedBeforeBodyIsRead() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: ImageCreateRoute(client: client))
+
+            // "UPPERCASE" fails Reference.parse's path grammar (lowercase alnum
+            // only) — a malformed reference the old digest-only check would not
+            // have caught before reading the body.
+            let hugeGarbageBody = ByteBuffer(repeating: 0xFF, count: 10_000_000)
+            try await app.testing().test(
+                .POST, "/v1.51/images/create?fromSrc=-&repo=UPPERCASE",
+                body: hugeGarbageBody
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("invalid reference format"))
+            }
+        }
+
+        #expect(!(await client.importImageWasCalled), "importImage must not run when repo is malformed")
+    }
 }
 
 private actor SpyImageClient: ClientImageProtocol {

--- a/Tests/socktainerTests/Routes/Images/RESTImageCreateQueryTests.swift
+++ b/Tests/socktainerTests/Routes/Images/RESTImageCreateQueryTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Vapor
+
+@testable import socktainer
+
+/// Docker sends `--change` as repeated flat `changes=` query keys
+/// (`?changes=CMD+x&changes=ENV+y`), never as a JSON array or bracketed form.
+/// This proves Vapor's `URLEncodedFormDecoder` accumulates those into `[String]`
+/// before `ImageCreateRoute` relies on it for real requests.
+@Suite("RESTImageCreateQuery decoding")
+struct RESTImageCreateQueryTests {
+
+    @Test("repeated changes= query keys decode into an array, in order")
+    func repeatedChangesKeysDecodeAsArray() throws {
+        let query = "fromSrc=-&repo=myrepo&tag=latest&changes=CMD%20%2Fapp&changes=ENV%20FOO%3Dbar"
+        let decoded = try URLEncodedFormDecoder().decode(RESTImageCreateQuery.self, from: query)
+
+        #expect(decoded.fromSrc == "-")
+        #expect(decoded.repo == "myrepo")
+        #expect(decoded.tag == "latest")
+        #expect(decoded.changes == ["CMD /app", "ENV FOO=bar"])
+    }
+
+    @Test("a single changes= query key decodes into a one-element array")
+    func singleChangesKeyDecodesAsArray() throws {
+        let query = "fromSrc=-&changes=CMD%20%2Fapp"
+        let decoded = try URLEncodedFormDecoder().decode(RESTImageCreateQuery.self, from: query)
+
+        #expect(decoded.changes == ["CMD /app"])
+    }
+
+    @Test("no changes= query key decodes to nil")
+    func absentChangesKeyDecodesToNil() throws {
+        let query = "fromSrc=-"
+        let decoded = try URLEncodedFormDecoder().decode(RESTImageCreateQuery.self, from: query)
+
+        #expect(decoded.changes == nil)
+    }
+}

--- a/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
@@ -65,6 +65,12 @@ private struct StubImageClient: ClientImageProtocol {
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
         URL(fileURLWithPath: "/dev/null")
     }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    }
 }
 
 // MARK: - loadSystemConfig

--- a/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
@@ -25,6 +25,10 @@ private struct EmptyImageClient: ClientImageProtocol {
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
         URL(fileURLWithPath: "/dev/null")
     }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) { fatalError("not exercised by this test") }
 }
 
 private struct EmptyVolumeClient: ClientVolumeProtocol {

--- a/Tests/socktainerTests/Utilities/CRC32Tests.swift
+++ b/Tests/socktainerTests/Utilities/CRC32Tests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("CRC32")
+struct CRC32Tests {
+    @Test("matches the standard CRC-32/ISO-HDLC check value")
+    func standardCheckValue() {
+        var crc = CRC32.Incremental()
+        Array("123456789".utf8).withUnsafeBufferPointer { crc.update(UnsafeRawBufferPointer($0)) }
+        #expect(crc.value == 0xCBF4_3926)
+    }
+
+    @Test("an empty input hashes to zero")
+    func emptyInput() {
+        let crc = CRC32.Incremental()
+        #expect(crc.value == 0)
+    }
+
+    @Test("accumulating across multiple chunks matches one contiguous update")
+    func incrementalMatchesWhole() {
+        let data = Array("the quick brown fox jumps over the lazy dog".utf8)
+
+        var whole = CRC32.Incremental()
+        data.withUnsafeBufferPointer { whole.update(UnsafeRawBufferPointer($0)) }
+
+        var chunked = CRC32.Incremental()
+        for chunk in [data[0..<10], data[10..<20], data[20...]] {
+            Array(chunk).withUnsafeBufferPointer { chunked.update(UnsafeRawBufferPointer($0)) }
+        }
+
+        #expect(whole.value == chunked.value)
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
@@ -1,3 +1,4 @@
+import ContainerizationArchive
 import ContainerizationOCI
 import CryptoKit
 import DataCompression
@@ -47,6 +48,56 @@ struct ContainerImageImportTests {
         #expect(config.rootfs.diffIDs == [expectedDiffID])
         #expect(config.architecture == "arm64")
         #expect(config.os == "linux")
+    }
+
+    /// `tar cf scratch.tar -T /dev/null` (two 512-byte zero blocks, no file
+    /// entries) is the standard idiom for building a "scratch" base image, and
+    /// real `docker import` accepts it. This is a structurally valid, empty
+    /// tar — not a foreign format — so the tar-family confirmation check must
+    /// tell it apart from actual foreign content (which produces a spurious,
+    /// path-less entry instead of a clean EOF).
+    @Test("a zero-entry (scratch) tar is accepted, not treated as a foreign format")
+    func zeroEntryTarIsAccepted() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = fixture.root.appendingPathComponent("scratch.tar")
+        try Data(repeating: 0, count: 1024).write(to: tarPath)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let index = try fixture.index()
+        #expect(index.manifests.count == 1)
+    }
+
+    @Test("a gzip-wrapped zero-entry tar is also accepted")
+    func gzipWrappedZeroEntryTarIsAccepted() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = fixture.root.appendingPathComponent("scratch.tar.gz")
+        try #require(Data(repeating: 0, count: 1024).gzip()).write(to: tarPath)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let index = try fixture.index()
+        #expect(index.manifests.count == 1)
     }
 
     @Test("a repo:tag reference registers the tag via the manifest annotation")
@@ -219,6 +270,23 @@ struct ContainerImageImportTests {
         try layerData.write(to: layerPath)
         try ArchiveUtility.extract(tarPath: layerPath, to: extractDir)
         #expect(try String(contentsOf: extractDir.appendingPathComponent("hello.txt"), encoding: .utf8) == content)
+
+        // diff_id must be the digest of the real decompressed layer content —
+        // not the still-compressed input, and not disconnected from what's
+        // actually stored. Independently decompress the stored blob (gunzip
+        // for bzip2/xz, which are reserialized to gzip; the zstd decoder for
+        // zstd, which is stored as-is) and compare hashes directly, rather
+        // than only asserting the layer's file contents extract correctly.
+        let decompressed: Data
+        if fixtureCase.format == "zstd" {
+            let decompressedPath = try ArchiveReader.decompressZstd(layerPath)
+            defer { ArchiveReader.cleanUpDecompressedZstd(decompressedPath) }
+            decompressed = try Data(contentsOf: decompressedPath)
+        } else {
+            decompressed = try #require(layerData.gunzip())
+        }
+        let expectedDiffID = "sha256:\(decompressed.sha256Hex())"
+        #expect(try fixture.config(manifest).rootfs.diffIDs == [expectedDiffID])
     }
 
     @Test("a zip body is rejected instead of silently hashed as raw bytes")
@@ -244,6 +312,43 @@ struct ContainerImageImportTests {
     @Test("a cpio body is rejected instead of silently hashed as raw bytes")
     func cpioBodyIsRejectedCleanly() async throws {
         try assertForeignFormatRejected(magic: Array("070701".utf8), expectedFormat: "cpio")
+    }
+
+    /// A gzip-wrapped zip: `classifyLayerSource` sees gzip at the outer magic
+    /// bytes and only the tar-family confirmation gate (not the magic-byte
+    /// blacklist, which never looks past the outer layer) catches that the
+    /// decompressed content isn't tar.
+    private static let gzipWrappedZipBase64 =
+        "H4sICKyaWGoAA3ppcC1hcmNoaXZlLnppcAAL8GZm4WIAgS+hH2IYkAAHgwxDcn5eSWpeiX5oCCcD8+pZEVkgXFrBzcDI8o2RgYEFpC4AxQRda471PEA2CAsgmZCWmZOqV1JRgs+kjNScnHyF8vyinBSuAJzuQjY1Jz8vPSWziAT3+Xyc1MULZIPwMiwmJQ5KgM9/IJcrQL2BJ9j4kTxbXJpEWqghx6o4pkE5mXnZpEUuI5McM65kJwGP6LeOIBqRCFkhpmM4FdU01CQIMQ2olmFJoxOSaYgESZypqEkQ2Y0zkExFJEjiTEVNjshufYTF1IFOhtgBOSHIjxKC5xkZMNMm6ZEtjhKAEkwYhiLSKS7DWdlANBsQzgBqL2UC8QDH16NZIwUAAA=="
+
+    @Test("a gzip-wrapped zip is rejected, not just a bare zip")
+    func gzipWrappedZipIsRejectedCleanly() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let bodyPath = fixture.root.appendingPathComponent("import.tar")
+        try #require(Data(base64Encoded: Self.gzipWrappedZipBase64)).write(to: bodyPath)
+
+        try assertRejected(bodyPath: bodyPath, fixture: fixture, expectedFormat: "not a supported docker import source")
+    }
+
+    /// A real `xar` archive (macOS's `xar -cf`) — a libarchive-readable
+    /// container format with no distinctive-enough magic bytes to be worth a
+    /// dedicated blacklist entry, exercising the tar-family confirmation gate
+    /// (added alongside the blacklist) against a format the blacklist never
+    /// covered at all.
+    private static let xarBase64 =
+        "eGFyIQAcAAEAAAAAAAACVwAAAAAAAAVdAAAAAXjatFRNb6MwEL33VyDuxGOD+YhcelipvyB72Zuxh8RaMBGQbNpfv7YhzVZNe6i0J8bPb2bsZ96Ip0vfRWccJzPYx5huII7QqkEbu3+Mf+6ekzJ+qh/ERY71QyTmQblPJNSIcnYZyWx6rBmwPIEiofkOqi2DLQdB3lNC0gHV7+nUR9P80uFjPB0kjf1OJIa2nXCuXdoaBXQyr764ICHwJci1Rli1psPIaHfstYyWswxRJDq0+/kQstdwwdf6afWu1dqLslsvh12FuB5YHo+dUeFW5JLsX80xJlfqZR6lmlEn92/JGK/yNE+bVGMGDeRtVdK2KbkuWUoZlgpQc0oF+VhpbSFHdTDnTztImbYlqEJx5AAlq4A3VLcNl1mOTct4AVxxiYJ8KLSIR97UEyiDrBC/F5NW98VkcFdM+r/ERIS2lSVtsiZlGdOcN6DykqbcyVpkvFQSVAb8+2IC14XMUq01AKVMcZ1lSIuUIhSMaZQ5aI55/pmYkbDS/fVq6Df+nrg5jsMZrbTK6R+2FslxFfzZWI3jD28Z3K1+CUXsMKEarJ68N/5dLoTgLVoBJEATgB1jW8q3rBTk6jrX5G5xoT5Yt9xmxTatfjmX3bL7L2j9jSa/oMkbbT8Op2P954DYCbIsFtxof0H/CevThGM9vXRnaezGqdjgJEgAl23H4+DMerom9IPGGvIsc6fy4TIO8GwU2qGmeVEULHUJb1AgGOu51LmFFhlz/+sChL355Yi1nzBOSx8+vL2qBzfzZb69pCAe8wOShAkpSJiXfwEAAP//AwAHkJqpqPqpEol7Pvd4RO/qGfoSUaLpKPZ42mNkYohMT8zlzHdaDQAMygL3eNrLSM3JyVcozy/KSeECAB5yBGc="
+
+    @Test("a xar archive is rejected instead of silently hashed as raw bytes")
+    func xarBodyIsRejectedCleanly() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let bodyPath = fixture.root.appendingPathComponent("import.tar")
+        try #require(Data(base64Encoded: Self.xarBase64)).write(to: bodyPath)
+
+        try assertRejected(bodyPath: bodyPath, fixture: fixture, expectedFormat: "not a supported docker import source")
     }
 
     @Test("an iso9660 body is rejected instead of silently hashed as raw bytes")

--- a/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
@@ -293,6 +293,59 @@ struct ContainerImageImportTests {
         #expect(try fixture.config(manifest).rootfs.diffIDs == [expectedDiffID])
     }
 
+    @Test(
+        "a bzip2/xz/zstd layer whose decompressed size exceeds the configured cap is rejected",
+        arguments: reserializeFixtures)
+    func decompressedContentExceedingCapIsRejected(fixtureCase: (format: String, base64: String, expectedMediaType: String)) async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let compressedPath = fixture.root.appendingPathComponent("cap-\(fixtureCase.format).tar")
+        try #require(Data(base64Encoded: fixtureCase.base64)).write(to: compressedPath)
+
+        do {
+            _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: compressedPath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger,
+                maxExpandedLayerSize: 10
+            )
+            Issue.record("expected \(fixtureCase.format) import exceeding the cap to be rejected")
+        } catch ContainerImageUtility.Error.invalidTarball(let reason) {
+            #expect(reason.contains("exceeds"))
+        }
+    }
+
+    @Test("a gzip layer whose decompressed size exceeds the configured cap is rejected")
+    func gzipDecompressedContentExceedingCapIsRejected() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let plainTarPath = try fixture.makeTar(fileContents: "reserialize round-trip\n")
+        let gzipPath = fixture.root.appendingPathComponent("cap-gzip.tar.gz")
+        try #require(try Data(contentsOf: plainTarPath).gzip()).write(to: gzipPath)
+
+        do {
+            _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: gzipPath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger,
+                maxExpandedLayerSize: 10
+            )
+            Issue.record("expected a gzip import exceeding the cap to be rejected")
+        } catch ContainerImageUtility.Error.invalidTarball(let reason) {
+            #expect(reason.contains("exceeds"))
+        }
+    }
+
     @Test("a zip body is rejected instead of silently hashed as raw bytes")
     func zipBodyIsRejectedCleanly() async throws {
         try assertForeignFormatRejected(magic: [0x50, 0x4b, 0x03, 0x04], expectedFormat: "zip")

--- a/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
@@ -346,6 +346,40 @@ struct ContainerImageImportTests {
         }
     }
 
+    @Test("many empty entries are still bounded by the cap even though their content bytes alone round to zero")
+    func manyEmptyEntriesAreBoundedByHeaderAccounting() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        // Plain (uncompressed), not gzip-wrapped: a gzip layer's expansion cap
+        // is separately enforced by `GzipStreamDecoder` over the raw
+        // decompressed byte stream (headers included), which would catch an
+        // undercounting bug here for the wrong reason. A plain tar isolates
+        // `validateTar`'s own per-entry accounting, since `writeImportedLayerBlob`
+        // applies no expansion cap at all to an already-uncompressed input.
+        for i in 0..<2000 {
+            try Data().write(to: fixture.rootfsDir.appendingPathComponent("empty-\(i)"))
+        }
+        let tarPath = fixture.root.appendingPathComponent("many-empty.tar")
+        try ArchiveUtility.create(tarPath: tarPath, from: fixture.rootfsDir)
+
+        do {
+            _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: tarPath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger,
+                maxExpandedLayerSize: 100_000
+            )
+            Issue.record("expected many-empty-entry import exceeding the cap via header/padding accounting to be rejected")
+        } catch ContainerImageUtility.Error.invalidTarball(let reason) {
+            #expect(reason.contains("exceeds"))
+        }
+    }
+
     @Test("a zip body is rejected instead of silently hashed as raw bytes")
     func zipBodyIsRejectedCleanly() async throws {
         try assertForeignFormatRejected(magic: [0x50, 0x4b, 0x03, 0x04], expectedFormat: "zip")

--- a/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
@@ -1,0 +1,382 @@
+import ContainerizationOCI
+import CryptoKit
+import DataCompression
+import Foundation
+import Logging
+import Testing
+
+@testable import socktainer
+
+@Suite("buildSingleLayerOCILayout — docker import")
+struct ContainerImageImportTests {
+
+    @Test("a bare import (no repo, no changes) produces a single-layer OCI layout with the right diff_id")
+    func bareImportProducesSingleLayerLayout() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(fileContents: "hello from import\n")
+        let tarData = try Data(contentsOf: tarPath)
+        let expectedDiffID = "sha256:\(tarData.sha256Hex())"
+        // moby's docker import always gzip-compresses an uncompressed input before
+        // storing it (daemon/containerd/image_import.go) — it never stores a plain
+        // tar layer — so the manifest's layer digest is the compressed hash, distinct
+        // from diff_id, which stays the uncompressed hash.
+        let expectedLayerDigest = "sha256:\(tarData.gzip()!.sha256Hex())"
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let index = try fixture.index()
+        #expect(index.manifests.count == 1)
+        #expect(index.manifests[0].annotations == nil)
+
+        let manifest = try fixture.manifest(index.manifests[0])
+        #expect(manifest.layers.count == 1)
+        #expect(manifest.layers[0].digest == expectedLayerDigest)
+        #expect(manifest.layers[0].mediaType == MediaTypes.imageLayerGzip)
+
+        let config = try fixture.config(manifest)
+        #expect(config.rootfs.diffIDs == [expectedDiffID])
+        #expect(config.architecture == "arm64")
+        #expect(config.os == "linux")
+    }
+
+    @Test("a repo:tag reference registers the tag via the manifest annotation")
+    func repoTagRegistersAnnotation() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(fileContents: "tagged content\n")
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: "docker.io/library/crafted-import:latest",
+            logger: fixture.logger
+        )
+
+        let index = try fixture.index()
+        #expect(index.manifests[0].annotations?["org.opencontainers.image.ref.name"] == "docker.io/library/crafted-import:latest")
+    }
+
+    @Test("a message sets the image history comment")
+    func messageSetsHistoryComment() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(fileContents: "commented content\n")
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: "Imported from -",
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let manifest = try fixture.manifest(try fixture.index().manifests[0])
+        let config = try fixture.config(manifest)
+        #expect(config.history?.first?.comment == "Imported from -")
+    }
+
+    @Test("changes (CMD, ENV, EXPOSE) are applied to the synthesized config")
+    func changesApplyToConfig() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let tarPath = try fixture.makeTar(fileContents: "content\n")
+
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(
+            [
+                "CMD [\"/app\", \"serve\"]",
+                "ENV FOO=bar",
+                "EXPOSE 8080/tcp",
+            ], to: &config)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: tarPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: config,
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let manifest = try fixture.manifest(try fixture.index().manifests[0])
+        let ociImage = try fixture.config(manifest)
+        #expect(ociImage.config?.cmd == ["/app", "serve"])
+        #expect(ociImage.config?.env == ["FOO=bar"])
+
+        // ContainerizationOCI.ImageConfig has no ExposedPorts field, so assert
+        // against the raw JSON to prove EXPOSE is actually persisted in the blob.
+        let rawConfig = try fixture.rawConfigDict(manifest)
+        let configObject = try #require(rawConfig["config"] as? [String: Any])
+        let exposedPorts = try #require(configObject["ExposedPorts"] as? [String: Any])
+        #expect(exposedPorts["8080/tcp"] != nil)
+    }
+
+    @Test("a gzip-compressed body's diff_id is the uncompressed content hash, not the compressed file hash")
+    func gzipImportUsesDecompressedContentForDiffID() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let plainTarPath = try fixture.makeTar(fileContents: "gzip round-trip\n")
+        let plainTarData = try Data(contentsOf: plainTarPath)
+        let expectedDiffID = "sha256:\(plainTarData.sha256Hex())"
+        let compressed = plainTarData.gzip()!
+        let expectedLayerDigest = "sha256:\(compressed.sha256Hex())"
+        let gzipPath = fixture.root.appendingPathComponent("import.tar.gz")
+        try compressed.write(to: gzipPath)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: gzipPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let manifest = try fixture.manifest(try fixture.index().manifests[0])
+        // The manifest layer descriptor's digest is the stored (compressed) blob's
+        // digest; rootfs.diffIDs is the uncompressed content's digest — these must
+        // differ for a gzip layer, which is exactly the distinction the compression
+        // fix depends on getting right.
+        #expect(manifest.layers[0].digest == expectedLayerDigest)
+        #expect(manifest.layers[0].mediaType == "application/vnd.oci.image.layer.v1.tar+gzip")
+        #expect(try fixture.config(manifest).rootfs.diffIDs == [expectedDiffID])
+    }
+
+    /// `.tar` containing one `hello.txt` with contents `"reserialize round-trip\n"`,
+    /// compressed with each codec — `ArchiveWriter` can't encode bzip2/xz/zstd in
+    /// this environment (only decode, which is what production code needs), so
+    /// these are baked in rather than generated by the test at runtime.
+    ///
+    /// moby stores zstd input as-is (`tar+zstd`); bzip2/xz are decompressed and
+    /// re-compressed to gzip (`tar+gzip`) since OCI has no bzip2/xz layer media type.
+    private static let reserializeFixtures: [(format: String, base64: String, expectedMediaType: String)] = [
+        (
+            "bzip2",
+            "QlpoOTFBWSZTWRkuyEcAAHr/sf65A4BQA//iOmb/8P7n//AAQA4IABAACDABWVCDKaaFJtR6j1PUGmm0QGhoaAYQaMmTTI9JtQ4yZNGIaaGAmhiaNMmIGRhNGmmEGTDakVG9TJplPUYRoaGQNAAGgDT1AaaG1MEdB4GT2KcdxOtDZdByTfFeb9TklZYNZq+fUekKdkOZAsVl1tkjavxvnSPocKJMkKNsDEisCToOWVlhco3c9bXcTYYYwbRYVOqfZwlAtRpjt+a1YDI6iU7wzkD7KMObOpEjnnckiU4xkd+Kh5pFQ62HjEZGbLwQxhDTVTjfBbKAQRELzXdQqAX67X6xXrjewhHuLC8uLrzVAi1IKXwasz6p2PS9gEw4rmPALnzhwianMEyYs2jK36e1sKTE5HRKbDDZqRGf9FswOI7QzT95ngc1IhGyXaPspSZv0zIWGQ3/Wsbt8LpM+jS+pKUkjOEqhaeWgqOkG7eYgZhWqmNW0SJQkIGoXpXkyk7WdLVHmRpjCXy4XYllkUxNZpLSTiknhBRFYsRlLHSmSX+LuSKcKEgMl2QjgA==",
+            "application/vnd.oci.image.layer.v1.tar+gzip"
+        ),
+        (
+            "xz",
+            "/Td6WFoAAATm1rRGBMDOAoAgIQEWAAAAAAAAAPrQkD7gD/8BRl0AFxfJBlOXkB3hI639Z/BGKdQsiNk3G5TXgSL/9PGJePOERCMsgYG7SRkm7x/x1QlB6IymM77jwvL+3uVRKpSuVgGKzX27zZpn1ukRtdADafE3gYjzDdb3EILHfcfYnJObF/wZoI6eEcxwHyAaZtL37BFqSf3+2TcHRTRzPV38HQlp48FUM29Mo4EvotRBel/qM+pR0IszPtGiWUIkjgiUZOJE4T02wYToEVcYHi87qdxcuGtOdRjMEd9fzz7SCk5QGzBDuQ3huy4/0RsxqQK2WWigdxfN7TA3WNrdfgxNMlMI3WJAJFJDcOUtm4zZcIsi74/RbxAYsGb9W9hApQqcj3RYkkDhv5f2D8P8Pno2PbU2LiDbt/A18/vscNJpIqaKQZT54XU+4o1AqJoOTRq70Jch5aqr9WOh0GpVxWuMEj+6SLNa7QAAAAD6JSwLckZHRQAB6gKAIAAAgk9e27HEZ/sCAAAAAARZWg==",
+            "application/vnd.oci.image.layer.v1.tar+gzip"
+        ),
+        (
+            "zstd",
+            "KLUv/WQADyULAPYQPS4wpWobgFwKQ0EBpSp+u9FNwHgoQ3QPVHpuXX5hRQAZQ3b7u0ka1MClXAsMRigFLAAwADAAHAuj3FXRUI3Q3NnSq4G8GXrP55G7fC9G7YDP3d2lnA2hdHe+23VYre9xcAHURa8PYTZzX7OMOgujCBQDzDxxyWQkAMwfZn7MzODuhsYoNEUTmBcsUBDQ9d8DoX2SqdIzNiD0Byd8SAeBxBcj+JhR5K3qWu2OrfnFKT06sN+hT9noQgAJxrDow4YXCv5ZZa9B5wJhtl+iqrSyr72d7rGxqUyUCaYhsKF9LKFq4Xg6Go00WaSIs/fSzSEwTJTJRQoqINCCESot0AP9aStwTQE7yVZtYwOo0gncTxYGEANguPxOkIEsqTv/OIidGSI7vcFQtzscQMZwC9CETE0F6ZS/wbettQ2eUSP+Tl5eC86wlUjBqPmwIUckkFRXYBzNB6BJDAltmBw4N9auySUBAxjqzA==",
+            "application/vnd.oci.image.layer.v1.tar+zstd"
+        ),
+    ]
+
+    @Test(
+        "a compressed body reserializes with the diff_id reflecting real content, not compressed bytes",
+        arguments: reserializeFixtures)
+    func reserializedCompressionUsesRealContentForDiffID(fixtureCase: (format: String, base64: String, expectedMediaType: String)) async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let content = "reserialize round-trip\n"
+        let compressedPath = fixture.root.appendingPathComponent("import-\(fixtureCase.format).tar")
+        try #require(Data(base64Encoded: fixtureCase.base64)).write(to: compressedPath)
+
+        _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+            tarPath: compressedPath,
+            ociLayoutPath: fixture.ociLayoutDir,
+            platform: Platform(arch: "arm64", os: "linux"),
+            config: SynthesizedImageConfig(),
+            message: nil,
+            reference: nil,
+            logger: fixture.logger
+        )
+
+        let manifest = try fixture.manifest(try fixture.index().manifests[0])
+        #expect(manifest.mediaType == "application/vnd.oci.image.manifest.v1+json")
+        #expect(manifest.layers[0].mediaType == fixtureCase.expectedMediaType)
+
+        let layerData = try fixture.blobData(manifest.layers[0].digest)
+        let extractDir = fixture.root.appendingPathComponent("extracted-\(fixtureCase.format)")
+        let layerPath = fixture.root.appendingPathComponent("layer-\(fixtureCase.format).tar")
+        try layerData.write(to: layerPath)
+        try ArchiveUtility.extract(tarPath: layerPath, to: extractDir)
+        #expect(try String(contentsOf: extractDir.appendingPathComponent("hello.txt"), encoding: .utf8) == content)
+    }
+
+    @Test("a zip body is rejected instead of silently hashed as raw bytes")
+    func zipBodyIsRejectedCleanly() async throws {
+        try assertForeignFormatRejected(magic: [0x50, 0x4b, 0x03, 0x04], expectedFormat: "zip")
+    }
+
+    @Test("a 7z body is rejected instead of silently hashed as raw bytes")
+    func sevenZipBodyIsRejectedCleanly() async throws {
+        try assertForeignFormatRejected(magic: [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c], expectedFormat: "7z")
+    }
+
+    @Test("a rar body is rejected instead of silently hashed as raw bytes")
+    func rarBodyIsRejectedCleanly() async throws {
+        try assertForeignFormatRejected(magic: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07], expectedFormat: "rar")
+    }
+
+    @Test("an ar body is rejected instead of silently hashed as raw bytes")
+    func arBodyIsRejectedCleanly() async throws {
+        try assertForeignFormatRejected(magic: Array("!<arch>\n".utf8), expectedFormat: "ar")
+    }
+
+    @Test("a cpio body is rejected instead of silently hashed as raw bytes")
+    func cpioBodyIsRejectedCleanly() async throws {
+        try assertForeignFormatRejected(magic: Array("070701".utf8), expectedFormat: "cpio")
+    }
+
+    @Test("an iso9660 body is rejected instead of silently hashed as raw bytes")
+    func iso9660BodyIsRejectedCleanly() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let bodyPath = fixture.root.appendingPathComponent("import.tar")
+        var bytes = Data(repeating: 0, count: 32769 + 5)
+        bytes.replaceSubrange(32769..<32774, with: Data("CD001".utf8))
+        try bytes.write(to: bodyPath)
+
+        try assertRejected(bodyPath: bodyPath, fixture: fixture, expectedFormat: "iso9660")
+    }
+
+    private func assertForeignFormatRejected(magic: [UInt8], expectedFormat: String) throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let bodyPath = fixture.root.appendingPathComponent("import.tar")
+        try Data(magic + [UInt8](repeating: 0, count: 512)).write(to: bodyPath)
+
+        try assertRejected(bodyPath: bodyPath, fixture: fixture, expectedFormat: expectedFormat)
+    }
+
+    private func assertRejected(bodyPath: URL, fixture: ImportFixture, expectedFormat: String) throws {
+        do {
+            _ = try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: bodyPath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger
+            )
+            Issue.record("expected \(expectedFormat) import to be rejected")
+        } catch ContainerImageUtility.Error.invalidTarball(let reason) {
+            #expect(reason.contains(expectedFormat))
+        }
+    }
+
+    @Test("an empty request body fails cleanly")
+    func emptyBodyFailsCleanly() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let emptyPath = fixture.root.appendingPathComponent("empty.tar")
+        try Data().write(to: emptyPath)
+
+        #expect(throws: ContainerImageUtility.Error.self) {
+            try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: emptyPath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger
+            )
+        }
+    }
+
+    @Test("a malformed (non-tar) request body fails cleanly")
+    func malformedBodyFailsCleanly() async throws {
+        let fixture = try ImportFixture()
+        defer { fixture.cleanUp() }
+
+        let garbagePath = fixture.root.appendingPathComponent("garbage.tar")
+        try Data(repeating: 0xFF, count: 512).write(to: garbagePath)
+
+        #expect(throws: ContainerImageUtility.Error.self) {
+            try ContainerImageUtility.buildSingleLayerOCILayout(
+                tarPath: garbagePath,
+                ociLayoutPath: fixture.ociLayoutDir,
+                platform: Platform(arch: "arm64", os: "linux"),
+                config: SynthesizedImageConfig(),
+                message: nil,
+                reference: nil,
+                logger: fixture.logger
+            )
+        }
+    }
+}
+
+private struct ImportFixture {
+    let root: URL
+    let rootfsDir: URL
+    let ociLayoutDir: URL
+    let logger = Logger(label: "test")
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent("import-fixture-\(UUID().uuidString)")
+        rootfsDir = root.appendingPathComponent("rootfs")
+        ociLayoutDir = root.appendingPathComponent("oci-layout")
+        try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: ociLayoutDir, withIntermediateDirectories: true)
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func makeTar(fileContents: String) throws -> URL {
+        try Data(fileContents.utf8).write(to: rootfsDir.appendingPathComponent("hello.txt"))
+        let tarPath = root.appendingPathComponent("import.tar")
+        try ArchiveUtility.create(tarPath: tarPath, from: rootfsDir)
+        return tarPath
+    }
+
+    func index() throws -> Index {
+        try JSONDecoder().decode(Index.self, from: Data(contentsOf: ociLayoutDir.appendingPathComponent("index.json")))
+    }
+
+    func manifest(_ descriptor: Descriptor) throws -> Manifest {
+        try JSONDecoder().decode(Manifest.self, from: blob(descriptor.digest))
+    }
+
+    func config(_ manifest: Manifest) throws -> ContainerizationOCI.Image {
+        try JSONDecoder().decode(ContainerizationOCI.Image.self, from: blob(manifest.config.digest))
+    }
+
+    func rawConfigDict(_ manifest: Manifest) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: blob(manifest.config.digest))
+        return try #require(object as? [String: Any])
+    }
+
+    func blobData(_ digest: String) throws -> Data {
+        try blob(digest)
+    }
+
+    private func blob(_ digest: String) throws -> Data {
+        let hex = digest.replacingOccurrences(of: "sha256:", with: "")
+        return try Data(contentsOf: ociLayoutDir.appendingPathComponent("blobs/sha256/\(hex)"))
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerImageImportTests.swift
@@ -16,14 +16,10 @@ struct ContainerImageImportTests {
         let fixture = try ImportFixture()
         defer { fixture.cleanUp() }
 
-        let tarPath = try fixture.makeTar(fileContents: "hello from import\n")
+        let content = "hello from import\n"
+        let tarPath = try fixture.makeTar(fileContents: content)
         let tarData = try Data(contentsOf: tarPath)
         let expectedDiffID = "sha256:\(tarData.sha256Hex())"
-        // moby's docker import always gzip-compresses an uncompressed input before
-        // storing it (daemon/containerd/image_import.go) — it never stores a plain
-        // tar layer — so the manifest's layer digest is the compressed hash, distinct
-        // from diff_id, which stays the uncompressed hash.
-        let expectedLayerDigest = "sha256:\(tarData.gzip()!.sha256Hex())"
 
         _ = try ContainerImageUtility.buildSingleLayerOCILayout(
             tarPath: tarPath,
@@ -41,8 +37,16 @@ struct ContainerImageImportTests {
 
         let manifest = try fixture.manifest(index.manifests[0])
         #expect(manifest.layers.count == 1)
-        #expect(manifest.layers[0].digest == expectedLayerDigest)
         #expect(manifest.layers[0].mediaType == MediaTypes.imageLayerGzip)
+
+        // Compressed bytes are an implementation detail of the gzip encoder,
+        // so this checks self-consistency and correct decompression instead
+        // of a byte-for-byte match.
+        let layerData = try fixture.blobData(manifest.layers[0].digest)
+        #expect(manifest.layers[0].digest == "sha256:\(layerData.sha256Hex())")
+        let layerPath = fixture.root.appendingPathComponent("layer.tar.gz")
+        try layerData.write(to: layerPath)
+        #expect(try GzipStreamDecoder.sha256OfDecompressedContent(at: layerPath, cap: 10_000_000) == tarData.sha256Hex())
 
         let config = try fixture.config(manifest)
         #expect(config.rootfs.diffIDs == [expectedDiffID])

--- a/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
+++ b/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
@@ -106,6 +106,21 @@ struct DockerfileChangeApplierTests {
         #expect(config.env == ["=value"])
     }
 
+    @Test("an unterminated quote is rejected, matching moby's 'unexpected end of statement'")
+    func envUnterminatedQuoteIsRejected() throws {
+        var config = SynthesizedImageConfig()
+        #expect(throws: DockerfileChangeError.self) {
+            try DockerfileChangeApplier.apply(["ENV FOO=\"bar"], to: &config)
+        }
+    }
+
+    @Test("a trailing unconsumed backslash is silently dropped, not rejected")
+    func envTrailingBackslashIsDropped() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO=bar\\"], to: &config)
+        #expect(config.env == ["FOO=bar"])
+    }
+
     @Test("the legacy LABEL KEY VALUE form takes the whole remainder verbatim")
     func labelLegacyFormTakesWholeRemainder() throws {
         var config = SynthesizedImageConfig()

--- a/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
+++ b/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("DockerfileChangeApplier — docker import --change")
+struct DockerfileChangeApplierTests {
+
+    @Test("CMD in JSON exec form is applied as-is")
+    func cmdExecForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["CMD [\"/app\", \"serve\"]"], to: &config)
+        #expect(config.cmd == ["/app", "serve"])
+    }
+
+    @Test("CMD in shell form is wrapped as /bin/sh -c")
+    func cmdShellForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["CMD /app serve"], to: &config)
+        #expect(config.cmd == ["/bin/sh", "-c", "/app serve"])
+    }
+
+    @Test("ENTRYPOINT in JSON exec form is applied as-is")
+    func entrypointExecForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENTRYPOINT [\"/app\"]"], to: &config)
+        #expect(config.entrypoint == ["/app"])
+    }
+
+    @Test("multiple ENV pairs on one line are all applied")
+    func envMultiplePairs() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO=bar BAZ=qux"], to: &config)
+        #expect(config.env == ["FOO=bar", "BAZ=qux"])
+    }
+
+    @Test("the legacy ENV KEY VALUE form is applied")
+    func envLegacyForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO bar"], to: &config)
+        #expect(config.env == ["FOO=bar"])
+    }
+
+    @Test("a repeated ENV key overwrites in place rather than duplicating")
+    func envOverwritesInPlace() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO=bar", "ENV FOO=baz"], to: &config)
+        #expect(config.env == ["FOO=baz"])
+    }
+
+    @Test("LABEL with a quoted value containing spaces is parsed as one pair")
+    func labelQuotedValue() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["LABEL description=\"two words\""], to: &config)
+        #expect(config.labels == ["description": "two words"])
+    }
+
+    @Test("multiple LABEL pairs on one line are all applied")
+    func labelMultiplePairs() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["LABEL a=1 b=2"], to: &config)
+        #expect(config.labels == ["a": "1", "b": "2"])
+    }
+
+    @Test("EXPOSE without a protocol defaults to tcp")
+    func exposeDefaultsToTcp() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["EXPOSE 8080"], to: &config)
+        #expect(config.exposedPorts == ["8080/tcp"])
+    }
+
+    @Test("EXPOSE with an explicit protocol is kept as given")
+    func exposeExplicitProtocol() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["EXPOSE 53/udp"], to: &config)
+        #expect(config.exposedPorts == ["53/udp"])
+    }
+
+    @Test("EXPOSE accepts multiple ports on one line")
+    func exposeMultiplePorts() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["EXPOSE 8080 53/udp"], to: &config)
+        #expect(config.exposedPorts == ["8080/tcp", "53/udp"])
+    }
+
+    @Test("VOLUME in JSON array form is applied as-is")
+    func volumeJSONForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["VOLUME [\"/data\"]"], to: &config)
+        #expect(config.volumes == ["/data"])
+    }
+
+    @Test("VOLUME in shell form accepts multiple paths")
+    func volumeShellForm() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["VOLUME /data /var/log"], to: &config)
+        #expect(config.volumes == ["/data", "/var/log"])
+    }
+
+    @Test("USER sets the config's user")
+    func userInstruction() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["USER app"], to: &config)
+        #expect(config.user == "app")
+    }
+
+    @Test("WORKDIR sets the config's working directory")
+    func workdirInstruction() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["WORKDIR /srv/app"], to: &config)
+        #expect(config.workingDir == "/srv/app")
+    }
+
+    @Test("an instruction this endpoint does not support (e.g. STOPSIGNAL) is rejected, not silently dropped")
+    func unsupportedInstructionIsRejected() throws {
+        var config = SynthesizedImageConfig()
+        #expect(throws: DockerfileChangeError.self) {
+            try DockerfileChangeApplier.apply(["STOPSIGNAL SIGTERM"], to: &config)
+        }
+    }
+
+    @Test("a genuinely invalid instruction (no value) is rejected")
+    func missingValueIsRejected() throws {
+        var config = SynthesizedImageConfig()
+        #expect(throws: DockerfileChangeError.self) {
+            try DockerfileChangeApplier.apply(["WORKDIR"], to: &config)
+        }
+    }
+
+    @Test("an empty change entry is ignored")
+    func emptyEntryIsIgnored() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["  "], to: &config)
+        #expect(config.cmd == nil)
+        #expect(config.env.isEmpty)
+    }
+}

--- a/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
+++ b/Tests/socktainerTests/Utilities/DockerfileChangeApplierTests.swift
@@ -48,6 +48,71 @@ struct DockerfileChangeApplierTests {
         #expect(config.env == ["FOO=baz"])
     }
 
+    @Test("the legacy ENV KEY VALUE form takes the whole remainder verbatim, even if it contains '='")
+    func envLegacyFormTakesWholeRemainder() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO bar=1 baz=2"], to: &config)
+        #expect(config.env == ["FOO=bar=1 baz=2"])
+    }
+
+    @Test("the legacy ENV form preserves internal whitespace in the value")
+    func envLegacyFormPreservesInternalWhitespace() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV NAME   spaced   out"], to: &config)
+        #expect(config.env == ["NAME=spaced   out"])
+    }
+
+    @Test("a backslash-escaped space in a modern ENV pair is kept literal, not a token separator")
+    func envBackslashEscapedSpace() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV DESC=hello\\ world"], to: &config)
+        #expect(config.env == ["DESC=hello world"])
+    }
+
+    @Test("a backslash-escaped quote inside a quoted ENV value is kept literal")
+    func envBackslashEscapedQuote() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV ESCAPED=\"a\\\"b\""], to: &config)
+        #expect(config.env == ["ESCAPED=a\"b"])
+    }
+
+    @Test("ENV with only a key and no value is rejected")
+    func envSingleTokenIsRejected() throws {
+        var config = SynthesizedImageConfig()
+        #expect(throws: DockerfileChangeError.self) {
+            try DockerfileChangeApplier.apply(["ENV JUSTONE"], to: &config)
+        }
+    }
+
+    @Test("an empty quoted ENV value clears to an empty string, not a parse error")
+    func envEmptyQuotedValue() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV FOO=\"\""], to: &config)
+        #expect(config.env == ["FOO="])
+    }
+
+    @Test("ENV with a blank name in KEY=VALUE form is rejected, matching moby's 'ENV names can not be blank'")
+    func envBlankNameIsRejected() throws {
+        var config = SynthesizedImageConfig()
+        #expect(throws: DockerfileChangeError.self) {
+            try DockerfileChangeApplier.apply(["ENV =value"], to: &config)
+        }
+    }
+
+    @Test("ENV with a blank quoted name in the legacy KEY VALUE form is accepted, unlike KEY=VALUE form")
+    func envBlankNameInLegacyFormIsAccepted() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["ENV \"\" value"], to: &config)
+        #expect(config.env == ["=value"])
+    }
+
+    @Test("the legacy LABEL KEY VALUE form takes the whole remainder verbatim")
+    func labelLegacyFormTakesWholeRemainder() throws {
+        var config = SynthesizedImageConfig()
+        try DockerfileChangeApplier.apply(["LABEL JUSTONE value with spaces"], to: &config)
+        #expect(config.labels == ["JUSTONE": "value with spaces"])
+    }
+
     @Test("LABEL with a quoted value containing spaces is parsed as one pair")
     func labelQuotedValue() throws {
         var config = SynthesizedImageConfig()

--- a/Tests/socktainerTests/Utilities/GzipStreamDecoderTests.swift
+++ b/Tests/socktainerTests/Utilities/GzipStreamDecoderTests.swift
@@ -60,6 +60,87 @@ struct GzipStreamDecoderTests {
             _ = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 10_000_000)
         }
     }
+
+    @Test("a gzip member with no content decodes to an empty digest")
+    func emptyMemberDecodesToEmptyContent() throws {
+        let content = Data()
+        let path = try write(try #require(content.gzip()))
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 1_000_000)
+        #expect(digest == content.sha256Hex())
+    }
+
+    @Test("a DEFLATE stream truncated mid-member is rejected, not silently accepted")
+    func truncatedMemberFailsCleanly() throws {
+        let content = Data(String(repeating: "some real content that needs a truncated stream check. ", count: 200).utf8)
+        let compressed = try #require(content.gzip())
+        let path = try write(compressed.prefix(compressed.count / 2))
+        #expect(throws: (any Error).self) {
+            _ = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 1_000_000)
+        }
+    }
+
+    /// `cat a.gz b.gz > combined.gz` is a valid gzip file per RFC 1952 §2.2 —
+    /// real `gunzip` and Go's `compress/gzip` (moby's own decoder, which
+    /// defaults `Multistream: true`) both decompress it as the concatenation
+    /// of every member's content, not just the first.
+    @Test("concatenated gzip members hash as one continuous decompressed stream")
+    func decodesConcatenatedMembers() throws {
+        let first = Data("first member content\n".utf8)
+        let second = Data("second member content\n".utf8)
+        let third = Data("third member content\n".utf8)
+        var combined = try #require(first.gzip())
+        combined.append(try #require(second.gzip()))
+        combined.append(try #require(third.gzip()))
+
+        let path = try write(combined)
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 10_000_000)
+        #expect(digest == (first + second + third).sha256Hex())
+    }
+
+    /// The multi-member boundary search only re-decodes when there's a
+    /// concrete reason to suspect ambiguity; a lone large member spanning
+    /// several chunks must never pay that cost.
+    @Test("a large single-member gzip decodes without disambiguation overhead")
+    func largeSingleMemberStaysFast() throws {
+        let content = Data((0..<5_000_000).map { UInt8($0 % 251) })
+        let path = try write(try #require(content.gzip()))
+        let start = Date()
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 100_000_000)
+        #expect(-start.timeIntervalSinceNow < 2.0, "a lone large member should skip the boundary search entirely")
+        #expect(digest == content.sha256Hex())
+    }
+
+    @Test("a large member followed by a small member still decodes correctly")
+    func largeMemberFollowedBySmallMember() throws {
+        let large = Data((0..<3_000_000).map { UInt8($0 % 251) })
+        let small = Data("tiny trailing member\n".utf8)
+        var combined = try #require(large.gzip())
+        combined.append(try #require(small.gzip()))
+        let path = try write(combined)
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 100_000_000)
+        #expect(digest == (large + small).sha256Hex())
+    }
+
+    /// Regression for a real failure: a small, HIGHLY compressible first
+    /// member (its whole compressed form well under one read's worth) landed
+    /// in the same chunk read as a large chunk of a second member's own
+    /// compressed bytes. `compression_stream_process` swallowed a big enough
+    /// slice of that second member's DEFLATE stream to reach a false-positive
+    /// `END` deep inside it, converging the (then-buggy) boundary search on
+    /// entirely the wrong length. Low-entropy synthetic data (like
+    /// `largeMemberFollowedBySmallMember`'s mod-251 pattern) doesn't
+    /// reproduce this — it needs content that compresses well, same as a
+    /// real tar of a real filesystem.
+    @Test("a small, highly-compressible member followed by a large member decodes correctly")
+    func smallCompressibleMemberFollowedByLargeMember() throws {
+        let first = Data("repetitive, highly compressible content. ".repeated(3000).utf8)
+        let second = Data((0..<2_000_000).map { UInt8(($0 / 37) % 256) })
+        var combined = try #require(first.gzip())
+        combined.append(try #require(second.gzip()))
+        let path = try write(combined)
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 100_000_000)
+        #expect(digest == (first + second).sha256Hex())
+    }
 }
 
 extension String {

--- a/Tests/socktainerTests/Utilities/GzipStreamDecoderTests.swift
+++ b/Tests/socktainerTests/Utilities/GzipStreamDecoderTests.swift
@@ -1,0 +1,69 @@
+import CryptoKit
+import DataCompression
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("GzipStreamDecoder")
+struct GzipStreamDecoderTests {
+
+    private func write(_ data: Data) throws -> URL {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gz")
+        try data.write(to: path)
+        return path
+    }
+
+    /// Rebuilds a `DataCompression`-produced gzip's header with the FNAME
+    /// flag set and a filename spliced in, leaving the DEFLATE payload and
+    /// trailer untouched — exercises RFC 1952's optional-field handling
+    /// without depending on the system `gzip` binary being present.
+    private func withEmbeddedFilename(_ gzipped: Data, name: String) -> Data {
+        var result = Data(gzipped.prefix(10))
+        result[3] = 0x08  // FLG: FNAME
+        result.append(contentsOf: name.utf8)
+        result.append(0)
+        result.append(gzipped.suffix(from: gzipped.startIndex + 10))
+        return result
+    }
+
+    @Test("decompressed content hashes the same as DataCompression's gunzip")
+    func matchesWholeBufferDecompression() throws {
+        let content = Data("hello streaming gzip world, repeated. ".repeated(500).utf8)
+        let path = try write(try #require(content.gzip()))
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 10_000_000)
+        #expect(digest == content.sha256Hex())
+    }
+
+    @Test("a gzip header with an embedded filename (FNAME) is parsed correctly")
+    func handlesEmbeddedFilename() throws {
+        let content = Data("content behind an FNAME-bearing header".utf8)
+        let plain = try #require(content.gzip())
+        let path = try write(withEmbeddedFilename(plain, name: "original.tar"))
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 10_000_000)
+        #expect(digest == content.sha256Hex())
+    }
+
+    @Test("a highly-compressible payload exceeding the cap is rejected mid-stream")
+    func rejectsCompressionBomb() throws {
+        let content = Data(repeating: 0, count: 1 << 20)  // 1 MiB of zeros compresses to ~1 KB
+        let path = try write(try #require(content.gzip()))
+        #expect(throws: GzipStreamDecoder.Error.exceedsCap) {
+            _ = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 1000)
+        }
+    }
+
+    @Test("a non-gzip file is rejected as an invalid header")
+    func rejectsNonGzipInput() throws {
+        let path = try write(Data(repeating: 0xFF, count: 64))
+        #expect(throws: GzipStreamDecoder.Error.invalidHeader) {
+            _ = try GzipStreamDecoder.sha256OfDecompressedContent(at: path, cap: 10_000_000)
+        }
+    }
+}
+
+extension String {
+    fileprivate func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/Tests/socktainerTests/Utilities/GzipStreamEncoderTests.swift
+++ b/Tests/socktainerTests/Utilities/GzipStreamEncoderTests.swift
@@ -1,0 +1,90 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("GzipStreamEncoder")
+struct GzipStreamEncoderTests {
+    private func write(_ data: Data) throws -> URL {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try data.write(to: path)
+        return path
+    }
+
+    /// The real correctness bar: not "does my own decoder accept its own
+    /// encoder's output" (circular), but does the system `gzip` binary — a
+    /// completely independent implementation — accept it and recover the
+    /// exact original bytes.
+    private func realGunzipDecodes(_ path: URL) throws -> Data {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/gzip")
+        process.arguments = ["-dc", path.path]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        let output = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        try #require(process.terminationStatus == 0)
+        return output
+    }
+
+    @Test("real gunzip decodes the output back to the exact original content")
+    func realGunzipRoundTrip() throws {
+        let content = Data(String(repeating: "streamed gzip encoder content, repeated many times. ", count: 400).utf8)
+        let sourcePath = try write(content)
+        let destinationPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let result = try GzipStreamEncoder.compressFile(at: sourcePath, to: destinationPath)
+
+        #expect(try realGunzipDecodes(destinationPath) == content)
+        #expect(result.uncompressedDigest == content.sha256Hex())
+    }
+
+    @Test("the reported compressed digest and size match the actual written file")
+    func compressedDigestIsSelfConsistent() throws {
+        let content = Data("some layer content".utf8)
+        let sourcePath = try write(content)
+        let destinationPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let result = try GzipStreamEncoder.compressFile(at: sourcePath, to: destinationPath)
+
+        let written = try Data(contentsOf: destinationPath)
+        #expect(result.compressedDigest == written.sha256Hex())
+        #expect(result.compressedSize == written.count)
+    }
+
+    @Test("an empty source file encodes to a valid, empty gzip stream")
+    func emptySourceEncodesCorrectly() throws {
+        let sourcePath = try write(Data())
+        let destinationPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let result = try GzipStreamEncoder.compressFile(at: sourcePath, to: destinationPath)
+
+        #expect(try realGunzipDecodes(destinationPath).isEmpty)
+        #expect(result.uncompressedDigest == Data().sha256Hex())
+    }
+
+    @Test("a multi-chunk source streams and decodes correctly, matching moby's own streaming encoder")
+    func largeSourceStreamsCorrectly() throws {
+        let content = Data((0..<3_000_000).map { UInt8($0 % 251) })
+        let sourcePath = try write(content)
+        let destinationPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let result = try GzipStreamEncoder.compressFile(at: sourcePath, to: destinationPath)
+
+        #expect(try realGunzipDecodes(destinationPath) == content)
+        #expect(result.uncompressedDigest == content.sha256Hex())
+    }
+
+    @Test("the encoded output round-trips through this codebase's own streaming decoder")
+    func roundTripsThroughOwnDecoder() throws {
+        let content = Data("round trip through GzipStreamDecoder".utf8)
+        let sourcePath = try write(content)
+        let destinationPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        _ = try GzipStreamEncoder.compressFile(at: sourcePath, to: destinationPath)
+        let digest = try GzipStreamDecoder.sha256OfDecompressedContent(at: destinationPath, cap: 10_000_000)
+        #expect(digest == content.sha256Hex())
+    }
+}


### PR DESCRIPTION
## Summary

Implements `docker import` (`POST /images/create?fromSrc=-`): a tar streamed in the request body becomes a single-layer image, with optional `repo:tag`, `message` (history comment), and `--change` (Dockerfile-instruction-style config edits).

## Changes

- **`fromSrc=-`** (request body tar) is implemented; a URL `fromSrc` is rejected with a clear error rather than half-implemented (no outbound HTTP client exists anywhere in this codebase).
- **`--change`** supports CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, USER, VOLUME, WORKDIR (exec/shell forms where applicable). ONBUILD/STOPSIGNAL/HEALTHCHECK are rejected with a clear error rather than silently dropped.
- **Compression handling matches moby exactly** (verified against `daemon/containerd/image_import.go`): gzip and zstd inputs are stored as-is; bzip2/xz are decompressed and re-compressed to gzip; an uncompressed input is *also* gzip-compressed before storage — moby never stores a plain uncompressed layer.
  - bzip2/xz decompression reconstructs a canonical tar via `ArchiveReader` + `ArchiveWriter` (libarchive can decode these codecs; the vendored `DataCompression` package only handles gzip).
  - zstd is decompressed only to compute `diff_id` (via the vendored `ArchiveReader.decompressZstd`) and stored unmodified, matching moby.
- **Non-tar archive formats** a client might mistakenly import (zip, 7z, rar, ar, cpio, iso9660) are rejected by signature check before the expensive structural validation runs, rather than silently hashed as opaque bytes into a corrupt, unrunnable image.
- **`repo`/`tag` validation (including digest-reference rejection) runs before the request body is read at all**, matching moby's exact ordering (`api/server/router/image/image_routes.go`) — a request with a bad reference fails fast instead of buffering a potentially large body first.
- The digest-reference check matches any digest algorithm (`@algorithm:hex`), not just sha256.
- Untagged imports fall in with the existing `untagged@<digest>` dangling-image convention for free, since import reuses the same `ImageStore.load(from:)` call `docker load` already uses.

`docs/API_PARITY.md` is intentionally not part of this PR — it lives on a separate local branch.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (734 tests)
- [x] Unit tests: single-layer OCI layout synthesis (diff_id, repo:tag annotation, message→history, `--change` application), `DockerfileChangeApplier` (16 cases), a real `ImageStore` round-trip (tagged/untagged/default-tag/digest-rejected), query-param decoding (repeated `changes=` keys), compression classification (gzip/bzip2/xz/zstd/foreign-format rejection, each mutation-verified), and a route-level fail-fast test proving the request body is never read when the reference is a digest (mutation-verified: fails on all assertions with the fix reverted)
- [x] Live-verified against a release build on the real 1.1.0 runtime: bare import, `repo:tag`, `message`, every `--change` instruction, non-default `platform`, all four compression forms via a real ~4.4MB busybox rootfs (confirmed correct mediaType/diff_id *and* that the resulting images actually run — `docker run` executing the real busybox binary), the export|import round-trip, and untagged-import dangling-image integration

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)