### PR TITLE
fix(logs): honor tail=N and reject a request that attaches to neither stream

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -17,9 +17,23 @@ extension ContainerLogsRoute {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
+            // moby validates the stream parameters before resolving the container:
+            // a request that attaches to neither stream is a 400. The docker CLI
+            // always sends stdout=1&stderr=1, so neither is a client error, not a
+            // request for the default.
+            let wantStdout = MobyBool.queryValue(req.query["stdout"] as String?)
+            let wantStderr = MobyBool.queryValue(req.query["stderr"] as String?)
+            guard wantStdout || wantStderr else {
+                throw Abort(.badRequest, reason: "Bad parameters: you must choose at least one stream")
+            }
+
             guard let container = try await client.getContainer(id: id) else {
                 throw Abort(.notFound, reason: "Container not found")
             }
+
+            // `tail=<N>` limits the backlog to the last N lines; "all" (the
+            // default) or an unparseable value streams the whole backlog.
+            let tail = ContainerLogsRoute.parseTail(req.query["tail"] as String?)
 
             // Containers started with a TTY produce a raw, unmultiplexed log
             // stream; non-TTY containers use Docker's 8-byte stdcopy framing.
@@ -53,15 +67,30 @@ extension ContainerLogsRoute {
                     }
 
                     do {
-                        // Read initial logs
-                        while true {
-                            let data = try fileHandle.read(upToCount: 4096)
-                            guard let data, !data.isEmpty else { break }
-                            buffer.append(data)
-
-                            // Process complete frames from buffer
-                            buffer = ContainerLogsRoute.processDockerLogFrames(from: buffer, ttyMode: isTTY, timestamps: timestamps) { outputBuffer in
+                        if let tail {
+                            // Apple Container's log API is a forward byte stream with
+                            // no reverse-seek. Read it through, trimming to the last
+                            // `tail` lines after each chunk so memory stays bounded to
+                            // ~tail lines rather than the whole (unrotated) log.
+                            var backlog = Data()
+                            while let data = try fileHandle.read(upToCount: 4096), !data.isEmpty {
+                                backlog.append(data)
+                                backlog = ContainerLogsRoute.lastLines(backlog, count: tail)
+                            }
+                            buffer = ContainerLogsRoute.processDockerLogFrames(from: backlog, ttyMode: isTTY, timestamps: timestamps) { outputBuffer in
                                 _ = writer.write(.buffer(outputBuffer))
+                            }
+                        } else {
+                            // Read initial logs
+                            while true {
+                                let data = try fileHandle.read(upToCount: 4096)
+                                guard let data, !data.isEmpty else { break }
+                                buffer.append(data)
+
+                                // Process complete frames from buffer
+                                buffer = ContainerLogsRoute.processDockerLogFrames(from: buffer, ttyMode: isTTY, timestamps: timestamps) { outputBuffer in
+                                    _ = writer.write(.buffer(outputBuffer))
+                                }
                             }
                         }
 
@@ -121,6 +150,38 @@ extension ContainerLogsRoute {
                 body: body
             )
         }
+    }
+
+    /// Parses moby's `tail` query value. "all", an absent value, or anything
+    /// non-numeric means the whole backlog (nil); a non-negative integer means
+    /// only that many trailing lines.
+    static func parseTail(_ value: String?) -> Int? {
+        guard let value, !value.isEmpty, value.lowercased() != "all" else { return nil }
+        guard let n = Int(value), n >= 0 else { return nil }
+        return n
+    }
+
+    /// Returns only the last `count` newline-delimited lines of `data`. A
+    /// trailing line with no terminating newline still counts as a line, and a
+    /// single trailing newline is not treated as an extra empty line. `count == 0`
+    /// yields no output.
+    static func lastLines(_ data: Data, count: Int) -> Data {
+        guard count > 0 else { return Data() }
+        guard !data.isEmpty else { return data }
+        // Ignore one trailing newline so "a\nb\n" with count 1 yields "b\n".
+        var searchEnd = data.endIndex
+        if data.last == 0x0A { searchEnd = data.index(before: data.endIndex) }
+        var seen = 0
+        var i = searchEnd
+        while i > data.startIndex {
+            let prev = data.index(before: i)
+            if data[prev] == 0x0A {
+                seen += 1
+                if seen == count { return Data(data[i...]) }
+            }
+            i = prev
+        }
+        return data
     }
 
     static func processDockerLogFrames(from buffer: Data, ttyMode: Bool, timestamps: Bool = false, writeOutput: (ByteBuffer) -> Void) -> Data {

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -68,6 +68,14 @@ extension ContainerLogsRoute {
 
                     do {
                         if let tail {
+                            // tail=0 without follow returns an empty backlog; skip
+                            // reading the log at all. With follow the read-through
+                            // below still runs so the handle reaches EOF and the
+                            // follow loop emits only new lines.
+                            if tail == 0, !follow {
+                                finish()
+                                return
+                            }
                             // Apple Container's log API is a forward byte stream with
                             // no reverse-seek. Read it through, keeping only the last
                             // `tail` lines so memory stays bounded to ~2x tail lines

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -69,16 +69,24 @@ extension ContainerLogsRoute {
                     do {
                         if let tail {
                             // Apple Container's log API is a forward byte stream with
-                            // no reverse-seek. Read it through, trimming to the last
-                            // `tail` lines after each chunk so memory stays bounded to
-                            // ~tail lines rather than the whole (unrotated) log.
-                            var backlog = Data()
-                            while let data = try fileHandle.read(upToCount: 4096), !data.isEmpty {
-                                backlog.append(data)
-                                backlog = ContainerLogsRoute.lastLines(backlog, count: tail)
-                            }
+                            // no reverse-seek. Read it through, keeping only the last
+                            // `tail` lines so memory stays bounded to ~2x tail lines
+                            // rather than the whole (unrotated) log.
+                            let backlog = try ContainerLogsRoute.tailBacklog(tail: tail) { try fileHandle.read(upToCount: 4096) }
+                            var frames: [ByteBuffer] = []
                             buffer = ContainerLogsRoute.processDockerLogFrames(from: backlog, ttyMode: isTTY, timestamps: timestamps) { outputBuffer in
-                                _ = writer.write(.buffer(outputBuffer))
+                                frames.append(outputBuffer)
+                            }
+                            // Await each write so a client disconnect aborts the
+                            // response instead of queueing the whole window (the
+                            // same contract as the follow loop below).
+                            for frame in frames {
+                                do {
+                                    try await writer.write(.buffer(frame)).get()
+                                } catch {
+                                    finish()
+                                    return
+                                }
                             }
                         } else {
                             // Read initial logs
@@ -165,6 +173,25 @@ extension ContainerLogsRoute {
     /// trailing line with no terminating newline still counts as a line, and a
     /// single trailing newline is not treated as an extra empty line. `count == 0`
     /// yields no output.
+    /// Reads a stream through chunk by chunk via `read` (nil or empty means
+    /// EOF) and returns only its last `tail` lines. The window is trimmed once
+    /// it holds twice the wanted lines, not on every chunk, so each byte is
+    /// scanned O(1) times amortized even for a huge `tail` over a huge log.
+    static func tailBacklog(tail: Int, read: () throws -> Data?) rethrows -> Data {
+        var backlog = Data()
+        var newlines = 0
+        let trimAt = max(tail, 1) > Int.max / 2 ? Int.max : max(tail, 1) * 2
+        while let data = try read(), !data.isEmpty {
+            newlines += data.reduce(0) { $1 == 0x0A ? $0 + 1 : $0 }
+            backlog.append(data)
+            if newlines >= trimAt {
+                backlog = lastLines(backlog, count: tail)
+                newlines = tail
+            }
+        }
+        return lastLines(backlog, count: tail)
+    }
+
     static func lastLines(_ data: Data, count: Int) -> Data {
         guard count > 0 else { return Data() }
         guard !data.isEmpty else { return data }

--- a/Tests/socktainerTests/Routes/ContainerLogsTailTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerLogsTailTests.swift
@@ -1,0 +1,104 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// `docker logs --tail N` must return only the last N lines of the backlog.
+/// Apple Container's log API is a forward byte stream, so socktainer slices the
+/// tail itself via `lastLines`. `parseTail` maps moby's `tail` query value to a
+/// line count (or nil for "all").
+@Suite("ContainerLogsRoute — tail")
+struct ContainerLogsTailTests {
+
+    private func lastLines(_ s: String, _ count: Int) -> String {
+        String(decoding: ContainerLogsRoute.lastLines(Data(s.utf8), count: count), as: UTF8.self)
+    }
+
+    @Test("tail keeps only the last N newline-terminated lines")
+    func keepsLastN() {
+        #expect(lastLines("a\nb\nc\nd\n", 2) == "c\nd\n")
+        #expect(lastLines("a\nb\nc\nd\n", 1) == "d\n")
+        #expect(lastLines("a\nb\nc\nd\n", 3) == "b\nc\nd\n")
+    }
+
+    @Test("A trailing line without a newline still counts as a line")
+    func trailingPartialLineCounts() {
+        #expect(lastLines("a\nb\nc", 2) == "b\nc")
+        #expect(lastLines("a\nb\nc", 1) == "c")
+    }
+
+    @Test("Asking for more lines than exist returns everything")
+    func moreThanAvailable() {
+        #expect(lastLines("a\nb\n", 10) == "a\nb\n")
+        #expect(lastLines("only-one-line", 5) == "only-one-line")
+    }
+
+    @Test("tail=0 yields no output; empty input stays empty")
+    func zeroAndEmpty() {
+        #expect(lastLines("a\nb\nc\n", 0) == "")
+        #expect(lastLines("", 3) == "")
+    }
+
+    @Test("parseTail maps the moby query value to a line count or nil for all")
+    func parseTailValues() {
+        #expect(ContainerLogsRoute.parseTail(nil) == nil)
+        #expect(ContainerLogsRoute.parseTail("all") == nil)
+        #expect(ContainerLogsRoute.parseTail("ALL") == nil)
+        #expect(ContainerLogsRoute.parseTail("garbage") == nil)
+        #expect(ContainerLogsRoute.parseTail("-1") == nil)
+        #expect(ContainerLogsRoute.parseTail("5") == 5)
+        #expect(ContainerLogsRoute.parseTail("0") == 0)
+    }
+
+    @Test(
+        "Attaching to neither stdout nor stderr is a 400",
+        arguments: ["stdout=0&stderr=0", "stdout=false&stderr=false"])
+    func neitherStreamIs400(query: String) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: ContainerLogsRoute(client: LogsContainerMock()))
+
+            try await app.testing().test(.GET, "/v1.51/containers/ctr/logs?\(query)") { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("Bad parameters: you must choose at least one stream"))
+            }
+        }
+    }
+}
+
+/// Mock whose getContainer returns a running snapshot so the logs route reaches
+/// the stdout/stderr validation before touching Apple Container.
+private struct LogsContainerMock: ClientContainerProtocol {
+    private var snapshot: ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0))
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0))
+        let config = ContainerConfiguration(id: "ctr", image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: .running, networks: [])
+    }
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerLogsTailTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerLogsTailTests.swift
@@ -44,6 +44,31 @@ struct ContainerLogsTailTests {
         #expect(lastLines("", 3) == "")
     }
 
+    @Test("tailBacklog over chunked reads equals lastLines over the whole stream", arguments: [1, 2, 3, 7])
+    func tailBacklogMatchesOneShot(chunkSize: Int) throws {
+        // 30 lines through tiny chunks forces many trim cycles, including
+        // chunk boundaries that split lines mid-way.
+        let whole = (1...30).map { "line \($0)" }.joined(separator: "\n") + "\n"
+        let bytes = Array(whole.utf8)
+        for tail in [0, 1, 2, 5, 29, 30, 100] {
+            var offset = 0
+            let streamed = try ContainerLogsRoute.tailBacklog(tail: tail) {
+                guard offset < bytes.count else { return nil }
+                let next = min(offset + chunkSize, bytes.count)
+                defer { offset = next }
+                return Data(bytes[offset..<next])
+            }
+            #expect(streamed == ContainerLogsRoute.lastLines(Data(whole.utf8), count: tail), "tail=\(tail)")
+        }
+    }
+
+    @Test("tailBacklog keeps a trailing line with no newline")
+    func tailBacklogTrailingPartial() throws {
+        var chunks: [Data?] = [Data("a\nb\nc\nlast-par".utf8), Data("tial".utf8), nil]
+        let result = try ContainerLogsRoute.tailBacklog(tail: 2) { chunks.removeFirst() }
+        #expect(String(decoding: result, as: UTF8.self) == "c\nlast-partial")
+    }
+
     @Test("parseTail maps the moby query value to a line count or nil for all")
     func parseTailValues() {
         #expect(ContainerLogsRoute.parseTail(nil) == nil)


### PR DESCRIPTION
## Summary

`GET /containers/{id}/logs` ignored the `tail` parameter and always streamed the whole backlog, and it did not reject a request that attaches to neither `stdout` nor `stderr`.

moby returns only the last N lines for `tail=N` (with `all`, an absent value, a negative value, or a non-numeric value meaning the whole backlog), and returns a 400 ("Bad parameters: you must choose at least one stream") when both streams are off. The docker CLI always sends `stdout=1&stderr=1`, so a request for neither is a client error, validated before the container is resolved.

Apple Container's log API is a forward byte stream with no reverse-seek, so the backlog is trimmed to the last N lines chunk by chunk as it is read, keeping memory bounded to about `tail` lines rather than buffering the entire (unrotated) log. `tail` applies to the initial backlog only; `follow` is unchanged, matching moby.

## Before

```console
$ docker run --name tail-demo alpine sh -c 'for i in 1 2 3 4 5; do echo "line $i"; done'
...
$ docker logs --tail 2 tail-demo
line 1
line 2
line 3
line 4
line 5          # --tail 2 ignored, whole log streamed

$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' --unix-socket ~/.socktainer/container.sock 'http://localhost/v1.51/containers/tail-demo/logs?stdout=0&stderr=0'
HTTP 200        # whole log streamed with both streams off
```

## After

```console
$ docker logs --tail 2 tail-demo
line 4
line 5

$ docker logs --tail 0 tail-demo    # empty, like moby

$ docker logs tail-demo             # no tail: whole backlog, unchanged
line 1
line 2
line 3
line 4
line 5

$ curl -s -w '\nHTTP %{http_code}\n' --unix-socket ~/.socktainer/container.sock 'http://localhost/v1.51/containers/tail-demo/logs?stdout=0&stderr=0'
{"message":"Bad parameters: you must choose at least one stream",...}
HTTP 400
```

## Testing

- New unit tests in `Tests/socktainerTests/Routes/ContainerLogsTailTests.swift`:
  - `lastLines` keeps the last N newline-delimited lines, counts a trailing line with no newline, handles `count == 0`, empty input, and asking for more than exist
  - `parseTail` maps `all`/absent/non-numeric/negative to "all" (nil) and a non-negative integer to that count
  - a request with `stdout=0&stderr=0` (or `false`/`false`) returns 400
- Under the previous implementation the neither-stream request reaches the log stream and 500s instead of returning 400.
- `make fmt`, `make build`, `make test` (700 tests) pass.
