### PR TITLE
fix: report unavailable Apple Container service correctly

### DIFF
--- a/Sources/socktainer/Utilities/AppleContainerUtility.swift
+++ b/Sources/socktainer/Utilities/AppleContainerUtility.swift
@@ -1,5 +1,6 @@
 import ContainerAPIClient
 import Containerization
+import ContainerizationError
 import Foundation
 
 public func getLinuxDefaultKernelName() async throws -> String {
@@ -31,11 +32,10 @@ public struct AppleContainerVersionCheck {
     }
 
     /// Error types for version checking
-    public enum VersionCheckError: Error, LocalizedError {
+    public enum VersionCheckError: Error, LocalizedError, Equatable {
         case incompatibleVersion(detected: String, expected: String)
         case versionDetectionFailed(String)
-        case xpcConnectionError
-        case notStartedError
+        case appleContainerUnavailable
 
         public var errorDescription: String? {
             switch self {
@@ -44,10 +44,9 @@ public struct AppleContainerVersionCheck {
                     "Apple Container version mismatch: detected \(detected) but this socktainer binary requires \(expected). This version incompatibility will cause XPC connection errors. Skip the check using --no-check-compatibility flag."
             case .versionDetectionFailed(let reason):
                 return "Failed to detect Apple Container version: \(reason)"
-            case .xpcConnectionError:
-                return "XPC connection error detected. This usually indicates an incompatible Apple Container version."
-            case .notStartedError:
-                return "Ensure container system service has been started with `container system start`."
+            case .appleContainerUnavailable:
+                return
+                    "Unable to connect to the Apple Container service. Check its status with `container system status` and start it with `container system start` if necessary."
             }
         }
 
@@ -55,10 +54,15 @@ public struct AppleContainerVersionCheck {
 
     /// Checks if the installed Apple Container version is compatible
     public static func checkCompatibility() async throws {
+        try await checkCompatibility {
+            try await ClientHealthCheck.ping(timeout: .seconds(2)).apiServerVersion
+        }
+    }
+
+    static func checkCompatibility(fetchAPIServerVersion: @Sendable () async throws -> String) async throws {
         do {
             // Attempt to get version from Apple Container daemon
-            let healthCheck = try await ClientHealthCheck.ping(timeout: .seconds(2))
-            let serverVersionFull = healthCheck.apiServerVersion
+            let serverVersionFull = try await fetchAPIServerVersion()
             let serverVersion = extractSemver(from: serverVersionFull) ?? serverVersionFull
 
             // Check if client and server versions are compatible
@@ -72,18 +76,21 @@ public struct AppleContainerVersionCheck {
 
         } catch let error as VersionCheckError {
             throw error
+        } catch let error as ContainerizationError where isAppleContainerUnavailable(error) {
+            throw VersionCheckError.appleContainerUnavailable
         } catch {
-            // Check for XPC connection issues which indicate version incompatibility
-            if error.localizedDescription.contains("XPC connection") || error.localizedDescription.contains("Connection interrupted") {
-                throw VersionCheckError.xpcConnectionError
-            }
-            if error.localizedDescription.contains("The operation couldn’t be completed") {
-                throw VersionCheckError.notStartedError
-            }
-
             // Other errors are version detection failures
             throw VersionCheckError.versionDetectionFailed(error.localizedDescription)
         }
+    }
+
+    private static func isAppleContainerUnavailable(_ error: ContainerizationError) -> Bool {
+        if error.isCode(.interrupted) || error.isCode(.timeout) {
+            return true
+        }
+
+        // XPCClient reports response timeouts as internalError in Apple Container 1.1.0.
+        return error.isCode(.internalError) && error.message.hasPrefix("XPC timeout for request")
     }
 
     /// Performs compatibility check with user-friendly output and exit if it fails

--- a/Tests/socktainerTests/Utilities/AppleContainerVersionCheckTests.swift
+++ b/Tests/socktainerTests/Utilities/AppleContainerVersionCheckTests.swift
@@ -1,0 +1,101 @@
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("Apple Container version check")
+struct AppleContainerVersionCheckTests {
+
+    @Test("interrupted connections report the Apple Container service as unavailable")
+    func interruptedConnection() async {
+        let error = await capturedError {
+            throw ContainerizationError(.interrupted, message: "XPC connection error: Connection invalid")
+        }
+
+        #expect(error == .appleContainerUnavailable)
+        #expect(error?.localizedDescription.contains("container system status") == true)
+        #expect(error?.localizedDescription.contains("container system start") == true)
+        #expect(error?.localizedDescription.contains("incompatible") == false)
+    }
+
+    @Test("XPC response timeouts report the Apple Container service as unavailable")
+    func xpcResponseTimeout() async {
+        let error = await capturedError {
+            throw ContainerizationError(
+                .internalError,
+                message: "XPC timeout for request to com.apple.container.apiserver/Ping"
+            )
+        }
+
+        #expect(error == .appleContainerUnavailable)
+    }
+
+    @Test("typed timeouts report the Apple Container service as unavailable")
+    func typedTimeout() async {
+        let error = await capturedError {
+            throw ContainerizationError(.timeout, message: "Connection timed out")
+        }
+
+        #expect(error == .appleContainerUnavailable)
+    }
+
+    @Test("other internal errors remain version detection failures")
+    func otherInternalError() async {
+        let underlyingError = ContainerizationError(
+            .internalError,
+            message: "failed to decode apiServerVersion in health check"
+        )
+        let error = await capturedError {
+            throw underlyingError
+        }
+
+        #expect(error == .versionDetectionFailed(underlyingError.localizedDescription))
+    }
+
+    @Test("a reachable service with the wrong version reports the version mismatch")
+    func incompatibleVersion() async {
+        let error = await capturedError {
+            "apiserver version 99.0.0"
+        }
+
+        #expect(
+            error
+                == .incompatibleVersion(
+                    detected: "99.0.0",
+                    expected: getAppleContainerVersion()
+                )
+        )
+    }
+
+    @Test("error message text does not determine the failure classification")
+    func doesNotClassifyLocalizedDescription() async {
+        let underlyingError = NSError(
+            domain: "AppleContainerVersionCheckTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "XPC connection interrupted"]
+        )
+        let error = await capturedError {
+            throw underlyingError
+        }
+
+        #expect(error == .versionDetectionFailed("XPC connection interrupted"))
+    }
+
+    private func capturedError(
+        fetchAPIServerVersion: @escaping @Sendable () async throws -> String
+    ) async -> AppleContainerVersionCheck.VersionCheckError? {
+        do {
+            try await AppleContainerVersionCheck.checkCompatibility(
+                fetchAPIServerVersion: fetchAPIServerVersion
+            )
+            Issue.record("Expected compatibility check to fail")
+            return nil
+        } catch let error as AppleContainerVersionCheck.VersionCheckError {
+            return error
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Report Apple Container service connection failures as service unavailability instead of suggesting an unverified version incompatibility. The error now directs users to inspect and start the Apple Container service.

## Related Issue

N/A

## Changes

- Classify structured interrupted and timeout errors as Apple Container service unavailability
- Handle the XPC response timeout shape emitted by Apple Container 1.1.0 without misclassifying other internal errors
- Replace localized error-string matching with focused error classification and add regression tests

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (700 tests in 128 suites)
- [x] Unit tests added for interrupted connections, XPC and typed timeouts, unrelated internal errors, version mismatches, and misleading localized text
- [x] Manual testing performed with the apiserver job unregistered; the corrected service-unavailable message was shown and the service was restored successfully

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)