### PR TITLE
ci: replace deprecated tmate with direct launchd system-domain bootstrap

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -160,20 +160,24 @@ jobs:
       # at "Testing access to container-apiserver" with an XPC error. tmate
       # was used here to work around that by providing a session whose
       # computed domain happened to work, but tmate is deprecated in Homebrew
-      # (disabled 2026-12-11). Instead: let the first start write the plist,
-      # bootstrap it into the system domain ourselves (Mach lookups chain
-      # gui -> user -> system, so a system-domain service is reachable from
-      # any session; the plist's LimitLoadToSessionType allows System), then
-      # re-run start, which now passes its ping and completes the
-      # init-filesystem and kernel setup it skips on failure.
+      # (disabled 2026-12-11). Instead: when the first start fails, it has
+      # already written the plist - bootstrap it into the system domain
+      # ourselves (Mach lookups chain gui -> user -> system, so a
+      # system-domain service is reachable from any session; the plist's
+      # LimitLoadToSessionType allows System), then re-run start, which now
+      # passes its ping and completes the init-filesystem and kernel setup
+      # it skips on failure. Gated on the first start failing so an eventual
+      # upstream fix doesn't turn the bootstrap into a spurious "already
+      # bootstrapped" error.
       - name: Start container system
         run: |
-          sudo container system start --enable-kernel-install || true
-          PLIST="$(sudo find /var/root "$HOME" -maxdepth 6 \
-            -path '*/com.apple.container/apiserver/apiserver.plist' 2>/dev/null | head -1)"
-          [ -n "$PLIST" ] || { echo "apiserver.plist not found" >&2; exit 1; }
-          sudo launchctl bootstrap system "$PLIST"
-          sudo container system start --enable-kernel-install
+          if ! sudo container system start --enable-kernel-install; then
+            PLIST="$(sudo find /var/root "$HOME" -maxdepth 6 \
+              -path '*/com.apple.container/apiserver/apiserver.plist' 2>/dev/null | head -1)"
+            [ -n "$PLIST" ] || { echo "apiserver.plist not found" >&2; exit 1; }
+            sudo launchctl bootstrap system "$PLIST"
+            sudo container system start --enable-kernel-install
+          fi
           sudo container system status
 
       - name: run socktainer

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -151,43 +151,30 @@ jobs:
       - name: install apple container
         run: sudo installer -pkg container-installer-signed.pkg -target / -verbose
 
-      - name: setup tmate
+      # `container system start` writes the apiserver launchd plist, then
+      # bootstraps it via a launchctl call whose output and exit status it
+      # discards (ServiceManager.register in apple/container). It derives the
+      # target domain from `launchctl managername` + getuid(): under sudo in
+      # a CI session that yields a domain like user/0 that can't be
+      # bootstrapped into, so the registration silently fails and start dies
+      # at "Testing access to container-apiserver" with an XPC error. tmate
+      # was used here to work around that by providing a session whose
+      # computed domain happened to work, but tmate is deprecated in Homebrew
+      # (disabled 2026-12-11). Instead: let the first start write the plist,
+      # bootstrap it into the system domain ourselves (Mach lookups chain
+      # gui -> user -> system, so a system-domain service is reachable from
+      # any session; the plist's LimitLoadToSessionType allows System), then
+      # re-run start, which now passes its ping and completes the
+      # init-filesystem and kernel setup it skips on failure.
+      - name: Start container system
         run: |
-          brew install tmate
-
-      - name: Start internal tmate session and start container system using this tmate session
-        run: |
-          # Start a detached tmate session
-          tmate -S /tmp/tmate.sock new-session -d
-          tmate -S /tmp/tmate.sock wait tmate-ready
-          # skip welcome screen
-          tmate -F -S /tmp/tmate.sock send-keys "q" C-m
-
-          # Send Apple Container commands automatically
-          tmate -S /tmp/tmate.sock send-keys "echo 'Starting Apple Container...'" C-m
-          tmate -S /tmp/tmate.sock send-keys "sudo container system start --enable-kernel-install | tee /tmp/container.log" C-m
-
-          # Loop until 'container system status' returns exit code 1 or timeout (60s)
-          START=$SECONDS
-          TIMEOUT=60
-
-          while [ $((SECONDS - START)) -lt $TIMEOUT ]; do
-            # Capture tmate session output
-            tmate -S /tmp/tmate.sock capture-pane -p > /tmp/container.log
-            cat /tmp/container.log
-
-            # Check container status locally
-            if sudo container system status >/dev/null 2>&1; then
-              # Exit code 0 → container is ready
-              echo "Container is ready. Exiting loop."
-              break
-            else
-              echo "Container not ready yet..."
-            fi
-          done
-
-          # stop tmate session
-          tmate -S /tmp/tmate.sock kill-session
+          sudo container system start --enable-kernel-install || true
+          PLIST="$(sudo find /var/root "$HOME" -maxdepth 6 \
+            -path '*/com.apple.container/apiserver/apiserver.plist' 2>/dev/null | head -1)"
+          [ -n "$PLIST" ] || { echo "apiserver.plist not found" >&2; exit 1; }
+          sudo launchctl bootstrap system "$PLIST"
+          sudo container system start --enable-kernel-install
+          sudo container system status
 
       - name: run socktainer
         run: |


### PR DESCRIPTION
# Pull Request

## Summary
Homebrew has deprecated `tmate` (disabled 2026-12-11), which shows a warning on every integration-test run today and will break the job when the formula is disabled. This replaces the tmate session trick with a direct fix for the underlying problem, which turns out not to involve a pty at all — and drops the startup step from ~2 minutes to ~15 seconds as a side effect.

## Related Issue
None filed; happy to open one if preferred.

## Changes
- Root cause: `container system start` writes the apiserver launchd plist, then bootstraps it via a `launchctl` call whose output **and exit status are both discarded** (`ServiceManager.register` in apple/container). The target domain is derived from `launchctl managername` + `getuid()` — under `sudo` in a CI session that computes a domain (e.g. `user/0`) that can't be bootstrapped into, so registration silently fails and `start` dies at its self-ping with the generic XPC "Connection invalid" error. tmate was never the mechanism; it just happened to provide a session whose computed domain worked. (An empty `log show --predicate 'subsystem == "com.apple.container"'` during the failure confirms the apiserver never launched at all.)
- Fix: run `start` once so it writes the plist, `sudo launchctl bootstrap system <plist>` ourselves — Mach service lookups chain gui → user → system, so a system-domain service is reachable from any session, and the plist's `LimitLoadToSessionType` already allows `System`; unlike upstream's swallowed call, ours surfaces its error output — then re-run `start`, which now passes its ping and completes the init-filesystem/kernel setup it skips on failure.
- Removes the `setup tmate` step and the capture-pane polling loop entirely.

## Testing
- [x] Verified in [Whalebridge](https://github.com/cap10morgan/whalebridge)'s CI, which vendors socktainer and used the identical tmate trick against the same apple/container version this repo pins: with this approach the integration job passes ([run](https://github.com/cap10morgan/whalebridge/actions/runs/30044035004), integration green in 56s), including image pull/list and container create through the Docker API. Also verified the failure modes along the way: bare `container system start`, tmux, and tmux-with-`login` wrappers all fail identically, isolating the launchd domain as the real variable.
- [ ] `make fmt` passes (no formatting drift) — n/a, workflow-only change
- [ ] `make test` passes — n/a, workflow-only change
- [ ] Unit tests added or updated — n/a, workflow-only change
- [x] Manual testing performed (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)