### PR TITLE
fix(containers): preserve real error from create image existence check

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -150,7 +150,7 @@ extension ContainerCreateRoute {
             do {
                 _ = try await ClientImage.get(reference: body.Image, containerSystemConfig: systemConfig)
             } catch {
-                throw Abort(.notFound, reason: "No such image: \(body.Image)")
+                throw ContainerCreateRoute.imageExistenceError(error, image: body.Image)
             }
 
             // Fetch the image; on arm64 hosts fall back to amd64 (Rosetta) when no arm64
@@ -707,6 +707,23 @@ extension ContainerCreateRoute {
         if let net = endpointsConfigKeys.first(where: { !$0.isEmpty && !reservedModes.contains($0) }) { return net }
         if let mode = networkMode, !mode.isEmpty, !reservedModes.contains(mode) { return mode }
         return nil
+    }
+
+    /// Maps an error from the pre-flight image existence check to a client-facing error.
+    ///
+    /// A genuine not-found is reported with Docker's `No such image: <ref>` phrasing,
+    /// which is load-bearing: docker-py raises `ImageNotFound` off that exact text.
+    /// Any other error — most notably a transient `ContainerizationError(.interrupted,
+    /// "XPC connection error: …")` (see issue #130) — is preserved unchanged so its real
+    /// cause reaches the client instead of being mislabeled as a missing image.
+    ///
+    /// Extracted as a pure function so the mapping can be asserted in unit tests without
+    /// driving Apple Container APIs.
+    static func imageExistenceError(_ error: Error, image: String) -> Error {
+        if let containerError = error as? ContainerizationError, containerError.code == .notFound {
+            return Abort(.notFound, reason: "No such image: \(image)")
+        }
+        return error
     }
 
     /// Resolves the process user, preferring an explicit request override over the image

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -10,6 +10,26 @@ import VaporTesting
 
 @testable import socktainer
 
+/// Asserts a create request got past input validation to the pre-flight image stage.
+///
+/// The create handler checks image existence right after validation. The test
+/// environment has no Apple Container apiserver, so that check always fails — as
+/// `.notFound` (→ 404 "No such image") when the image is simply absent, or as
+/// `.internalServerError` when the missing apiserver surfaces as an XPC
+/// `ContainerizationError(.interrupted, …)` (which the route now preserves instead
+/// of mislabeling as "No such image"). Either outcome proves the input passed
+/// validation; a validation failure would be `.badRequest` or `.payloadTooLarge`.
+private func expectReachedImageStage(
+    _ res: TestingHTTPResponse,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(
+        res.status == .notFound || res.status == .internalServerError,
+        "expected to reach the pre-flight image stage (404 or 500), got \(res.status)",
+        sourceLocation: sourceLocation
+    )
+}
+
 /// Regression tests for the >16 KB request-body fix on `POST /containers/create`.
 ///
 /// `Request.body.collect()` defaults to Vapor's `1 << 14` (16 KB) cap, and
@@ -29,9 +49,6 @@ import VaporTesting
 @Suite("ContainerCreateRoute — request body size")
 struct ContainerCreateRouteTests {
 
-    /// The Abort error body shape (`{"error":true,"reason":"…"}`).
-    private struct ErrorBody: Content { let reason: String }
-
     @Test("a >16 KB create body is collected, not rejected with 413")
     func largeBodyIsAccepted() async throws {
         // Valid create JSON, padded well past 16 KB via a large label value.
@@ -44,13 +61,11 @@ struct ContainerCreateRouteTests {
                 .POST, "/v1.51/containers/create?name=body-size-probe",
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: payload)
-            ) { res async throws in
+            ) { res async in
                 // The body streamed in and was collected past 16 KB; the request
-                // then fails only at the image-existence check. With the bug the
+                // then fails only at the pre-flight image stage. With the bug the
                 // body cap (16 KB) would raise 413 before the handler ran.
-                #expect(res.status == .notFound)
-                let err = try res.content.decode(ErrorBody.self)
-                #expect(err.reason.contains("No such image"))
+                expectReachedImageStage(res)
             }
         }
     }
@@ -267,7 +282,7 @@ struct StopSignalValidationTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","StopSignal":"SIGWINCH"}"#)
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -366,7 +381,7 @@ struct CapabilityValidationTests {
                 body: ByteBuffer(
                     string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"CapAdd":["NET_ADMIN"],"CapDrop":["MKNOD"]}}"#)
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -379,7 +394,7 @@ struct CapabilityValidationTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"CapAdd":["ALL"]}}"#)
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -494,7 +509,7 @@ struct CpuLimitRouteValidationTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"NanoCpus":1500000000}}"#)
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -513,7 +528,7 @@ struct DockerSocketRelayRouteTests {
                     string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"Binds":["/var/run/docker.sock:/var/run/docker.sock:ro"]}}"#
                 )
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -529,7 +544,7 @@ struct DockerSocketRelayRouteTests {
                         #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"Mounts":[{"Type":"bind","Source":"/var/run/docker.sock","Target":"/var/run/docker.sock","ReadOnly":true}]}}"#
                 )
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -546,7 +561,7 @@ struct DockerSocketRelayRouteTests {
                         #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"Binds":["/Users/test/.socktainer/container.sock:/var/run/docker.sock:ro"]}}"#
                 )
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }
@@ -613,7 +628,7 @@ struct RestartPolicyValidationTests {
                 headers: ["Content-Type": "application/json"],
                 body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"RestartPolicy":{"Name":"on-failure","MaximumRetryCount":3}}}"#)
             ) { res async in
-                #expect(res.status == .notFound)
+                expectReachedImageStage(res)
             }
         }
     }

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -1,6 +1,7 @@
 import ContainerAPIClient
 import ContainerPersistence
 import ContainerResource
+import ContainerizationError
 import Foundation
 import Logging
 import Testing
@@ -640,5 +641,28 @@ struct ConvertPortBindingsTests {
         let ports = try convertPortBindings(from: ["5432/tcp": [PortBinding(HostIp: nil, HostPort: "")]])
         #expect(ports.count == 1)
         #expect(ports[0].hostPort != 0)
+    }
+}
+
+@Suite("ContainerCreateRoute — image existence error mapping")
+struct ImageExistenceErrorTests {
+    @Test("a genuine not-found is reported with Docker's load-bearing 'No such image: <ref>' text")
+    func notFoundMapsToNoSuchImage() {
+        let mapped = ContainerCreateRoute.imageExistenceError(
+            ContainerizationError(.notFound, message: "image with reference redis:latest"),
+            image: "redis:latest"
+        )
+        let abort = mapped as? AbortError
+        #expect(abort?.status == .notFound)
+        #expect(abort?.reason == "No such image: redis:latest")
+    }
+
+    @Test("a non-not-found error (e.g. XPC interruption, issue #130) is preserved, not mislabeled as a missing image")
+    func transientErrorIsPreserved() {
+        let xpc = ContainerizationError(.interrupted, message: "XPC connection error: Connection interrupted")
+        let mapped = ContainerCreateRoute.imageExistenceError(xpc, image: "redis:latest")
+        // Must NOT be collapsed into a 404 "No such image" — the real cause has to reach the client.
+        #expect((mapped as? AbortError)?.status != .notFound)
+        #expect((mapped as? ContainerizationError)?.code == .interrupted)
     }
 }


### PR DESCRIPTION
## Summary
The pre-flight image existence check in `POST /containers/create` caught **every** error and rewrote it to `No such image: <ref>`, discarding the real cause. A transient failure — e.g. `ContainerizationError(.interrupted, "XPC connection error: Connection interrupted")` (see #130) — was reported to the client as a missing image, which is misleading and defeats docker-py's `ImageNotFound` detection.

## Related Issue
Related to #130 (XPC connection errors surfaced as generic/misleading messages).

## Changes
- Extract `ContainerCreateRoute.imageExistenceError(_:image:)` as a pure helper.
- A genuine `.notFound` keeps Docker's load-bearing `No such image: <ref>` phrasing (docker-py's `ImageNotFound` depends on that exact text).
- Any other error is preserved unchanged so its real cause reaches the client instead of being mislabeled as a missing image.
- Add unit tests for both paths (not-found → `No such image`; `.interrupted` → preserved).

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (822 tests in 144 suites)
- [x] Unit tests added (`ImageExistenceErrorTests`)
- [ ] Manual testing performed (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
