### PR TITLE
fix(app): time-box startup housekeeping so a wedged runtime cannot block startup

### DIFF
--- a/Sources/socktainer/Utilities/StartupHousekeeping.swift
+++ b/Sources/socktainer/Utilities/StartupHousekeeping.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Runs best-effort startup work under a deadline that the work itself cannot
+/// extend or ignore.
+///
+/// Startup housekeeping (DNS-sidecar adoption, orphaned-network reaping) calls
+/// into Apple Container over XPC, and those calls can hang forever when the
+/// runtime is wedged (apple/container#1884: per-container/network operations
+/// hang indefinitely while reads keep working). Task cancellation can't
+/// interrupt an await stuck inside an XPC continuation, so a plain
+/// timeout-and-cancel race deadlocks with it. Instead the work runs in a
+/// detached task and the caller resumes on whichever finishes first — the work
+/// or the deadline. On timeout the stuck task is abandoned (it holds no
+/// resources the daemon needs) so startup can proceed and bind the API socket;
+/// the alternative is a daemon that never comes up at all.
+enum StartupHousekeeping {
+    /// Runs `work`, returning `true` if it finished within `timeout` and
+    /// `false` if it was abandoned at the deadline.
+    static func runBounded(timeout: Duration, _ work: @escaping @Sendable () async -> Void) async -> Bool {
+        final class Once: @unchecked Sendable {
+            private let lock = NSLock()
+            private var resumed = false
+            func claim() -> Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                guard !resumed else { return false }
+                resumed = true
+                return true
+            }
+        }
+        let once = Once()
+        return await withCheckedContinuation { continuation in
+            Task.detached {
+                await work()
+                if once.claim() { continuation.resume(returning: true) }
+            }
+            Task.detached {
+                try? await Task.sleep(for: timeout)
+                if once.claim() { continuation.resume(returning: false) }
+            }
+        }
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -235,12 +235,23 @@ func configure(_ app: Application) async throws {
         }
     }
 
-    await dnsManager.adoptOrRemoveSidecarsFromPreviousRun()
-
-    // Reap networks orphaned by a previous run (containers removed, network left behind).
-    // Apple Container's vmnet state degrades as stale networks accumulate and eventually
-    // breaks container-to-container routing (EHOSTUNREACH); runs after the DNS-sidecar
-    // cleanup so a network whose only member was its sidecar now appears empty.
-    await OrphanedNetworkReaper.reap(networkClient: networkClient, logger: app.logger)
+    // Sidecar adoption and network reaping (in that order — a network whose only
+    // member was its sidecar must appear empty to the reaper) are best-effort
+    // housekeeping over XPC calls that hang indefinitely when the runtime is
+    // wedged (apple/container#1884). Time-box them: a daemon that skips
+    // housekeeping still serves clients, one that never binds its socket serves
+    // nothing. Network reaping context: Apple Container's vmnet state degrades
+    // as orphaned networks accumulate and eventually breaks container-to-container
+    // routing (EHOSTUNREACH).
+    let housekeepingLogger = app.logger
+    let housekeepingFinished = await StartupHousekeeping.runBounded(timeout: .seconds(30)) {
+        await dnsManager.adoptOrRemoveSidecarsFromPreviousRun()
+        await OrphanedNetworkReaper.reap(networkClient: ClientNetworkService(), logger: housekeepingLogger)
+    }
+    if !housekeepingFinished {
+        app.logger.warning(
+            "[startup] DNS-sidecar adoption / orphaned-network reaping did not finish within 30s — continuing startup without it. The container runtime may be unhealthy (see apple/container#1884)."
+        )
+    }
 
 }

--- a/Tests/socktainerTests/Utilities/StartupHousekeepingTests.swift
+++ b/Tests/socktainerTests/Utilities/StartupHousekeepingTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+@Suite("Startup housekeeping deadline")
+struct StartupHousekeepingTests {
+
+    @Test("work that finishes in time returns true")
+    func finishesInTime() async {
+        let finished = await StartupHousekeeping.runBounded(timeout: .seconds(5)) {
+            // completes immediately
+        }
+        #expect(finished == true)
+    }
+
+    @Test("work that outlives the deadline is abandoned and returns false")
+    func abandonedAtDeadline() async {
+        let finished = await StartupHousekeeping.runBounded(timeout: .milliseconds(50)) {
+            // Simulates an XPC await that never resolves and ignores
+            // cancellation — sleep is cancellable, but nothing cancels the
+            // abandoned task, so it stands in for a stuck continuation.
+            try? await Task.sleep(for: .seconds(600))
+        }
+        #expect(finished == false)
+    }
+
+    @Test("work finishing after the deadline does not double-resume")
+    func lateFinishIsHarmless() async throws {
+        let finished = await StartupHousekeeping.runBounded(timeout: .milliseconds(20)) {
+            try? await Task.sleep(for: .milliseconds(60))
+        }
+        #expect(finished == false)
+        // Give the late worker time to complete its claim() after the timeout
+        // already resumed — a double-resume would crash the process here.
+        try await Task.sleep(for: .milliseconds(120))
+    }
+
+    @Test("slow-but-in-time work still returns true")
+    func slowWorkWithinDeadline() async {
+        let finished = await StartupHousekeeping.runBounded(timeout: .seconds(5)) {
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+        #expect(finished == true)
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
When the Apple Container runtime is wedged (apple/container#1884: per-container/network mutation operations hang indefinitely over XPC while reads keep working), socktainer's startup hangs forever right after `[dns-manager] adopting running DNS container: ...` and the API socket is never created — the daemon becomes entirely unreachable instead of degraded. This time-boxes the responsible startup housekeeping at 30 seconds so the daemon always comes up.

## Related Issue
Observed in the field via Whalebridge (which vendors socktainer): cap10morgan/whalebridge#3 (see the analysis comment there for the full diagnosis). Root cause of the underlying runtime state is upstream apple/container#1884.

## Changes
- The DNS-sidecar adoption (`adoptOrRemoveSidecarsFromPreviousRun`) and orphaned-network reaping steps in `configure()` are best-effort housekeeping, but they await XPC calls with no deadline, and the socket is only bound after `configure()` completes — so a wedged runtime turns best-effort cleanup into a total outage.
- New `StartupHousekeeping.runBounded(timeout:_:)` races the work against a deadline using detached tasks and a once-guarded continuation. Task cancellation can't interrupt an await stuck inside an XPC continuation (that's precisely the hang), so a cancel-based timeout would deadlock the same way; on timeout the stuck task is abandoned instead — it holds nothing the daemon needs.
- On timeout, a warning is logged pointing at runtime health, and startup proceeds to bind the socket. A daemon that skipped housekeeping serves clients with clear per-operation errors; one that never binds its socket serves nothing.

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes locally for the new suite; full suite exercised in CI
- [x] Unit tests added or updated (required for features and bug fixes) — 4 tests in `StartupHousekeepingTests`: completes in time → true; outlives deadline → abandoned, false; a late finisher doesn't double-resume the continuation; slow-but-within-deadline → true
- [x] Manual testing performed (if applicable) — the same change is running in Whalebridge's vendored socktainer (built and full unit suite green there)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)