### PR TITLE
fix(volumes): return 404 for missing volume delete, honor force

### DIFF
--- a/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
@@ -45,6 +45,15 @@ struct VolumeDeleteRoute: RouteCollection {
             if let abortError = error as? AbortError {
                 throw abortError
             }
+            // The volume can vanish between the inspect above and this delete
+            // (another client, or `container volume rm`). moby maps that race to
+            // the same force contract: a silent 204 under force, else a 404.
+            if VolumeNotFound.matches(error) {
+                if force {
+                    return Response(status: .noContent)
+                }
+                throw Abort(.notFound, reason: "get \(name): no such volume")
+            }
             throw Abort(.internalServerError, reason: "Failed to delete volume: \(error)")
         }
     }

--- a/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeDeleteRoute.swift
@@ -1,7 +1,7 @@
 import Vapor
 
 struct VolumeDeleteRoute: RouteCollection {
-    let client: ClientVolumeService
+    let client: ClientVolumeProtocol
 
     func boot(routes: RoutesBuilder) throws {
         try routes.registerVersionedRoute(.DELETE, pattern: "/volumes/{name}", use: self.handler)
@@ -11,16 +11,33 @@ struct VolumeDeleteRoute: RouteCollection {
         guard let name = req.parameters.get("name") else {
             throw Abort(.badRequest, reason: "Missing volume name")
         }
-        // Capture the driver before deletion so the destroy event can report it
-        // (moby volume events include {driver}).
-        let driver = (try? await client.inspect(name: name))?.Driver ?? "local"
+        // Docker Engine API: `force` removes the volume even if it does not exist.
+        let force = MobyBool.queryValue(req.query["force"] as String?)
+
+        // moby inspects the volume before removing it: to look up its driver for
+        // the destroy event, and to tell "missing" apart from a real failure.
+        // Without force a missing volume is a 404; with force it is a silent 204.
+        let volume: Volume
+        do {
+            volume = try await client.inspect(name: name)
+        } catch {
+            if VolumeNotFound.matches(error) {
+                // force purges a missing volume silently (204); otherwise 404.
+                if force {
+                    return Response(status: .noContent)
+                }
+                throw Abort(.notFound, reason: "get \(name): no such volume")
+            }
+            throw Abort(.internalServerError, reason: "Failed to inspect volume: \(error)")
+        }
+
         do {
             try await client.delete(name: name)
             if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
                 await broadcaster.broadcast(
                     DockerEvent.make(
                         type: "volume", action: "destroy", actorID: name,
-                        attributes: ["driver": driver]))
+                        attributes: ["driver": volume.Driver]))
             }
             // Docker Engine API: DELETE /volumes/{name} returns 204 No Content.
             return Response(status: .noContent)
@@ -28,7 +45,6 @@ struct VolumeDeleteRoute: RouteCollection {
             if let abortError = error as? AbortError {
                 throw abortError
             }
-            // You may want to check for not found error specifically
             throw Abort(.internalServerError, reason: "Failed to delete volume: \(error)")
         }
     }

--- a/Sources/socktainer/Routes/Volumes/VolumeInspectRoute.swift
+++ b/Sources/socktainer/Routes/Volumes/VolumeInspectRoute.swift
@@ -15,9 +15,7 @@ struct VolumeInspectRoute: RouteCollection {
             let volume = try await client.inspect(name: name)
             return try await volume.encodeResponse(for: req)
         } catch {
-            // Generic error handling: if error indicates not found, return 404
-            let errorDescription = String(describing: error)
-            if errorDescription.contains("not found") || errorDescription.contains("No such volume") {
+            if VolumeNotFound.matches(error) {
                 throw Abort(.notFound, reason: "Volume not found: \(name)")
             }
             throw Abort(.internalServerError, reason: "Failed to inspect volume: \(error)")

--- a/Sources/socktainer/Utilities/VolumeNotFound.swift
+++ b/Sources/socktainer/Utilities/VolumeNotFound.swift
@@ -25,8 +25,16 @@ enum VolumeNotFound {
             if containerError.code == .notFound {
                 return true
             }
+            // The flattened shape is specifically `.invalidArgument` carrying the
+            // whole "volume '<name>' not found" payload. Require both the code and
+            // the exact message envelope so an unrelated invalid-argument error is
+            // not caught. (Docker volume names cannot contain a quote, so the
+            // prefix/suffix pair pins the payload precisely.)
+            guard containerError.code == .invalidArgument else {
+                return false
+            }
             let message = containerError.message
-            return message.contains("volume '") && message.contains("not found")
+            return message.hasPrefix("volume '") && message.hasSuffix("' not found")
         }
         return false
     }

--- a/Sources/socktainer/Utilities/VolumeNotFound.swift
+++ b/Sources/socktainer/Utilities/VolumeNotFound.swift
@@ -1,0 +1,19 @@
+import ContainerResource
+
+/// Single source of truth for detecting a "volume not found" condition.
+///
+/// The framework's `ClientVolume.inspect` throws a typed
+/// `VolumeError.volumeNotFound`, but that type does not survive Apple
+/// Container's XPC boundary: the service flattens it into a
+/// `ContainerizationError(.invalidArgument, message: "volume '<name>' not found")`
+/// (see `XPCServer`). So both the typed error (defensive, for in-process
+/// paths) and the flattened message must be recognized.
+enum VolumeNotFound {
+    static func matches(_ error: any Error) -> Bool {
+        if let volumeError = error as? VolumeError, case .volumeNotFound = volumeError {
+            return true
+        }
+        let description = String(describing: error)
+        return description.contains("not found") || description.contains("No such volume")
+    }
+}

--- a/Sources/socktainer/Utilities/VolumeNotFound.swift
+++ b/Sources/socktainer/Utilities/VolumeNotFound.swift
@@ -1,4 +1,5 @@
 import ContainerResource
+import ContainerizationError
 
 /// Single source of truth for detecting a "volume not found" condition.
 ///
@@ -6,14 +7,27 @@ import ContainerResource
 /// `VolumeError.volumeNotFound`, but that type does not survive Apple
 /// Container's XPC boundary: the service flattens it into a
 /// `ContainerizationError(.invalidArgument, message: "volume '<name>' not found")`
-/// (see `XPCServer`). So both the typed error (defensive, for in-process
-/// paths) and the flattened message must be recognized.
+/// (see `XPCServer`). Match only these two well-defined shapes so an unrelated
+/// backend failure is never misread as a missing volume (which would otherwise
+/// turn a 500 into a 404, or be silently swallowed under `force`).
 enum VolumeNotFound {
     static func matches(_ error: any Error) -> Bool {
+        // In-process paths throw the framework's typed error directly.
         if let volumeError = error as? VolumeError, case .volumeNotFound = volumeError {
             return true
         }
-        let description = String(describing: error)
-        return description.contains("not found") || description.contains("No such volume")
+        // Across the XPC boundary the typed error arrives as a
+        // ContainerizationError: either with the `.notFound` code, or flattened
+        // into `.invalidArgument` carrying the "volume '<name>' not found"
+        // message. Scope the message check to a volume-not-found payload so
+        // other invalid-argument or storage errors are not caught.
+        if let containerError = error as? ContainerizationError {
+            if containerError.code == .notFound {
+                return true
+            }
+            let message = containerError.message
+            return message.contains("volume '") && message.contains("not found")
+        }
+        return false
     }
 }

--- a/Tests/socktainerTests/Routes/VolumeDeleteForceTests.swift
+++ b/Tests/socktainerTests/Routes/VolumeDeleteForceTests.swift
@@ -1,0 +1,140 @@
+import ContainerResource
+import ContainerizationError
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// DELETE /volumes/{name} must follow the Docker Engine API force contract:
+/// removing a volume that does not exist is a 404 ("no such volume") without
+/// `force`, and a silent 204 no-op with `force=1`. moby inspects the volume
+/// first, so a missing volume never reaches the delete call. The previous
+/// implementation ignored `force` and let the not-found error surface as a 500.
+///
+/// The not-found error is exercised in both shapes it can reach the route as:
+/// the framework's typed `VolumeError.volumeNotFound`, and the
+/// `ContainerizationError` it is flattened into across Apple Container's XPC
+/// boundary (the shape that actually reaches the route in production).
+@Suite("VolumeDeleteRoute — force query parameter")
+struct VolumeDeleteForceTests {
+
+    /// How a missing volume surfaces from `client.inspect`.
+    enum NotFound: CaseIterable, Sendable {
+        case xpcFlattened  // production: ContainerizationError with a "not found" message
+        case typed  // defensive: the framework's own VolumeError
+
+        func error(_ name: String) -> any Error {
+            switch self {
+            case .xpcFlattened: return ContainerizationError(.invalidArgument, message: "volume '\(name)' not found")
+            case .typed: return VolumeError.volumeNotFound(name)
+            }
+        }
+    }
+
+    @Test("Deleting an existing volume returns 204 and removes it")
+    func existingVolumeDeletes() async throws {
+        let log = CallLog()
+        let mock = RecordingVolumeMock(existing: Self.volume(name: "pgdata"), notFound: .xpcFlattened, log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: VolumeDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/volumes/pgdata") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["delete"], "An existing volume is deleted")
+    }
+
+    @Test(
+        "Deleting a missing volume without force returns 404 and performs no delete",
+        arguments: NotFound.allCases)
+    func missingWithoutForceIsNotFound(notFound: NotFound) async throws {
+        let log = CallLog()
+        let mock = RecordingVolumeMock(existing: nil, notFound: notFound, log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: VolumeDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/volumes/ghost") { res async in
+                #expect(res.status == .notFound)
+                #expect(res.body.string.contains("no such volume"))
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls.isEmpty, "A missing volume must not reach the delete call")
+    }
+
+    @Test(
+        "Deleting a missing volume with force returns 204 and performs no delete",
+        arguments: ["force=1", "force=true"], NotFound.allCases)
+    func missingWithForceIsNoOp(forceParam: String, notFound: NotFound) async throws {
+        let log = CallLog()
+        let mock = RecordingVolumeMock(existing: nil, notFound: notFound, log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: VolumeDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/volumes/ghost?\(forceParam)") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls.isEmpty, "force purges a missing volume silently, without a delete call")
+    }
+
+    // MARK: - Helpers
+
+    private static func volume(name: String, driver: String = "local") -> Volume {
+        Volume(
+            Name: name, Driver: driver, Mountpoint: "/tmp/\(name)", CreatedAt: nil,
+            Status: nil, Labels: nil, Scope: "local", ClusterVolume: nil,
+            Options: [:], UsageData: nil)
+    }
+}
+
+// MARK: - Mocks
+
+private actor CallLog {
+    var calls: [String] = []
+    func add(_ call: String) { calls.append(call) }
+}
+
+/// Mock backing a single volume (or none). When the volume is absent, `inspect`
+/// throws the requested not-found shape, mirroring what `ClientVolume` surfaces.
+private struct RecordingVolumeMock: ClientVolumeProtocol {
+    let existing: Volume?
+    let notFound: VolumeDeleteForceTests.NotFound
+    let log: CallLog
+
+    func create(request: RESTVolumeCreate) async throws -> Volume {
+        throw VolumeError.storageError("not used")
+    }
+    func delete(name: String) async throws { await log.add("delete") }
+    func list(filters: String?, logger: Logger) async throws -> [Volume] {
+        existing.map { [$0] } ?? []
+    }
+    func inspect(name: String) async throws -> Volume {
+        guard let existing else { throw notFound.error(name) }
+        return existing
+    }
+}

--- a/Tests/socktainerTests/Routes/VolumeDeleteForceTests.swift
+++ b/Tests/socktainerTests/Routes/VolumeDeleteForceTests.swift
@@ -102,6 +102,56 @@ struct VolumeDeleteForceTests {
         #expect(calls.isEmpty, "force purges a missing volume silently, without a delete call")
     }
 
+    @Test(
+        "A volume that vanishes between inspect and delete is a 404 without force",
+        arguments: NotFound.allCases)
+    func deleteRaceWithoutForceIsNotFound(notFound: NotFound) async throws {
+        let log = CallLog()
+        // inspect succeeds, but the delete then hits the not-found shape.
+        let mock = RecordingVolumeMock(
+            existing: Self.volume(name: "pgdata"), notFound: notFound, log: log, deleteError: notFound.error("pgdata"))
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: VolumeDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/volumes/pgdata") { res async in
+                #expect(res.status == .notFound)
+                #expect(res.body.string.contains("no such volume"))
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["delete"], "the delete was attempted before the race was detected")
+    }
+
+    @Test(
+        "A volume that vanishes between inspect and delete is a silent 204 with force",
+        arguments: NotFound.allCases)
+    func deleteRaceWithForceIsNoOp(notFound: NotFound) async throws {
+        let log = CallLog()
+        let mock = RecordingVolumeMock(
+            existing: Self.volume(name: "pgdata"), notFound: notFound, log: log, deleteError: notFound.error("pgdata"))
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: VolumeDeleteRoute(client: mock))
+
+            try await app.testing().test(.DELETE, "/v1.51/volumes/pgdata?force=1") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["delete"], "force swallows the race after the delete attempt")
+    }
+
     // MARK: - Helpers
 
     private static func volume(name: String, driver: String = "local") -> Volume {
@@ -125,11 +175,17 @@ private struct RecordingVolumeMock: ClientVolumeProtocol {
     let existing: Volume?
     let notFound: VolumeDeleteForceTests.NotFound
     let log: CallLog
+    /// When set, `delete` throws this after logging, simulating a volume that
+    /// vanished between the route's inspect and its delete call.
+    var deleteError: (any Error)?
 
     func create(request: RESTVolumeCreate) async throws -> Volume {
         throw VolumeError.storageError("not used")
     }
-    func delete(name: String) async throws { await log.add("delete") }
+    func delete(name: String) async throws {
+        await log.add("delete")
+        if let deleteError { throw deleteError }
+    }
     func list(filters: String?, logger: Logger) async throws -> [Volume] {
         existing.map { [$0] } ?? []
     }

--- a/Tests/socktainerTests/Utilities/VolumeNotFoundTests.swift
+++ b/Tests/socktainerTests/Utilities/VolumeNotFoundTests.swift
@@ -1,0 +1,43 @@
+import ContainerResource
+import ContainerizationError
+import Testing
+
+@testable import socktainer
+
+/// `VolumeNotFound.matches` is the single source of truth for turning a
+/// volume-not-found error into a 404 (or a forced 204). It must recognize the
+/// two well-defined shapes a missing volume takes, and — just as importantly —
+/// must NOT catch an unrelated backend failure, which would silently downgrade a
+/// 500 to a 404 or swallow it under `force`.
+@Suite("VolumeNotFound.matches")
+struct VolumeNotFoundTests {
+
+    @Test("The framework's typed VolumeError.volumeNotFound matches")
+    func typedMatches() {
+        #expect(VolumeNotFound.matches(VolumeError.volumeNotFound("ghost")))
+    }
+
+    @Test("The XPC-flattened .invalidArgument \"volume '<name>' not found\" matches")
+    func flattenedMatches() {
+        #expect(VolumeNotFound.matches(ContainerizationError(.invalidArgument, message: "volume 'ghost' not found")))
+    }
+
+    @Test("A ContainerizationError with the .notFound code matches")
+    func notFoundCodeMatches() {
+        #expect(VolumeNotFound.matches(ContainerizationError(.notFound, message: "not found")))
+    }
+
+    @Test("Unrelated errors do not match")
+    func unrelatedDoesNotMatch() {
+        // A different VolumeError case.
+        #expect(!VolumeNotFound.matches(VolumeError.storageError("disk gone")))
+        // .invalidArgument, but not the volume-not-found envelope.
+        #expect(!VolumeNotFound.matches(ContainerizationError(.invalidArgument, message: "some other invalid argument")))
+        // The right words, but the wrong code (e.g. an internal failure that
+        // merely mentions a volume) must not be downgraded to a 404.
+        #expect(!VolumeNotFound.matches(ContainerizationError(.internalError, message: "volume 'x' not found")))
+        // A bare Swift error carrying the words must not match either.
+        struct Bogus: Error { let msg = "volume 'x' not found" }
+        #expect(!VolumeNotFound.matches(Bogus()))
+    }
+}


### PR DESCRIPTION
## Summary

`DELETE /volumes/{name}` ignored the `force` query parameter and let the not-found error from a missing volume surface as a generic 500. So `docker volume rm nonexistent` returned a 500 instead of Docker's `404 no such volume`, and `docker volume rm -f nonexistent` (which Docker treats as a silent no-op) also returned 500.

moby inspects the volume before removing it (`volume/service/service.go` `Remove` plus `api/server/router/volume/volume_routes.go`). Without `force` a missing volume is a `404` ("no such volume"); with `force=1` (`PurgeOnError`) it returns `204 No Content` and does nothing. This inspects first and maps not-found accordingly: no force gives 404, force gives a silent 204, and a real volume is deleted and its `destroy` event emitted as before. The route decodes `force` with `MobyBool.queryValue`, matching moby's `httputils.BoolValue` semantics (the helper the stats and logs routes already use).

The framework's typed `VolumeError.volumeNotFound` does not survive Apple Container's XPC boundary, which flattens it into a `ContainerizationError` whose message still carries the original description. A shared `VolumeNotFound.matches` helper recognizes both the typed error (for in-process paths) and the flattened message (what actually reaches the route in production), and `VolumeInspectRoute` now routes its own not-found detection through the same helper (single source of truth).

This is the volume-side sibling of #282, which applied the same force contract to container delete.

## Before

```console
$ docker volume rm ghost-vol
Error response from daemon: Failed to delete volume: invalidArgument: "volume 'ghost-vol' not found"   # HTTP 500

$ docker volume rm -f ghost-vol
Error response from daemon: Failed to delete volume: invalidArgument: "volume 'ghost-vol' not found"   # HTTP 500, force ignored
```

## After

```console
$ docker volume rm ghost-vol
Error response from daemon: get ghost-vol: no such volume   # HTTP 404

$ docker volume rm -f ghost-vol                             # silent no-op, HTTP 204

$ docker volume create realvol && docker volume rm realvol  # a real volume still deletes, HTTP 204
realvol
realvol
```

Matches real Docker: against orbstack, `docker volume rm ghost-vol` returns the same `get ghost-vol: no such volume`, and `-f` on a missing volume succeeds.

## Testing

- New unit tests in `Tests/socktainerTests/Routes/VolumeDeleteForceTests.swift`, each missing-volume case run against both error shapes (the typed `VolumeError` and the production `ContainerizationError` the XPC boundary flattens it into):
  - existing volume: 204 and the delete call runs
  - missing volume without force: 404 ("no such volume"), no delete call
  - missing volume with `force=1` / `force=true`: 204 no-op, no delete call
- Under the previous implementation the production error shape returns 500 for every missing-volume case, so those parameters fail without the fix.
- `make fmt`, `make build`, `make test` (823 tests) pass.
