### PR TITLE
deps: update apple/container to 1.2.0 and apple/containerization to 0.40.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2930f73e155f13128787a8b274ba55eb02b39ac723d368e18975989422af2428",
+  "originHash" : "b2e512e2fa90e51f5c2958d3c8c61b95826a6193a4ea61396fc171707cbbb20e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "5973b9cc626a3e7a499bb316a958237ebe14e2ed",
-        "version" : "1.1.0"
+        "revision" : "6e65319fe476ffe8db8ddaf828a537ed36fe2859",
+        "version" : "1.2.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version" : "0.35.0"
+        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
+        "version" : "0.40.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
       "state" : {
-        "revision" : "f62a09000685b5b86ee383b63e042f286b1a5422",
-        "version" : "2.7.0"
+        "revision" : "2ca31f06658ed288a2560e23ad649acbb3d6b3a3",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let buildVersion = ProcessInfo.processInfo.environment["BUILD_VERSION"] ?? "unsp
 let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
 let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "v1.32"
 let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "v1.51"
-let appleContainerVersion = "1.1.0"
-let appleContainerizationVersion = "0.35.0"
+let appleContainerVersion = "1.2.0"
+let appleContainerizationVersion = "0.40.1"
 
 let package = Package(
     name: "socktainer",

--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -144,7 +144,7 @@ struct ClientBuilderService: ClientBuilderProtocol {
             do {
                 let socket = try await dialBuilderSocket()
                 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-                let builder = try Builder(socket: socket, group: group, logger: logger)
+                let builder = try await Builder(socket: socket, group: group, logger: logger)
                 do {
                     _ = try await builder.info()
                     return builder

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -141,7 +141,9 @@ extension ContainerCreateRoute {
 
             let rawId = Utility.createContainerID(name: containerName)
             let id = ContainerNameUtility.sanitize(rawId)
-            try Utility.validEntityName(id)
+            guard ManagedContainer.nameValid(id) else {
+                throw Abort(.badRequest, reason: "invalid container name: \(id)")
+            }
 
             // Validate the requested platform only if provided
             var requestedPlatform = try Platform(from: containerPlatform)

--- a/Sources/socktainer/Utilities/ContainerNameUtility.swift
+++ b/Sources/socktainer/Utilities/ContainerNameUtility.swift
@@ -2,7 +2,7 @@ import CryptoKit
 import Foundation
 
 enum ContainerNameUtility {
-    static let maxLength = 64
+    static let maxLength = 63
 
     static func sanitize(_ name: String) -> String {
         guard name.count > maxLength else { return name }

--- a/Tests/socktainerTests/Utilities/ContainerNameShorteningTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerNameShorteningTests.swift
@@ -1,4 +1,4 @@
-import ContainerAPIClient
+import ContainerResource
 import Testing
 
 @testable import socktainer
@@ -12,27 +12,27 @@ struct ContainerNameShorteningTests {
         #expect(ContainerNameUtility.sanitize(name) == name)
     }
 
-    @Test("64-character name is returned unchanged")
-    func exactly64CharPassthrough() {
-        let name = "a" + String(repeating: "b", count: 63)
-        #expect(name.count == 64)
+    @Test("63-character name is returned unchanged")
+    func exactly63CharPassthrough() {
+        let name = "a" + String(repeating: "b", count: 62)
+        #expect(name.count == 63)
         #expect(ContainerNameUtility.sanitize(name) == name)
     }
 
-    @Test("65-character name is shortened to exactly 64 characters")
-    func shortens65CharName() {
-        let name = "a" + String(repeating: "b", count: 64)
-        #expect(name.count == 65)
+    @Test("64-character name is shortened to exactly 63 characters")
+    func shortens64CharName() {
+        let name = "a" + String(repeating: "b", count: 63)
+        #expect(name.count == 64)
         let result = ContainerNameUtility.sanitize(name)
-        #expect(result.count == 64)
+        #expect(result.count == 63)
     }
 
-    @Test("Name longer than 100 characters is shortened to exactly 64 characters")
+    @Test("Name longer than 100 characters is shortened to exactly 63 characters")
     func shortensVeryLongName() {
         let name = "act-Build-and-Test-on-Multiple-Platforms-build-ubuntu-latest-some-extra-suffix-here"
-        #expect(name.count > 64)
+        #expect(name.count > 63)
         let result = ContainerNameUtility.sanitize(name)
-        #expect(result.count == 64)
+        #expect(result.count == 63)
     }
 
     @Test("Shortening is deterministic")
@@ -51,12 +51,12 @@ struct ContainerNameShorteningTests {
         #expect(ContainerNameUtility.sanitize(name1) != ContainerNameUtility.sanitize(name2))
     }
 
-    @Test("Shortened name passes validEntityName")
+    @Test("Shortened name passes ManagedContainer.nameValid")
     func shortenedNamePassesValidation() throws {
         let name = "act-" + String(repeating: "valid-name-segment", count: 5)
         #expect(name.count > 64)
         let result = ContainerNameUtility.sanitize(name)
-        try Utility.validEntityName(result)
+        #expect(ManagedContainer.nameValid(result))
     }
 
     @Test("Shortened name preserves readable prefix")

--- a/Tests/socktainerTests/Utilities/ContainerNameValidationTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerNameValidationTests.swift
@@ -1,4 +1,4 @@
-import ContainerAPIClient
+import ContainerResource
 import Testing
 
 @Suite("Container name validation")
@@ -8,65 +8,46 @@ struct ContainerNameValidationTests {
 
     @Test("Accepts alphanumeric-only name")
     func alphanumericName() throws {
-        try Utility.validEntityName("mycontainer1")
+        #expect(ManagedContainer.nameValid("mycontainer1"))
     }
 
     @Test("Accepts name with allowed special characters (underscore, dot, hyphen)")
     func allowedSpecialCharacters() throws {
-        try Utility.validEntityName("my_container.name-1")
+        #expect(ManagedContainer.nameValid("my_container.name-1"))
     }
 
     @Test("Rejects name starting with special character")
     func rejectsLeadingSpecialCharacter() {
-        #expect(throws: Error.self) { try Utility.validEntityName("-badname") }
-        #expect(throws: Error.self) { try Utility.validEntityName("_badname") }
-        #expect(throws: Error.self) { try Utility.validEntityName(".badname") }
+        #expect(!ManagedContainer.nameValid("-badname"))
+        #expect(!ManagedContainer.nameValid("_badname"))
+        #expect(!ManagedContainer.nameValid(".badname"))
     }
 
     @Test("Rejects name with disallowed characters")
     func rejectsDisallowedCharacters() {
-        #expect(throws: Error.self) { try Utility.validEntityName("bad name") }
-        #expect(throws: Error.self) { try Utility.validEntityName("bad/name") }
-        #expect(throws: Error.self) { try Utility.validEntityName("bad@name") }
+        #expect(!ManagedContainer.nameValid("bad name"))
+        #expect(!ManagedContainer.nameValid("bad/name"))
+        #expect(!ManagedContainer.nameValid("bad@name"))
     }
 
     @Test("Rejects single-character name (regex requires at least 2 chars)")
     func rejectsSingleCharName() {
-        #expect(throws: Error.self) { try Utility.validEntityName("a") }
+        #expect(!ManagedContainer.nameValid("a"))
     }
 
     // MARK: - Length boundary tests
-    //
-    // validEntityName uses regex ^[a-zA-Z0-9][a-zA-Z0-9_.-]+$ with no explicit
-    // length cap. If Apple Container daemon rejects names beyond 64 chars, this
-    // layer won't catch it — these tests document current behaviour at the
-    // validation layer only.
 
     @Test("Accepts 63-character name")
     func accepts63CharName() throws {
         let name = "a" + String(repeating: "b", count: 62)
         #expect(name.count == 63)
-        try Utility.validEntityName(name)
+        #expect(ManagedContainer.nameValid(name))
     }
 
-    @Test("Accepts 64-character name")
-    func accepts64CharName() throws {
+    @Test("Rejects 64-character name (exceeds DNS label limit)")
+    func rejects64CharName() throws {
         let name = "a" + String(repeating: "b", count: 63)
         #expect(name.count == 64)
-        try Utility.validEntityName(name)
-    }
-
-    @Test("Accepts 65-character name")
-    func accepts65CharName() throws {
-        let name = "a" + String(repeating: "b", count: 64)
-        #expect(name.count == 65)
-        try Utility.validEntityName(name)
-    }
-
-    @Test("Accepts 255-character name")
-    func accepts255CharName() throws {
-        let name = "a" + String(repeating: "b", count: 254)
-        #expect(name.count == 255)
-        try Utility.validEntityName(name)
+        #expect(!ManagedContainer.nameValid(name))
     }
 }


### PR DESCRIPTION
## Summary

- Bump `apple/container` from 1.1.0 to [1.2.0](https://github.com/apple/container/releases/tag/1.2.0)
- Bump `apple/containerization` from 0.35.0 to 0.40.1 (required by container 1.2.0)

### API adaptations

- **`Utility.validEntityName` removed** ([apple/container#1956](https://github.com/apple/container/pull/1956)): container ID validation moved to the XPC daemon layer. Replaced with `ManagedContainer.nameValid` from `ContainerResource`, which uses the same regex plus a 63-char DNS label limit.
- **`Builder(socket:group:logger:)` is now `async`**: added `await` to the call in `ClientBuilderService.swift`.
- **`ContainerNameUtility.maxLength` reduced from 64 to 63**: aligns with the DNS label limit now enforced by `ManagedContainer.nameValid`.

### Notable upstream changes in 1.2.0

- OCI maskedPaths and readonlyPaths support
- Custom kernel boot args via `--kernel-arg`
- Container ID validation from XPC requests
- Image env vars, build context checks, and TCP/UDP port forward buffer fixes
- BuilderStart race condition fix

## Test plan

- [x] `swift build` compiles with zero errors
- [x] `make test` — all 833 tests pass
- [x] `swift-format` — no formatting drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)