### PR TITLE
ci: add Dependabot configuration for Swift and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Set update schedule for GitHub Actions and Swift dependencies
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    open-pull-requests-limit: 20
+    groups:
+      apple-container:
+        applies-to: version-updates
+        patterns:
+          - "apple-container"
+          - "apple-containerization"
+      apple-swift:
+        applies-to: version-updates
+        patterns:
+          - "apple-swift-*"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with daily update checks for **Swift** (SPM) and **GitHub Actions** ecosystems
- Groups Apple container packages (`apple-container`, `apple-containerization`) and Apple Swift packages (`swift-log`, `swift-argument-parser`) to reduce PR noise
- Checks daily at 03:00 UTC with up to 20 open PRs per ecosystem

## Test plan
- [ ] Verify Dependabot is enabled in repo Settings > Code security > Dependabot
- [ ] Confirm Dependabot opens PRs for outdated Swift and GitHub Actions dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)