### PR TITLE
ci: pin actions/cache to SHA for supply chain safety

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -96,7 +96,7 @@ jobs:
           repository: socktainer/prereleases
           ref: ${{ needs.tag.outputs.githubTag}}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -36,7 +36,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
         with:
           ref: ${{ needs.tag.outputs.githubTag}}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}


### PR DESCRIPTION
## Summary
- Pin all `actions/cache@v4` references to their commit SHA (`0057852bfaa89a56745cba8c7296529d2fc39830`, v4.3.0) across `pr-check.yaml`, `next-build.yaml`, and `release.yaml`
- Every other action in the workflows was already SHA-pinned; this closes the gap

## Test plan
- [ ] CI workflows run successfully with the pinned SHA
- [ ] Verify cache hits/misses still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)