### PR TITLE
fix(containers): return 304 when stopping an already-stopped container

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStopRoute.swift
@@ -25,6 +25,13 @@ extension ContainerStopRoute {
 
             let snapshot = try? await client.getContainer(id: id)
 
+            // Docker Engine API: stopping an already-stopped container is a 304
+            // Not Modified with no stop/die event (moby's containerStop returns
+            // containerNotModifiedError when !ctr.IsRunning()).
+            if snapshot?.status == .stopped {
+                return .notModified
+            }
+
             do {
                 try await client.stop(id: id, signal: signal, timeout: timeout)
             } catch ClientContainerError.notFound {

--- a/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
+++ b/Tests/socktainerTests/Events/ContainerEventLabelTests.swift
@@ -17,7 +17,9 @@ struct ContainerStopEventLabelTests {
     func stopEventCarriesLabels() async throws {
         let id = "stop-ctr-hex"
         let nativeId = "stop-native"
-        let snapshot = makeSnapshot(nativeId: nativeId, image: "redis:7", labels: ["svc": "cache"])
+        // A running container so /stop actually stops and emits the stop event
+        // (an already-stopped container is a 304 no-op under the moby contract).
+        let snapshot = makeSnapshot(nativeId: nativeId, image: "redis:7", labels: ["svc": "cache"], status: .running)
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
         let captureTask = Task<DockerEvent?, Never> {
@@ -233,7 +235,7 @@ struct ContainerAutoRemoveEventTests {
 
 // MARK: - Shared helpers
 
-private func makeSnapshot(nativeId: String, image: String, labels: [String: String]) -> ContainerSnapshot {
+private func makeSnapshot(nativeId: String, image: String, labels: [String: String], status: RuntimeStatus = .stopped) -> ContainerSnapshot {
     let proc = ProcessConfiguration(
         executable: "/bin/sh", arguments: [], environment: [],
         workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
@@ -247,7 +249,7 @@ private func makeSnapshot(nativeId: String, image: String, labels: [String: Stri
     )
     var config = ContainerConfiguration(id: nativeId, image: img, process: proc)
     config.labels = labels
-    return ContainerSnapshot(configuration: config, status: .stopped, networks: [])
+    return ContainerSnapshot(configuration: config, status: status, networks: [])
 }
 
 /// Mock returning a fixed snapshot and succeeding on all mutations.

--- a/Tests/socktainerTests/Routes/ContainerStopAlreadyStoppedTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStopAlreadyStoppedTests.swift
@@ -16,16 +16,26 @@ import VaporTesting
 @Suite("ContainerStopRoute — already-stopped is 304")
 struct ContainerStopAlreadyStoppedTests {
 
-    @Test("Stopping an already-stopped container returns 304 and performs no stop")
+    @Test("Stopping an already-stopped container returns 304, performs no stop, and emits no event")
     func stoppedReturnsNotModified() async throws {
         let log = CallLog()
         let mock = RecordingStopMock(snapshot: Self.snapshot(id: "idle-ctr", status: .stopped), log: log)
+
+        // Observe the broadcaster to prove the 304 path emits no stop event
+        // (moby's contract, and the reason this short-circuits before the
+        // broadcaster). Subscribe before the request so nothing is missed.
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let stopEvent = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "stop" { return event }
+            return nil
+        }
 
         try await withApp(configure: { _ in }) { app in
             let regexRouter = app.regexRouter(with: app.logger)
             app.setRegexRouter(regexRouter)
             regexRouter.installMiddleware(on: app)
-            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            app.storage[EventBroadcasterKey.self] = broadcaster
             try app.register(collection: ContainerStopRoute(client: mock))
 
             try await app.testing().test(.POST, "/v1.51/containers/idle-ctr/stop") { res async in
@@ -35,6 +45,11 @@ struct ContainerStopAlreadyStoppedTests {
 
         let calls = await log.calls
         #expect(calls.isEmpty, "An already-stopped container must not be stopped again")
+
+        // Give any (incorrect) broadcast a bounded window to arrive, then assert
+        // none did.
+        let observed = await Self.eventWithinBoundedWait(stopEvent)
+        #expect(observed == nil, "A 304 must not emit a stop event")
     }
 
     @Test("Stopping a running container returns 204 and stops it")
@@ -56,6 +71,16 @@ struct ContainerStopAlreadyStoppedTests {
 
         let calls = await log.calls
         #expect(calls == ["stop"], "A running container is stopped")
+    }
+
+    /// Returns the captured stop event if one arrives within a short bound, or
+    /// nil once the bound elapses. Waits the bound, then cancels the capture so
+    /// its `for await` ends (the stream would otherwise never terminate on its
+    /// own); a stop event that already arrived is returned, else nil.
+    private static func eventWithinBoundedWait(_ task: Task<DockerEvent?, Never>, milliseconds: UInt64 = 300) async -> DockerEvent? {
+        try? await Task.sleep(nanoseconds: milliseconds * 1_000_000)
+        task.cancel()
+        return await task.value
     }
 
     private static func snapshot(id: String, status: RuntimeStatus) -> ContainerSnapshot {

--- a/Tests/socktainerTests/Routes/ContainerStopAlreadyStoppedTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerStopAlreadyStoppedTests.swift
@@ -1,0 +1,102 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// POST /containers/{id}/stop must follow the Docker Engine API contract for an
+/// already-stopped container: moby's `containerStop` returns 304 Not Modified
+/// when `!ctr.IsRunning()` and emits no stop/die event (the swagger documents
+/// "304 container already stopped"). The previous implementation always called
+/// `client.stop()` and broadcast a stop event regardless of state.
+@Suite("ContainerStopRoute — already-stopped is 304")
+struct ContainerStopAlreadyStoppedTests {
+
+    @Test("Stopping an already-stopped container returns 304 and performs no stop")
+    func stoppedReturnsNotModified() async throws {
+        let log = CallLog()
+        let mock = RecordingStopMock(snapshot: Self.snapshot(id: "idle-ctr", status: .stopped), log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStopRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/idle-ctr/stop") { res async in
+                #expect(res.status == .notModified)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls.isEmpty, "An already-stopped container must not be stopped again")
+    }
+
+    @Test("Stopping a running container returns 204 and stops it")
+    func runningStops() async throws {
+        let log = CallLog()
+        let mock = RecordingStopMock(snapshot: Self.snapshot(id: "live-ctr", status: .running), log: log)
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+            try app.register(collection: ContainerStopRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/live-ctr/stop") { res async in
+                #expect(res.status == .noContent)
+            }
+        }
+
+        let calls = await log.calls
+        #expect(calls == ["stop"], "A running container is stopped")
+    }
+
+    private static func snapshot(id: String, status: RuntimeStatus) -> ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "alpine:latest",
+            descriptor: Descriptor(
+                mediaType: "application/vnd.oci.image.index.v1+json",
+                digest: "sha256:abc", size: 0
+            )
+        )
+        let config = ContainerConfiguration(id: id, image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: status, networks: [])
+    }
+}
+
+// MARK: - Mocks
+
+private actor CallLog {
+    var calls: [String] = []
+    func add(_ call: String) { calls.append(call) }
+}
+
+private struct RecordingStopMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+    let log: CallLog
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws { await log.add("stop") }
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}


### PR DESCRIPTION
## Summary

`POST /containers/{id}/stop` always called `client.stop()` and broadcast a `stop` event regardless of the container's state, so stopping an already-stopped container returned `204 No Content` and emitted a spurious `stop` event.

moby's `containerStop` returns `304 Not Modified` with no `stop`/`die` event when the container is not running, and the swagger documents "304 container already stopped". This short-circuits to `.notModified` when the snapshot is stopped, before touching the client or the broadcaster.

The guard is `snapshot?.status == .stopped` (which also covers created-but-never-started containers, reported as stopped). A stop still in progress keeps its running state and falls through to `client.stop()`, matching moby, where a container has no "stopping" state and stays running until its process exits (`ContainerDeleteRoute` already treats `.stopping` as running for the same reason). A missing container is unaffected: it falls through and `client.stop()` raises the 404.

## Before

```console
# stopdemo is already stopped
$ curl -s -o /dev/null -w '%{http_code}\n' --unix-socket ... -XPOST .../containers/stopdemo/stop
204                           # plus a spurious stop event on docker events
```

## After

```console
# a genuine running -> stopped transition still works and emits stop + die
$ curl -s -o /dev/null -w '%{http_code}\n' --unix-socket ... -XPOST .../containers/stopdemo/stop
204                           # (docker events shows: stop, die)

# stopping it again, now that it is stopped
$ curl -s -o /dev/null -w '%{http_code}\n' --unix-socket ... -XPOST .../containers/stopdemo/stop
304                           # Not Modified, no event (same as moby)
```

## Testing

- New unit tests in `Tests/socktainerTests/Routes/ContainerStopAlreadyStoppedTests.swift`:
  - already-stopped container: 304, no `client.stop()` call
  - running container: 204 and `client.stop()` runs
- Updated `Tests/socktainerTests/Events/ContainerEventLabelTests.swift` to drive the stop-event-label test with a running snapshot (an already-stopped one is now a 304 no-op).
- Under the previous implementation the already-stopped case returns 204 and issues the stop call, so it fails without the fix.
- `make fmt`, `make build`, `make test` (835 tests) pass.
