### PR TITLE
fix(build): inline version literals in Package.swift for Dependabot compatibility

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -144,7 +144,7 @@ jobs:
 
       - name: fetch apple container
         run: |
-          APPLE_CONTAINER_VERSION=$(grep 'let appleContainerVersion' Package.swift | sed -E 's/.*"([0-9.]+)".*/\1/')
+          APPLE_CONTAINER_VERSION=$(python3 -c "import json; d=json.load(open('Package.resolved')); print([p['state']['version'] for p in d['pins'] if p['identity']=='container'][0])")
           wget "https://github.com/apple/container/releases/download/${APPLE_CONTAINER_VERSION}/container-installer-unsigned.pkg" \
             -O container-installer-signed.pkg
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ func resolvedVersion(for identity: String) -> String {
         let pin = pins.first(where: { ($0["identity"] as? String) == identity }),
         let state = pin["state"] as? [String: Any],
         let version = state["version"] as? String
-    else { return "0.0.0" }
+    else {
+        fatalError("Package.resolved has no resolved version for \(identity)")
+    }
     return version
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,16 @@ let buildVersion = ProcessInfo.processInfo.environment["BUILD_VERSION"] ?? "unsp
 let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
 let dockerEngineApiMinVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MIN_VERSION"] ?? "v1.32"
 let dockerEngineApiMaxVersion = ProcessInfo.processInfo.environment["DOCKER_ENGINE_API_MAX_VERSION"] ?? "v1.51"
-let appleContainerVersion = "1.2.0"
-let appleContainerizationVersion = "0.40.1"
+func resolvedVersion(for identity: String) -> String {
+    guard let data = FileManager.default.contents(atPath: "Package.resolved"),
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let pins = json["pins"] as? [[String: Any]],
+        let pin = pins.first(where: { ($0["identity"] as? String) == identity }),
+        let state = pin["state"] as? [String: Any],
+        let version = state["version"] as? String
+    else { return "0.0.0" }
+    return version
+}
 
 let package = Package(
     name: "socktainer",
@@ -16,8 +24,8 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/container.git", exact: Version(stringLiteral: appleContainerVersion)),
-        .package(url: "https://github.com/apple/containerization.git", exact: Version(stringLiteral: appleContainerizationVersion)),
+        .package(url: "https://github.com/apple/container.git", exact: "1.2.0"),
+        .package(url: "https://github.com/apple/containerization.git", exact: "0.40.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
@@ -64,7 +72,7 @@ let package = Package(
                 .define("BUILD_TIME", to: "\"\(buildTime)\""),
                 .define("DOCKER_ENGINE_API_MIN_VERSION", to: "\"\(dockerEngineApiMinVersion)\""),
                 .define("DOCKER_ENGINE_API_MAX_VERSION", to: "\"\(dockerEngineApiMaxVersion)\""),
-                .define("APPLE_CONTAINER_VERSION", to: "\"\(appleContainerVersion)\""),
+                .define("APPLE_CONTAINER_VERSION", to: "\"\(resolvedVersion(for: "container"))\""),
             ]
         ),
     ]


### PR DESCRIPTION
## Summary
- Dependabot's Swift parser uses regex and cannot resolve `Version(stringLiteral: appleContainerVersion)`, causing all Swift dependency update runs to fail with `Illformed requirement`
- Inline version literals in `.package(exact:)` calls so Dependabot can parse them
- Add `resolvedVersion(for:)` helper that reads the version from `Package.resolved` for the `APPLE_CONTAINER_VERSION` cSettings define, avoiding version duplication
- Update `pr-check.yaml` to extract the container version from `Package.resolved` instead of grepping the removed variable

## Test plan
- [x] `make build` passes
- [x] `make test` passes (835 tests)
- [x] `make fmt` produces no diff
- [ ] Verify Dependabot Swift update succeeds on next scheduled run
