### PR TITLE
fix(containers): resolve 64-char Docker hex IDs without mangling

### DIFF
--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -228,14 +228,16 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func getContainer(id: String) async throws -> ContainerSnapshot? {
-        let id = ContainerNameUtility.sanitize(id)
+        let sanitizedId = ContainerNameUtility.sanitize(id)
         do {
-            let snapshot = try await containerClient.withClient { try await $0.get(id: id) }
+            let snapshot = try await containerClient.withClient { try await $0.get(id: sanitizedId) }
             return Self.isDNSSidecar(snapshot) ? nil : snapshot
         } catch let error as ContainerizationError where error.code == .notFound {
             // The reference may be a Docker-shaped hex ID, or a truncated
             // prefix of one fed back from `docker ps` output; resolve it
-            // against the derived IDs of all containers.
+            // against the derived IDs of all containers. Use the original
+            // unsanitized reference: sanitize() mangles 64-char hex IDs into
+            // non-hex strings (containing "-"), which breaks hex prefix matching.
             let allContainers = Self.withoutDNSSidecars(try await containerClient.withClient { try await $0.list() })
             let entries = allContainers.map { (nativeId: $0.id, hexId: DockerContainerID.hexId(for: $0)) }
             switch DockerContainerID.resolve(reference: id, entries: entries) {
@@ -314,7 +316,6 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func stop(id: String, signal: String?, timeout: Int?) async throws {
-        let id = ContainerNameUtility.sanitize(id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
@@ -334,13 +335,12 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func kill(id: String, signal: String?) async throws {
-        let id = ContainerNameUtility.sanitize(id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
 
         guard container.status == .running else {
-            throw ClientContainerError.notRunning(id: id)
+            throw ClientContainerError.notRunning(id: container.id)
         }
 
         let signal = signal ?? "SIGKILL"
@@ -350,7 +350,6 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func restart(id: String, signal: String?, timeout: Int?) async throws {
-        let id = ContainerNameUtility.sanitize(id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
@@ -371,7 +370,6 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func delete(id: String) async throws {
-        let id = ContainerNameUtility.sanitize(id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }

--- a/Tests/socktainerTests/Utilities/DockerContainerIDTests.swift
+++ b/Tests/socktainerTests/Utilities/DockerContainerIDTests.swift
@@ -129,4 +129,32 @@ struct DockerContainerIDTests {
         #expect(DockerContainerID.resolve(reference: "", entries: entries(["a"])) == .none)
         #expect(DockerContainerID.resolve(reference: "deadbeef", entries: entries(["a"])) == .none)
     }
+
+    @Test("Sanitized 64-char hex ID fails resolution (the bug from #344)")
+    func sanitizedHexIdFailsResolution() {
+        let hex = DockerContainerID.hexId(nativeId: "my-container", createdAt: created)
+        #expect(hex.count == 64)
+
+        let sanitized = ContainerNameUtility.sanitize(hex)
+        #expect(sanitized != hex)
+        #expect(sanitized.contains("-"))
+
+        let result = DockerContainerID.resolve(
+            reference: sanitized,
+            entries: entries(["my-container"])
+        )
+        #expect(result == .none)
+    }
+
+    @Test("Raw 64-char hex ID resolves correctly (#344)")
+    func rawHexIdResolvesCorrectly() {
+        let hex = DockerContainerID.hexId(nativeId: "my-container", createdAt: created)
+        #expect(hex.count == 64)
+
+        let result = DockerContainerID.resolve(
+            reference: hex,
+            entries: entries(["my-container"])
+        )
+        #expect(result == .match("my-container"))
+    }
 }


### PR DESCRIPTION
## Summary

- Fix 404 errors when Docker clients send back full 64-character hex container IDs for `start`, `stop`, `kill`, `restart`, `delete`, and `inspect` operations
- `getContainer()` applied `ContainerNameUtility.sanitize()` which truncates strings > 63 chars into `prefix(50)-sha256(12)`, mangling hex IDs into non-hex strings that fail prefix resolution
- Preserve the original unsanitized reference for the hex-ID fallback path and remove redundant pre-sanitize calls from callers

Closes #344

## Test plan

- [x] Added regression test proving sanitized 64-char hex IDs fail resolution (documents the bug)
- [x] Added test proving raw 64-char hex IDs resolve correctly (verifies the fix)
- [x] All 837 existing tests pass
- [x] `make fmt` clean