### PR TITLE
fix(exec): close hijacked exec-start channel even when wait() stalls, fixes #346

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -257,6 +257,29 @@ struct ExecRoute: RouteCollection {
         case unresolved
     }
 
+    /// Single-assignment race result: whichever of `wait()`/timeout finishes
+    /// first reports here, and late/duplicate reports are silently dropped.
+    /// Kept separate from `waitForExitOutcome`'s own task group because a
+    /// non-cooperative `wait()` (one that doesn't observe cancellation) must
+    /// not keep the caller suspended — an actor-backed continuation can be
+    /// resumed by the winner without the loser's task ever being awaited.
+    private actor ExitOutcomeRace {
+        private var continuation: CheckedContinuation<ExecWaitOutcome, Never>?
+        private var outcome: ExecWaitOutcome?
+
+        func resolve(_ result: ExecWaitOutcome) {
+            guard outcome == nil else { return }
+            outcome = result
+            continuation?.resume(returning: result)
+            continuation = nil
+        }
+
+        func awaitOutcome() async -> ExecWaitOutcome {
+            if let outcome { return outcome }
+            return await withCheckedContinuation { continuation = $0 }
+        }
+    }
+
     /// Races `wait` (typically `process.wait()`) against a fixed timeout so a
     /// stalled Apple Container XPC exit acknowledgement can never hang the
     /// caller forever. Every exec-start path (detached, chunked-stream, and
@@ -266,23 +289,33 @@ struct ExecRoute: RouteCollection {
     /// that cleanup can be conditioned on an XPC call that sometimes never
     /// resolves (issue #8: the hijacked path awaited `process.wait()` with no
     /// timeout at all, so a stalled wait left the channel open forever).
+    ///
+    /// `wait()` runs as an unstructured `Task`, not a `TaskGroup` child: a
+    /// structured child that never observes cancellation would keep the
+    /// enclosing group (and this function) suspended until it finally
+    /// finishes. Racing via `ExitOutcomeRace` instead lets this function
+    /// return the moment the timeout fires; the stalled `wait()` task is
+    /// cancelled (a no-op if it ignores cancellation) and left to finish or
+    /// not on its own, unobserved.
     static func waitForExitOutcome(
         timeoutNanoseconds: UInt64,
         wait: @escaping @Sendable () async throws -> Int32
     ) async -> ExecWaitOutcome {
-        await withTaskGroup(of: ExecWaitOutcome.self) { group in
-            group.addTask {
-                if let code = try? await wait() { return .observed(code) }
-                return .unresolved
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
-                return .unresolved
-            }
-            let result = await group.next() ?? .unresolved
-            group.cancelAll()
-            return result
+        let race = ExitOutcomeRace()
+
+        let waitTask = Task<Void, Never> {
+            let outcome = (try? await wait()).map(ExecWaitOutcome.observed) ?? .unresolved
+            await race.resolve(outcome)
         }
+        let timeoutTask = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+            await race.resolve(.unresolved)
+        }
+
+        let outcome = await race.awaitOutcome()
+        waitTask.cancel()
+        timeoutTask.cancel()
+        return outcome
     }
 
     static func startExec(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -251,6 +251,40 @@ struct ExecRoute: RouteCollection {
         }
     }
 
+    /// Outcome of racing an exec process's exit against a bounded fallback.
+    enum ExecWaitOutcome: Equatable {
+        case observed(Int32)
+        case unresolved
+    }
+
+    /// Races `wait` (typically `process.wait()`) against a fixed timeout so a
+    /// stalled Apple Container XPC exit acknowledgement can never hang the
+    /// caller forever. Every exec-start path (detached, chunked-stream, and
+    /// hijacked/TCP-upgrade) needs this: each has cleanup that must run once
+    /// the process is known to be done — recording the exit code, unblocking
+    /// a waiting stream/inspect, or closing the hijacked channel — and none of
+    /// that cleanup can be conditioned on an XPC call that sometimes never
+    /// resolves (issue #8: the hijacked path awaited `process.wait()` with no
+    /// timeout at all, so a stalled wait left the channel open forever).
+    static func waitForExitOutcome(
+        timeoutNanoseconds: UInt64,
+        wait: @escaping @Sendable () async throws -> Int32
+    ) async -> ExecWaitOutcome {
+        await withTaskGroup(of: ExecWaitOutcome.self) { group in
+            group.addTask {
+                if let code = try? await wait() { return .observed(code) }
+                return .unresolved
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return .unresolved
+            }
+            let result = await group.next() ?? .unresolved
+            group.cancelAll()
+            return result
+        }
+    }
+
     static func startExec(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
             guard let execId = req.parameters.get("id") else {
@@ -357,22 +391,8 @@ struct ExecRoute: RouteCollection {
                     // the code and broadcast exec_die; if the wait stalls or errors without
                     // an observed exit, record a sentinel so GET /exec/{id}/json stops
                     // reporting Running: true, but broadcast no exec_die.
-                    enum ExecExit {
-                        case observed(Int32)
-                        case unresolved
-                    }
-                    let outcome: ExecExit = await withTaskGroup(of: ExecExit.self) { g in
-                        g.addTask {
-                            if let code = try? await process.wait() { return .observed(code) }
-                            return .unresolved
-                        }
-                        g.addTask {
-                            try? await Task.sleep(nanoseconds: 60_000_000_000)
-                            return .unresolved
-                        }
-                        let result = await g.next() ?? .unresolved
-                        g.cancelAll()
-                        return result
+                    let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 60_000_000_000) {
+                        try await process.wait()
                     }
                     switch outcome {
                     case .observed(let code):
@@ -456,22 +476,8 @@ struct ExecRoute: RouteCollection {
                         // and broadcast exec_die; if it stalls/errors with no observed exit,
                         // record a sentinel so GET /exec/{id}/json leaves Running, but emit no
                         // exec_die (no death was observed).
-                        enum ExecExit {
-                            case observed(Int32)
-                            case unresolved
-                        }
-                        let outcome: ExecExit = await withTaskGroup(of: ExecExit.self) { g in
-                            g.addTask {
-                                if let code = try? await process.wait() { return .observed(code) }
-                                return .unresolved
-                            }
-                            g.addTask {
-                                try? await Task.sleep(nanoseconds: 10_000_000_000)
-                                return .unresolved
-                            }
-                            let result = await g.next() ?? .unresolved
-                            g.cancelAll()
-                            return result
+                        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 10_000_000_000) {
+                            try await process.wait()
                         }
                         await ProcessRegistry.shared.remove(id: execId)
                         switch outcome {
@@ -775,15 +781,26 @@ struct ExecRoute: RouteCollection {
 
                     // Process monitor with proper cleanup
                     group.addTask {
-                        // moby emits `exec_die` only on an observed real exit. If wait()
-                        // throws, record a synthetic exit code so the exec leaves the
-                        // Running state (GET /exec/{id}/json), but broadcast no exec_die —
-                        // no clean exit was observed.
-                        let observedCode: Int32? = try? await process.wait()
-                        await ExecManager.shared.setExitCode(id: execId, code: observedCode ?? -1)
+                        // moby emits `exec_die` only on an observed real exit. Race the
+                        // exit against a 10s XPC-stall fallback, mirroring the detached
+                        // and chunked-stream paths — Apple Container's XPC sometimes
+                        // never acknowledges exec process exit, and awaiting process.wait()
+                        // with no bound left the channel.close() below unreachable,
+                        // hanging any client waiting on EOF (issue #8). On an observed
+                        // exit, record the code and broadcast exec_die; if it stalls with
+                        // no observed exit, record a sentinel so GET /exec/{id}/json
+                        // leaves Running, but emit no exec_die (no death was observed) —
+                        // the channel still closes either way.
+                        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 10_000_000_000) {
+                            try await process.wait()
+                        }
                         await ProcessRegistry.shared.remove(id: execId)
-                        if let observedCode {
-                            await broadcastExecEvent("exec_die", exitCode: observedCode)
+                        switch outcome {
+                        case .observed(let code):
+                            await ExecManager.shared.setExitCode(id: execId, code: code)
+                            await broadcastExecEvent("exec_die", exitCode: code)
+                        case .unresolved:
+                            await ExecManager.shared.setExitCode(id: execId, code: -1)
                         }
 
                         // Give a small delay for any final output to be processed

--- a/Tests/socktainerTests/Routes/ExecWaitOutcomeTests.swift
+++ b/Tests/socktainerTests/Routes/ExecWaitOutcomeTests.swift
@@ -46,13 +46,22 @@ struct ExecWaitOutcomeTests {
         // fix's timeout race, this call would never return and the test
         // itself would hang — mirroring how a stalled process.wait() left
         // the hijacked channel open forever.
+        //
+        // Simulated here with a continuation that only resumes via a real-time
+        // callback, never observing Task cancellation — a genuinely
+        // non-cooperative stall. (A `Task.sleep`-based stand-in would throw
+        // `CancellationError` the instant it's cancelled, masking the bug
+        // this test guards against: the caller must not depend on the loser
+        // task ever finishing, cooperatively or otherwise.)
         let timeoutNanoseconds: UInt64 = 100_000_000  // 100ms
         let start = DispatchTime.now().uptimeNanoseconds
 
         let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: timeoutNanoseconds) {
-            // Simulates a wait() call that never returns (stalled XPC exit
-            // acknowledgement) by sleeping far longer than the timeout.
-            try await Task.sleep(nanoseconds: 60_000_000_000)
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 60) {
+                    continuation.resume()
+                }
+            }
             return 0
         }
 

--- a/Tests/socktainerTests/Routes/ExecWaitOutcomeTests.swift
+++ b/Tests/socktainerTests/Routes/ExecWaitOutcomeTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// `ExecRoute.waitForExitOutcome` races a process's exit against a bounded
+/// timeout. It backs the cleanup on every exec-start path (detached,
+/// chunked-stream, and hijacked/TCP-upgrade) — in particular, the hijacked
+/// path's channel-close call is unreachable until this function returns.
+///
+/// Before the fix for issue #8, the hijacked path awaited `process.wait()`
+/// directly with no timeout at all. If Apple Container's XPC never
+/// acknowledged the exec process's exit (a stall the codebase already
+/// accounts for on the other two paths), `process.wait()` would hang
+/// forever and the hijacked connection's `channel.close()` would never run
+/// — the exact "never closes the hijacked connection after the process
+/// exits" symptom from the bug report. These tests exercise that fallback
+/// directly, without needing a real Apple Container VM.
+@Suite("ExecRoute.waitForExitOutcome")
+struct ExecWaitOutcomeTests {
+
+    @Test("an exit observed before the timeout is reported as observed(code)")
+    func observedExitBeforeTimeout() async {
+        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 5_000_000_000) {
+            42
+        }
+
+        #expect(outcome == .observed(42))
+    }
+
+    @Test("a wait() that throws is treated as unresolved, not a crash")
+    func throwingWaitIsUnresolved() async {
+        struct BoomError: Error {}
+
+        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 5_000_000_000) {
+            throw BoomError()
+        }
+
+        #expect(outcome == .unresolved)
+    }
+
+    @Test("a wait() that never resolves still returns unresolved within the timeout bound")
+    func stalledWaitFallsBackWithinTimeout() async throws {
+        // Regression test for issue #8: a wait() that never completes (the
+        // XPC-stall scenario) must not hang the caller forever. Without the
+        // fix's timeout race, this call would never return and the test
+        // itself would hang — mirroring how a stalled process.wait() left
+        // the hijacked channel open forever.
+        let timeoutNanoseconds: UInt64 = 100_000_000  // 100ms
+        let start = DispatchTime.now().uptimeNanoseconds
+
+        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: timeoutNanoseconds) {
+            // Simulates a wait() call that never returns (stalled XPC exit
+            // acknowledgement) by sleeping far longer than the timeout.
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+            return 0
+        }
+
+        let elapsedNanoseconds = DispatchTime.now().uptimeNanoseconds - start
+
+        #expect(outcome == .unresolved)
+        // Generous upper bound (2s) well above the 100ms timeout, but far
+        // below the 60s stall — proves the call returned promptly on the
+        // timeout path rather than eventually finishing the stalled wait.
+        #expect(elapsedNanoseconds < 2_000_000_000)
+    }
+
+    @Test("a fast exit still wins even with a short timeout")
+    func fastExitWinsOverShortTimeout() async {
+        let outcome = await ExecRoute.waitForExitOutcome(timeoutNanoseconds: 50_000_000) {
+            7
+        }
+
+        #expect(outcome == .observed(7))
+    }
+}


### PR DESCRIPTION
## Summary

Non-interactive exec (`Detach:false, Tty:false`) upgrades the connection to a raw
hijacked stream and streams output correctly, but never closes the connection once
the exec'd process exits — any client waiting for EOF (Docker Go client, Docker CLI)
hangs forever. This extracts the timeout-racing pattern already used by the detached
and chunked-stream exec-start paths and applies it to the hijacked path too, so a
stalled Apple Container XPC `wait()` can no longer leave the channel open indefinitely.

## Related Issue

Fixes #346

## Changes

- Extract the duplicated "race `process.wait()` against a fixed timeout" logic (previously
  inlined separately in the detached and chunked-stream paths) into a single
  `ExecRoute.waitForExitOutcome` helper.
- Apply that helper to the third, previously-unbounded path: the hijacked/TCP-upgrade
  exec-start. Its `channel.close()` was only ever reached after `process.wait()`
  returned, with no timeout — so a stalled XPC exit-acknowledgement left the channel
  open forever, which is exactly the bug in #346.
- Preserve exit-code recording and `exec_die` broadcast semantics on all three paths:
  an observed exit still records the real code and emits `exec_die`; an unresolved
  wait still records the `-1` sentinel and emits nothing, matching existing behavior
  for the other two paths (and the ordering fix from #305 for the chunked path).

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed (if applicable)

Added `Tests/socktainerTests/Routes/ExecWaitOutcomeTests.swift`, exercising
`waitForExitOutcome` directly: a fast observed exit, a throwing `wait()`, a stalled
`wait()` that never resolves (the regression case for #346 — without the fix this
would hang the test itself), and a fast exit winning over a short timeout.

Manually reproduced #346's raw-HTTP repro (hijacked `POST /exec/{id}/start` against a
running container) before and after: hangs until `--max-time` kills it on `main`,
returns in well under a second on this branch.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
