### PR TITLE
fix(dns): drop additional records from local responses

### DIFF
--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -218,11 +218,11 @@ final class SocktainerDNSServer: @unchecked Sendable {
 
         // QDCOUNT > 1 → FORMERR is answered in handleLocalQuery (fast path).
         guard let (qname, qtype, questionEnd) = parseQuestion(packet, offset: 12) else {
+            // Malformed question — no end to strip; forward as-is.
             return forwardToUpstream(packet)
         }
 
         // Response skeleton: header + question, any additional sections dropped.
-        // Upstream forwarding below still uses the original packet.
         let responsePacket = makeResponsePacket(packet, questionEnd: questionEnd)
 
         let normalized = Self.normalize(qname)
@@ -253,7 +253,8 @@ final class SocktainerDNSServer: @unchecked Sendable {
             if known { return buildNodataResponse(packet: responsePacket) }
         }
 
-        return forwardToUpstream(packet)
+        // Forward without EDNS0: our 512-byte recv buffer can't hold a large response.
+        return forwardToUpstream(makeQueryPacket(packet, questionEnd: questionEnd))
     }
 
     private func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
@@ -294,6 +295,16 @@ final class SocktainerDNSServer: @unchecked Sendable {
     /// dropped), so the answer lands directly after the question, where clients parse it.
     private func makeResponsePacket(_ packet: [UInt8], questionEnd: Int) -> [UInt8] {
         makeResponseHeader(packet) + Array(packet[12..<questionEnd])
+    }
+
+    /// Query skeleton forwarded upstream: header + question with any additional records
+    /// (e.g. an EDNS0 OPT) dropped and ARCOUNT zeroed, so the packet stays well-formed.
+    private func makeQueryPacket(_ packet: [UInt8], questionEnd: Int) -> [UInt8] {
+        var query = Array(packet.prefix(12))
+        query[10] = 0  // ARCOUNT=0
+        query[11] = 0
+        query += Array(packet[12..<questionEnd])
+        return query
     }
 
     private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -174,7 +174,9 @@ final class SocktainerDNSServer: @unchecked Sendable {
         guard packet.count >= 12 else { return nil }
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
-        guard let (qname, qtype, _) = parseQuestion(packet, offset: 12) else { return nil }
+        guard let (qname, qtype, questionEnd) = parseQuestionSection(packet) else { return nil }
+        // Response skeleton: header + question, any additional sections dropped.
+        let responsePacket = makeResponsePacket(packet, questionEnd: questionEnd)
         let normalized = Self.normalize(qname)
         let isSingleLabel = !normalized.contains(".")
         if qtype == 1 {
@@ -183,24 +185,24 @@ final class SocktainerDNSServer: @unchecked Sendable {
             lock.unlock()
             if let ip {
                 log.info("[dns] A \(normalized) → \(ip[0]).\(ip[1]).\(ip[2]).\(ip[3]) (local)")
-                return buildAResponse(packet: packet, ip: ip)
+                return buildAResponse(packet: responsePacket, ip: ip)
             }
             if isSingleLabel {
                 log.info("[dns] \(normalized) not in table (local NXDOMAIN)")
-                return buildNxdomainResponse(packet: packet)
+                return buildNxdomainResponse(packet: responsePacket)
             }
         } else if qtype == 28 {
-            if isSingleLabel { return buildNodataResponse(packet: packet) }
+            if isSingleLabel { return buildNodataResponse(packet: responsePacket) }
             lock.lock()
             let known = entries[normalized] != nil
             lock.unlock()
-            if known { return buildNodataResponse(packet: packet) }
+            if known { return buildNodataResponse(packet: responsePacket) }
         }
         // Any other single-label query type (HTTPS/SVCB/SRV/TXT/…) is answered NODATA
         // locally rather than forwarded: a single-label name has no public meaning, so
         // forwarding it upstream only invites an authoritative NXDOMAIN that poisons the
         // resolver's parallel A+AAAA lookups.
-        if isSingleLabel { return buildNodataResponse(packet: packet) }
+        if isSingleLabel { return buildNodataResponse(packet: responsePacket) }
         return nil
     }
 
@@ -211,9 +213,13 @@ final class SocktainerDNSServer: @unchecked Sendable {
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
 
-        guard let (qname, qtype, _) = parseQuestion(packet, offset: 12) else {
+        guard let (qname, qtype, questionEnd) = parseQuestionSection(packet) else {
             return forwardToUpstream(packet)
         }
+
+        // Response skeleton: header + question, any additional sections dropped.
+        // Upstream forwarding below still uses the original packet.
+        let responsePacket = makeResponsePacket(packet, questionEnd: questionEnd)
 
         let normalized = Self.normalize(qname)
 
@@ -227,26 +233,26 @@ final class SocktainerDNSServer: @unchecked Sendable {
             lock.unlock()
             if let ip {
                 log.info("[dns] A \(normalized) → \(ip[0]).\(ip[1]).\(ip[2]).\(ip[3]) (local)")
-                return buildAResponse(packet: packet, ip: ip)
+                return buildAResponse(packet: responsePacket, ip: ip)
             }
             if isSingleLabel {
                 log.info("[dns] \(normalized) not in table (local NXDOMAIN)")
-                return buildNxdomainResponse(packet: packet)
+                return buildNxdomainResponse(packet: responsePacket)
             }
         } else if qtype == 28 {  // AAAA — container names are IPv4-only
             // For single-label names return NODATA unconditionally; forwarding to 1.1.1.1
             // would yield an authoritative NXDOMAIN that poisons concurrent A+AAAA resolvers.
-            if isSingleLabel { return buildNodataResponse(packet: packet) }
+            if isSingleLabel { return buildNodataResponse(packet: responsePacket) }
             lock.lock()
             let known = entries[normalized] != nil
             lock.unlock()
-            if known { return buildNodataResponse(packet: packet) }
+            if known { return buildNodataResponse(packet: responsePacket) }
         }
 
         return forwardToUpstream(packet)
     }
 
-    private func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
+    private func parseOneQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
         var pos = offset
         var labels: [String] = []
         while pos < packet.count {
@@ -264,18 +270,43 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return (labels.joined(separator: "."), qtype, pos)
     }
 
-    private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {
-        var response = packet
+    /// Parses all QDCOUNT questions; returns the first question's name/type and the
+    /// offset past the last, or nil if malformed.
+    private func parseQuestionSection(_ packet: [UInt8]) -> (String, UInt16, Int)? {
+        let qd = Int((UInt16(packet[4]) << 8) | UInt16(packet[5]))
+        guard qd >= 1 else { return nil }
+        var pos = 12
+        guard let (qname, qtype, firstEnd) = parseOneQuestion(packet, offset: pos) else { return nil }
+        pos = firstEnd
+        for _ in 1..<qd {
+            guard let (_, _, next) = parseOneQuestion(packet, offset: pos) else { return nil }
+            pos = next
+        }
+        return (qname, qtype, pos)
+    }
+
+    /// Response skeleton shared by the builders: header + question with any additional
+    /// records (e.g. an EDNS0 OPT) dropped, so the answer lands directly after the
+    /// question, where clients parse it.
+    private func makeResponsePacket(_ packet: [UInt8], questionEnd: Int) -> [UInt8] {
+        var response = Array(packet[0..<questionEnd])
         let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
-        let rflags: UInt16 = 0x8400 | rd  // QR=1, AA=1
+        let rflags: UInt16 = 0x8000 | rd  // QR=1
         response[2] = UInt8(rflags >> 8)
         response[3] = UInt8(rflags & 0xFF)
-        response[6] = 0
-        response[7] = 1  // ANCOUNT=1
-        response[8] = 0
+        response[6] = 0  // ANCOUNT=0
+        response[7] = 0
+        response[8] = 0  // NSCOUNT=0
         response[9] = 0
-        response[10] = 0
+        response[10] = 0  // ARCOUNT=0
         response[11] = 0
+        return response
+    }
+
+    private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {
+        var response = packet
+        response[2] |= 0x04  // AA=1 (Authoritative Answer)
+        response[7] = 1  // ANCOUNT=1
         response += [
             0xC0, 0x0C,  // NAME: pointer to offset 12
             0x00, 0x01,  // TYPE: A
@@ -289,32 +320,14 @@ final class SocktainerDNSServer: @unchecked Sendable {
 
     private func buildNodataResponse(packet: [UInt8]) -> [UInt8] {
         var response = packet
-        let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
-        let rflags: UInt16 = 0x8400 | rd
-        response[2] = UInt8(rflags >> 8)
-        response[3] = UInt8(rflags & 0xFF)
-        response[6] = 0
-        response[7] = 0
-        response[8] = 0
-        response[9] = 0
-        response[10] = 0
-        response[11] = 0
+        response[2] |= 0x04  // AA=1
         return response
     }
 
     // Non-authoritative NXDOMAIN (no AA bit) so clients retry rather than cache permanently.
     private func buildNxdomainResponse(packet: [UInt8]) -> [UInt8] {
         var response = packet
-        let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
-        let rflags: UInt16 = 0x8003 | rd  // QR=1, Recursion Desired, RCODE=3
-        response[2] = UInt8(rflags >> 8)
-        response[3] = UInt8(rflags & 0xFF)
-        response[6] = 0
-        response[7] = 0
-        response[8] = 0
-        response[9] = 0
-        response[10] = 0
-        response[11] = 0
+        response[3] |= 0x03  // RCODE=3 (NXDOMAIN)
         return response
     }
 

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -174,7 +174,10 @@ final class SocktainerDNSServer: @unchecked Sendable {
         guard packet.count >= 12 else { return nil }
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
-        guard let (qname, qtype, questionEnd) = parseQuestionSection(packet) else { return nil }
+        // RFC 9619: QDCOUNT > 1 is FORMERR.
+        let qd = (UInt16(packet[4]) << 8) | UInt16(packet[5])
+        guard qd <= 1 else { return buildFormerrResponse(packet: packet) }
+        guard let (qname, qtype, questionEnd) = parseQuestion(packet, offset: 12) else { return nil }
         // Response skeleton: header + question, any additional sections dropped.
         let responsePacket = makeResponsePacket(packet, questionEnd: questionEnd)
         let normalized = Self.normalize(qname)
@@ -213,7 +216,8 @@ final class SocktainerDNSServer: @unchecked Sendable {
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
 
-        guard let (qname, qtype, questionEnd) = parseQuestionSection(packet) else {
+        // QDCOUNT > 1 → FORMERR is answered in handleLocalQuery (fast path).
+        guard let (qname, qtype, questionEnd) = parseQuestion(packet, offset: 12) else {
             return forwardToUpstream(packet)
         }
 
@@ -252,7 +256,7 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return forwardToUpstream(packet)
     }
 
-    private func parseOneQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
+    private func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
         var pos = offset
         var labels: [String] = []
         while pos < packet.count {
@@ -270,26 +274,9 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return (labels.joined(separator: "."), qtype, pos)
     }
 
-    /// Parses all QDCOUNT questions; returns the first question's name/type and the
-    /// offset past the last, or nil if malformed.
-    private func parseQuestionSection(_ packet: [UInt8]) -> (String, UInt16, Int)? {
-        let qd = Int((UInt16(packet[4]) << 8) | UInt16(packet[5]))
-        guard qd >= 1 else { return nil }
-        var pos = 12
-        guard let (qname, qtype, firstEnd) = parseOneQuestion(packet, offset: pos) else { return nil }
-        pos = firstEnd
-        for _ in 1..<qd {
-            guard let (_, _, next) = parseOneQuestion(packet, offset: pos) else { return nil }
-            pos = next
-        }
-        return (qname, qtype, pos)
-    }
-
-    /// Response skeleton shared by the builders: header + question with any additional
-    /// records (e.g. an EDNS0 OPT) dropped, so the answer lands directly after the
-    /// question, where clients parse it.
-    private func makeResponsePacket(_ packet: [UInt8], questionEnd: Int) -> [UInt8] {
-        var response = Array(packet[0..<questionEnd])
+    /// DNS response header: QR=1, the query's RD echoed, AN/NS/AR counts zeroed.
+    private func makeResponseHeader(_ packet: [UInt8]) -> [UInt8] {
+        var response = Array(packet.prefix(12))
         let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
         let rflags: UInt16 = 0x8000 | rd  // QR=1
         response[2] = UInt8(rflags >> 8)
@@ -301,6 +288,12 @@ final class SocktainerDNSServer: @unchecked Sendable {
         response[10] = 0  // ARCOUNT=0
         response[11] = 0
         return response
+    }
+
+    /// Header + question skeleton shared by the answer builders (additional records
+    /// dropped), so the answer lands directly after the question, where clients parse it.
+    private func makeResponsePacket(_ packet: [UInt8], questionEnd: Int) -> [UInt8] {
+        makeResponseHeader(packet) + Array(packet[12..<questionEnd])
     }
 
     private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {
@@ -328,6 +321,15 @@ final class SocktainerDNSServer: @unchecked Sendable {
     private func buildNxdomainResponse(packet: [UInt8]) -> [UInt8] {
         var response = packet
         response[3] |= 0x03  // RCODE=3 (NXDOMAIN)
+        return response
+    }
+
+    // FORMERR (RCODE=1): header only, question dropped, so counts stay consistent.
+    private func buildFormerrResponse(packet: [UInt8]) -> [UInt8] {
+        var response = makeResponseHeader(packet)
+        response[3] |= 0x01  // RCODE=1 (FORMERR)
+        response[4] = 0  // QDCOUNT=0
+        response[5] = 0
         return response
     }
 

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -170,36 +170,44 @@ struct SocktainerDNSServerTests {
 
 // MARK: - DNS query behaviour
 
-/// Sends a minimal DNS A or AAAA query via UDP and returns the RCODE from the response.
-private func dnsRcode(type: UInt16, name: String, port: Int) -> UInt8? {
+/// Sends a minimal DNS query (one question per `names` entry) via UDP and returns the RCODE.
+private func dnsRcode(type: UInt16, names: [String], port: Int) -> UInt8? {
     guard
-        let response = sendDnsQuery(makeDnsQuery(name: name, type: type, edns0: false), port: port),
+        let response = sendDnsQuery(makeDnsQuery(names: names, type: type, edns0: false), port: port),
         response.count >= 4
     else { return nil }
     return response[3] & 0x0F
 }
 
-/// Builds a DNS query packet (ID 0x1234, RD=1), optionally with an EDNS0 OPT
-/// additional record (ARCOUNT=1, UDP payload 4096) like real resolvers send.
-private func makeDnsQuery(name: String, type: UInt16, edns0: Bool) -> [UInt8] {
-    var qname = [UInt8]()
-    for label in name.split(separator: ".") {
-        let bytes = Array(label.utf8)
-        qname.append(UInt8(bytes.count))
-        qname.append(contentsOf: bytes)
+/// Builds a DNS query packet (ID 0x1234, RD=1): one question per `names` entry
+/// (QDCOUNT = names.count), optionally with an EDNS0 OPT additional record
+/// (ARCOUNT=1, UDP payload 4096) like real resolvers send.
+private func makeDnsQuery(names: [String], type: UInt16, edns0: Bool) -> [UInt8] {
+    func qnameBytes(_ name: String) -> [UInt8] {
+        var qname = [UInt8]()
+        for label in name.split(separator: ".") {
+            let bytes = Array(label.utf8)
+            qname.append(UInt8(bytes.count))
+            qname.append(contentsOf: bytes)
+        }
+        qname.append(0)
+        return qname
     }
-    qname.append(0)
 
     var packet = [UInt8]()
     packet += [0x12, 0x34, 0x01, 0x00]  // ID + RD=1 query
-    packet += [0x00, 0x01, 0x00, 0x00, 0x00, 0x00]  // QDCOUNT=1
+    packet += [UInt8(names.count >> 8), UInt8(names.count & 0xFF)]  // QDCOUNT
+    packet += [0x00, 0x00]  // ANCOUNT=0
+    packet += [0x00, 0x00]  // NSCOUNT=0
     if edns0 {
         packet += [0x00, 0x01]  // ARCOUNT=1
     } else {
-        packet += [0x00, 0x00]
+        packet += [0x00, 0x00]  // ARCOUNT=0
     }
-    packet += qname
-    packet += [UInt8(type >> 8), UInt8(type & 0xFF), 0x00, 0x01]  // QTYPE + QCLASS IN
+    for name in names {
+        packet += qnameBytes(name)
+        packet += [UInt8(type >> 8), UInt8(type & 0xFF), 0x00, 0x01]  // QTYPE + QCLASS IN
+    }
     if edns0 {
         // EDNS0 OPT record: root name, TYPE=41, CLASS=4096 (UDP payload), TTL=0, RDLEN=0
         packet += [0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
@@ -242,9 +250,9 @@ private func sendDnsQuery(_ packet: [UInt8], port: Int) -> [UInt8]? {
 /// Sends an EDNS0-OPT query and returns the response's ARCOUNT and the bytes remaining
 /// after the question and answer sections. Both are 0 for a well-formed response — an
 /// echoed OPT record or trailing bytes would make them nonzero.
-private func dnsResponseTail(type: UInt16, name: String, port: Int) -> (arcount: Int, remaining: Int)? {
+private func dnsResponseTail(type: UInt16, names: [String], port: Int) -> (arcount: Int, remaining: Int)? {
     guard
-        let response = sendDnsQuery(makeDnsQuery(name: name, type: type, edns0: true), port: port),
+        let response = sendDnsQuery(makeDnsQuery(names: names, type: type, edns0: true), port: port),
         response.count >= 12
     else { return nil }
     let qd = Int((UInt16(response[4]) << 8) | UInt16(response[5]))
@@ -287,7 +295,7 @@ struct SocktainerDNSQueryTests {
             return
         }
         server.register(hostname: "supabase_db_supabase", ip: "192.168.67.3")
-        let rcode = dnsRcode(type: 1, name: "supabase_db_supabase", port: port)
+        let rcode = dnsRcode(type: 1, names: ["supabase_db_supabase"], port: port)
         #expect(rcode == 0, "A for known name must succeed (RCODE=0)")
     }
 
@@ -300,7 +308,7 @@ struct SocktainerDNSQueryTests {
         }
         // Warmup: register a dummy entry — the lock acquisition gives the server thread time to start.
         server.register(hostname: "_warmup", ip: "127.0.0.1")
-        let rcode = dnsRcode(type: 1, name: "no-such-container", port: port)
+        let rcode = dnsRcode(type: 1, names: ["no-such-container"], port: port)
         #expect(rcode == 3, "A for unknown single-label name must return NXDOMAIN without forwarding to 1.1.1.1")
     }
 
@@ -313,7 +321,7 @@ struct SocktainerDNSQueryTests {
         }
         server.register(hostname: "db", ip: "192.168.67.3")
         // NODATA is RCODE=0 with zero answer records; the test checks RCODE only.
-        let rcode = dnsRcode(type: 28, name: "db", port: port)
+        let rcode = dnsRcode(type: 28, names: ["db"], port: port)
         #expect(rcode == 0, "AAAA for single-label name must return NODATA (RCODE=0), not NXDOMAIN from 1.1.1.1")
     }
 
@@ -325,8 +333,21 @@ struct SocktainerDNSQueryTests {
             return
         }
         server.register(hostname: "_warmup", ip: "127.0.0.1")
-        let rcode = dnsRcode(type: 28, name: "unknown-svc", port: port)
+        let rcode = dnsRcode(type: 28, names: ["unknown-svc"], port: port)
         #expect(rcode == 0, "AAAA for unknown single-label name must return NODATA, never forward to 1.1.1.1")
+    }
+
+    @Test("Query with QDCOUNT > 1 returns FORMERR (RCODE 1)")
+    func qdcountGreaterThanOneReturnsFormerr() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19770, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+
+        // Two questions in one query — RFC 9619: must be refused with FORMERR.
+        let rcode = dnsRcode(type: 1, names: ["redis", "db"], port: port)
+        #expect(rcode == 1, "QDCOUNT > 1 must be answered with FORMERR (RCODE=1)")
     }
 
     // Regression: NS & AR sections should be dropped when their count is set to 0.
@@ -339,7 +360,7 @@ struct SocktainerDNSQueryTests {
         }
         server.register(hostname: "redis", ip: "192.168.1.10")
 
-        guard let tail = dnsResponseTail(type: 1, name: "redis", port: port) else {
+        guard let tail = dnsResponseTail(type: 1, names: ["redis"], port: port) else {
             Issue.record("No response for EDNS0 A query")
             return
         }
@@ -356,7 +377,7 @@ struct SocktainerDNSQueryTests {
         }
         server.register(hostname: "db", ip: "192.168.67.3")
 
-        guard let tail = dnsResponseTail(type: 28, name: "db", port: port) else {
+        guard let tail = dnsResponseTail(type: 28, names: ["db"], port: port) else {
             Issue.record("No response for EDNS0 AAAA query")
             return
         }
@@ -372,7 +393,7 @@ struct SocktainerDNSQueryTests {
             return
         }
 
-        guard let tail = dnsResponseTail(type: 1, name: "no-such-container", port: port) else {
+        guard let tail = dnsResponseTail(type: 1, names: ["no-such-container"], port: port) else {
             Issue.record("No response for EDNS0 A query")
             return
         }

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -291,24 +291,6 @@ struct SocktainerDNSQueryTests {
         #expect(rcode == 0, "A for known name must succeed (RCODE=0)")
     }
 
-    // Regression: NS & AR sections should be dropped when their count is set to 0.
-    @Test("A query with EDNS0 OPT for a registered name returns a well-formed response")
-    func aQueryWithOPTForRegisteredNameReturnsWellFormedResponse() throws {
-        let server = SocktainerDNSServer()
-        guard let port = server.start(preferredPort: 19740, maxAttempts: 5) else {
-            Issue.record("Could not bind DNS server port")
-            return
-        }
-        server.register(hostname: "redis", ip: "192.168.1.10")
-
-        guard let tail = dnsResponseTail(type: 1, name: "redis", port: port) else {
-            Issue.record("No response for EDNS0 A query")
-            return
-        }
-        #expect(tail.arcount == 0, "response must not echo the query's OPT record")
-        #expect(tail.remaining == 0, "no bytes may remain after the question and answer sections")
-    }
-
     @Test("A query for unknown single-label name returns local NXDOMAIN (RCODE 3)")
     func aQueryUnknownNameReturnsNxdomain() throws {
         let server = SocktainerDNSServer()
@@ -345,6 +327,57 @@ struct SocktainerDNSQueryTests {
         server.register(hostname: "_warmup", ip: "127.0.0.1")
         let rcode = dnsRcode(type: 28, name: "unknown-svc", port: port)
         #expect(rcode == 0, "AAAA for unknown single-label name must return NODATA, never forward to 1.1.1.1")
+    }
+
+    // Regression: NS & AR sections should be dropped when their count is set to 0.
+    @Test("A query with EDNS0 OPT for a registered name returns a well-formed response")
+    func aQueryWithOPTForRegisteredNameReturnsWellFormedResponse() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19740, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+        server.register(hostname: "redis", ip: "192.168.1.10")
+
+        guard let tail = dnsResponseTail(type: 1, name: "redis", port: port) else {
+            Issue.record("No response for EDNS0 A query")
+            return
+        }
+        #expect(tail.arcount == 0, "response must not echo the query's OPT record")
+        #expect(tail.remaining == 0, "no bytes may remain after the question and answer sections")
+    }
+
+    @Test("AAAA query with EDNS0 OPT for a single-label name returns a well-formed NODATA")
+    func aaaaQueryWithOPTForSingleLabelReturnsWellFormedNodata() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19750, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+        server.register(hostname: "db", ip: "192.168.67.3")
+
+        guard let tail = dnsResponseTail(type: 28, name: "db", port: port) else {
+            Issue.record("No response for EDNS0 AAAA query")
+            return
+        }
+        #expect(tail.arcount == 0, "response must not echo the query's OPT record")
+        #expect(tail.remaining == 0, "no bytes may remain after the question and answer sections")
+    }
+
+    @Test("A query with EDNS0 OPT for an unknown single-label name returns a well-formed NXDOMAIN")
+    func aQueryWithOPTForUnknownSingleLabelReturnsWellFormedNxdomain() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19760, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+
+        guard let tail = dnsResponseTail(type: 1, name: "no-such-container", port: port) else {
+            Issue.record("No response for EDNS0 A query")
+            return
+        }
+        #expect(tail.arcount == 0, "response must not echo the query's OPT record")
+        #expect(tail.remaining == 0, "no bytes may remain after the question and answer sections")
     }
 }
 

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -171,9 +171,17 @@ struct SocktainerDNSServerTests {
 // MARK: - DNS query behaviour
 
 /// Sends a minimal DNS A or AAAA query via UDP and returns the RCODE from the response.
-/// Retries up to 5 times with 50 ms gaps to handle the race between Thread.detachNewThread
-/// and the server loop reaching recvfrom(). Returns nil only if all attempts time out.
 private func dnsRcode(type: UInt16, name: String, port: Int) -> UInt8? {
+    guard
+        let response = sendDnsQuery(makeDnsQuery(name: name, type: type, edns0: false), port: port),
+        response.count >= 4
+    else { return nil }
+    return response[3] & 0x0F
+}
+
+/// Builds a DNS query packet (ID 0x1234, RD=1), optionally with an EDNS0 OPT
+/// additional record (ARCOUNT=1, UDP payload 4096) like real resolvers send.
+private func makeDnsQuery(name: String, type: UInt16, edns0: Bool) -> [UInt8] {
     var qname = [UInt8]()
     for label in name.split(separator: ".") {
         let bytes = Array(label.utf8)
@@ -184,10 +192,25 @@ private func dnsRcode(type: UInt16, name: String, port: Int) -> UInt8? {
 
     var packet = [UInt8]()
     packet += [0x12, 0x34, 0x01, 0x00]  // ID + RD=1 query
-    packet += [0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]  // QDCOUNT=1, rest 0
+    packet += [0x00, 0x01, 0x00, 0x00, 0x00, 0x00]  // QDCOUNT=1
+    if edns0 {
+        packet += [0x00, 0x01]  // ARCOUNT=1
+    } else {
+        packet += [0x00, 0x00]
+    }
     packet += qname
     packet += [UInt8(type >> 8), UInt8(type & 0xFF), 0x00, 0x01]  // QTYPE + QCLASS IN
+    if edns0 {
+        // EDNS0 OPT record: root name, TYPE=41, CLASS=4096 (UDP payload), TTL=0, RDLEN=0
+        packet += [0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    }
+    return packet
+}
 
+/// Sends raw query bytes via UDP to 127.0.0.1:port and returns the raw response.
+/// Retries up to 5 times with 50 ms gaps to handle the race between Thread.detachNewThread
+/// and the server loop reaching recvfrom(). Returns nil only if all attempts time out.
+private func sendDnsQuery(_ packet: [UInt8], port: Int) -> [UInt8]? {
     var dst = sockaddr_in()
     dst.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
     dst.sin_family = sa_family_t(AF_INET)
@@ -211,9 +234,46 @@ private func dnsRcode(type: UInt16, name: String, port: Int) -> UInt8? {
         guard sent > 0 else { continue }
         var buf = [UInt8](repeating: 0, count: 512)
         let n = recv(fd, &buf, buf.count, 0)
-        if n >= 4 { return buf[3] & 0x0F }
+        if n >= 12 { return Array(buf[0..<n]) }
     }
     return nil
+}
+
+/// Sends an EDNS0-OPT query and returns the response's ARCOUNT and the bytes remaining
+/// after the question and answer sections. Both are 0 for a well-formed response — an
+/// echoed OPT record or trailing bytes would make them nonzero.
+private func dnsResponseTail(type: UInt16, name: String, port: Int) -> (arcount: Int, remaining: Int)? {
+    guard
+        let response = sendDnsQuery(makeDnsQuery(name: name, type: type, edns0: true), port: port),
+        response.count >= 12
+    else { return nil }
+    let qd = Int((UInt16(response[4]) << 8) | UInt16(response[5]))
+    let an = Int((UInt16(response[6]) << 8) | UInt16(response[7]))
+    let arcount = Int((UInt16(response[10]) << 8) | UInt16(response[11]))
+    var pos = 12
+    func skipName() {
+        while pos < response.count {
+            let len = Int(response[pos])
+            pos += 1
+            if len == 0 { break }
+            if (len & 0xC0) == 0xC0 {
+                pos += 1
+                break
+            }  // compression pointer (2 bytes total)
+            pos += len
+        }
+    }
+    for _ in 0..<qd {
+        skipName()
+        pos += 4
+    }
+    for _ in 0..<an {
+        skipName()
+        guard pos + 10 <= response.count else { break }
+        let rdlen = Int((UInt16(response[pos + 8]) << 8) | UInt16(response[pos + 9]))
+        pos += 10 + rdlen
+    }
+    return (arcount, response.count - pos)
 }
 
 @Suite("SocktainerDNSServer — query behaviour")
@@ -229,6 +289,24 @@ struct SocktainerDNSQueryTests {
         server.register(hostname: "supabase_db_supabase", ip: "192.168.67.3")
         let rcode = dnsRcode(type: 1, name: "supabase_db_supabase", port: port)
         #expect(rcode == 0, "A for known name must succeed (RCODE=0)")
+    }
+
+    // Regression: NS & AR sections should be dropped when their count is set to 0.
+    @Test("A query with EDNS0 OPT for a registered name returns a well-formed response")
+    func aQueryWithOPTForRegisteredNameReturnsWellFormedResponse() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19740, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+        server.register(hostname: "redis", ip: "192.168.1.10")
+
+        guard let tail = dnsResponseTail(type: 1, name: "redis", port: port) else {
+            Issue.record("No response for EDNS0 A query")
+            return
+        }
+        #expect(tail.arcount == 0, "response must not echo the query's OPT record")
+        #expect(tail.remaining == 0, "no bytes may remain after the question and answer sections")
     }
 
     @Test("A query for unknown single-label name returns local NXDOMAIN (RCODE 3)")


### PR DESCRIPTION
# Pull Request

## Summary
Fixes DNS responses for queries carrying an EDNS0 OPT additional record (ARCOUNT=1), which real resolvers may send. The response builders previously echoed the entire query packet while zeroing ARCOUNT, so the A record was appended *after* the OPT — clients parsed the OPT record as the answer and never found the A record. Responses are now built from a header + question skeleton with the additional section dropped, and the answer is placed directly after the question.

## Related Issue
Fixes #329

## Changes
- `makeResponsePacket` builds the response skeleton once per query (header + question, QR=1, RD echoed, counts zeroed, additional sections dropped);
- `buildAResponse`/`buildNodataResponse`/`buildNxdomainResponse` now only set their per-response bits (AA, RCODE, ANCOUNT) and append records.
- ~~`parseQuestionSection` parses the full QDCOUNT question section, so responses echo every question and remain well-formed even for QDCOUNT > 1; compression pointers in any question are rejected per RFC 1035~~QDCOUNT > 1 is now rejected with FORMERR per RFC9619.
- Regression test: an EDNS0-OPT A query for a registered name must return ARCOUNT=0 and no trailing bytes after the question/answer sections. New `makeDnsQuery`/`sendDnsQuery`/`dnsResponseTail` test helpers, with `dnsRcode` refactored to share them. And additional tests on @coderabbitai's suggestion.

## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed (if applicable)
 
## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))