### PR TITLE
fix(images): honor the reference and dangling filters on image list

### DIFF
--- a/Sources/socktainer/Routes/Images/ImageListRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageListRoute.swift
@@ -6,6 +6,7 @@ import Vapor
 struct RESTImageListQuery: Vapor.Content {
     let manifests: Bool?
     let digests: Bool?
+    let filters: String?
 }
 
 struct ImageListRoute: RouteCollection {
@@ -62,6 +63,8 @@ extension ImageListRoute {
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> [RESTImageSummary] {
         { req in
             let query = try req.query.decode(RESTImageListQuery.self)
+            // moby validates the filters before doing any listing work.
+            let filters = try DockerImageFilterUtility.parseImageListFilters(filterParam: query.filters, logger: req.logger)
             guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
                 throw Abort(.internalServerError, reason: "Apple Container application support URL is not configured")
             }
@@ -176,7 +179,28 @@ extension ImageListRoute {
                 imagesSummaries.append(summary)
             }
 
-            return imagesSummaries
+            return try ImageListRoute.applyFilters(imagesSummaries, filters: filters)
         }
+    }
+
+    /// Applies the `dangling` and `reference` image-ls filters. Different keys
+    /// AND together, matching moby.
+    static func applyFilters(_ summaries: [RESTImageSummary], filters: [String: [String]]) throws -> [RESTImageSummary] {
+        var result = summaries
+        if let dangling = filters["dangling"], !dangling.isEmpty {
+            // moby's filters.GetBoolOrDefault recognizes only 0/1/true/false
+            // here (stricter than the MobyBool query-parameter semantics) and
+            // rejects an unrecognized or conflicting value with a 400.
+            let isTrue = dangling.contains("1") || dangling.contains("true")
+            let isFalse = dangling.contains("0") || dangling.contains("false")
+            guard isTrue != isFalse else {
+                throw Abort(.badRequest, reason: "invalid filter 'dangling=[\(dangling.joined(separator: " "))]'")
+            }
+            result = result.filter { ImageListFilter.isDangling(repoTags: $0.RepoTags) == isTrue }
+        }
+        if let patterns = filters["reference"], !patterns.isEmpty {
+            result = result.filter { ImageListFilter.referenceMatches(patterns: patterns, repoTags: $0.RepoTags) }
+        }
+        return result
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageListRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageListRoute.swift
@@ -63,8 +63,14 @@ extension ImageListRoute {
     static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> [RESTImageSummary] {
         { req in
             let query = try req.query.decode(RESTImageListQuery.self)
-            // moby validates the filters before doing any listing work.
+            // moby validates the filters before doing any listing work. Key/shape
+            // validation already happens inside the parser; running applyFilters
+            // against an empty list here additionally fail-fasts on an invalid
+            // `dangling` value (e.g. `dangling=bogus`) before the real listing
+            // and image-summary work below, at the cost of a second (cheap,
+            // no-op-on-empty-input) filter pass once the real summaries exist.
             let filters = try DockerImageFilterUtility.parseImageListFilters(filterParam: query.filters, logger: req.logger)
+            _ = try ImageListRoute.applyFilters([], filters: filters)
             guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
                 throw Abort(.internalServerError, reason: "Apple Container application support URL is not configured")
             }
@@ -187,10 +193,18 @@ extension ImageListRoute {
     /// AND together, matching moby.
     static func applyFilters(_ summaries: [RESTImageSummary], filters: [String: [String]]) throws -> [RESTImageSummary] {
         var result = summaries
-        if let dangling = filters["dangling"], !dangling.isEmpty {
+        // A present (even empty) `dangling` key is validated, unlike `reference`
+        // (where a present-but-empty filter matches nothing): real Docker 400s
+        // `{"dangling":[]}` outright rather than treating it as "no filter" —
+        // verified live. `!dangling.isEmpty` would treat it as absent instead.
+        if let dangling = filters["dangling"] {
             // moby's filters.GetBoolOrDefault recognizes only 0/1/true/false
             // here (stricter than the MobyBool query-parameter semantics) and
-            // rejects an unrecognized or conflicting value with a 400.
+            // rejects the value set if it has no recognized true/false token,
+            // or has both — but does NOT reject an extra unrecognized token
+            // once a real one is present: `dangling=[true,maybe]` behaves as
+            // `dangling=true` on real Docker (verified live), so `maybe` here
+            // is silently irrelevant, not itself invalid.
             let isTrue = dangling.contains("1") || dangling.contains("true")
             let isFalse = dangling.contains("0") || dangling.contains("false")
             guard isTrue != isFalse else {

--- a/Sources/socktainer/Routes/Images/ImageListRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageListRoute.swift
@@ -198,7 +198,12 @@ extension ImageListRoute {
             }
             result = result.filter { ImageListFilter.isDangling(repoTags: $0.RepoTags) == isTrue }
         }
-        if let patterns = filters["reference"], !patterns.isEmpty {
+        // A present `reference` key with zero values (an empty array, or a
+        // boolean map with no true entries) is a real Docker filter that
+        // matches nothing — not the same as the key being absent. `contains`
+        // over an empty `patterns` array already returns false for every
+        // image, which is exactly that "matches nothing" behavior.
+        if let patterns = filters["reference"] {
             result = result.filter { ImageListFilter.referenceMatches(patterns: patterns, repoTags: $0.RepoTags) }
         }
         return result

--- a/Sources/socktainer/Utilities/DockerFilterUtility.swift
+++ b/Sources/socktainer/Utilities/DockerFilterUtility.swift
@@ -287,8 +287,11 @@ struct DockerImageFilterUtility {
                 guard dict.values.allSatisfy({ DockerImageFilterUtility.isJSONBool($0) }) else {
                     throw Abort(.badRequest, reason: "invalid filter")
                 }
-                let keys = dict.compactMap { (k, v) in (v as? Bool == true) ? k : nil }
-                if !keys.isEmpty { parsedFilters[key] = keys }
+                // Always register the key, even with zero true entries: real
+                // Docker treats a present-but-empty filter as "match nothing"
+                // (verified live: `{"reference":{}}` and an all-false map both
+                // return no images), not "no filter" the way an absent key does.
+                parsedFilters[key] = dict.compactMap { (k, v) in (v as? Bool == true) ? k : nil }
             } else if let arr = value as? [Any] {
                 guard let strings = arr as? [String] else {
                     throw Abort(.badRequest, reason: "invalid filter")

--- a/Sources/socktainer/Utilities/DockerFilterUtility.swift
+++ b/Sources/socktainer/Utilities/DockerFilterUtility.swift
@@ -252,6 +252,36 @@ struct DockerImageFilterUtility {
 
         return parsedFilters
     }
+
+    /// Parses the `filters` query for GET /images/json. moby's image-ls accepts
+    /// before, dangling, label, reference, since, and until, and rejects any
+    /// other key with a 400 (filters.Validate); this normalizes the three JSON
+    /// shapes docker clients send into `[key: [value]]`.
+    static func parseImageListFilters(filterParam: String?, logger: Logger) throws -> [String: [String]] {
+        var parsedFilters: [String: [String]] = [:]
+        let allowedKeys: Set<String> = ["before", "dangling", "label", "reference", "since", "until"]
+
+        guard let filterParam, let data = filterParam.data(using: .utf8) else { return parsedFilters }
+        guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            logger.warning("Failed to decode image list filters")
+            return parsedFilters
+        }
+        for (key, value) in json {
+            guard allowedKeys.contains(key) else {
+                throw Abort(.badRequest, reason: "invalid filter '\(key)'")
+            }
+            // {"reference": {"alpine:*": true}} / {"reference": ["alpine:*"]} / {"reference": "alpine:*"}
+            if let dict = value as? [String: Any] {
+                let keys = dict.compactMap { (k, v) in (v as? Bool == true) ? k : nil }
+                if !keys.isEmpty { parsedFilters[key] = keys }
+            } else if let arr = value as? [String] {
+                parsedFilters[key] = arr
+            } else if let str = value as? String {
+                parsedFilters[key] = [str]
+            }
+        }
+        return parsedFilters
+    }
 }
 
 // utility for parsing build cache filters from query string

--- a/Sources/socktainer/Utilities/DockerFilterUtility.swift
+++ b/Sources/socktainer/Utilities/DockerFilterUtility.swift
@@ -257,14 +257,23 @@ struct DockerImageFilterUtility {
     /// before, dangling, label, reference, since, and until, and rejects any
     /// other key with a 400 (filters.Validate); this normalizes the three JSON
     /// shapes docker clients send into `[key: [value]]`.
+    ///
+    /// An absent or empty `filters` param means "no filter" (200, unfiltered).
+    /// A non-empty param that fails to decode — malformed JSON, a non-object
+    /// top level, or a value that is not one of the three accepted shapes
+    /// (map of string->bool, array of strings, or a single string) — is a 400
+    /// `invalid filter`, matching real Docker's `filters.FromJSON`. Verified
+    /// against a live daemon: malformed JSON, `[]`, `{"reference": 1}`,
+    /// `{"reference": {"alpine": "yes"}}`, and `{"reference": [1, 2]}` all 400.
     static func parseImageListFilters(filterParam: String?, logger: Logger) throws -> [String: [String]] {
         var parsedFilters: [String: [String]] = [:]
         let allowedKeys: Set<String> = ["before", "dangling", "label", "reference", "since", "until"]
 
-        guard let filterParam, let data = filterParam.data(using: .utf8) else { return parsedFilters }
-        guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
-            logger.warning("Failed to decode image list filters")
+        guard let filterParam, !filterParam.isEmpty, let data = filterParam.data(using: .utf8) else {
             return parsedFilters
+        }
+        guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw Abort(.badRequest, reason: "invalid filter")
         }
         for (key, value) in json {
             guard allowedKeys.contains(key) else {
@@ -272,15 +281,35 @@ struct DockerImageFilterUtility {
             }
             // {"reference": {"alpine:*": true}} / {"reference": ["alpine:*"]} / {"reference": "alpine:*"}
             if let dict = value as? [String: Any] {
+                // `as? Bool` bridges any NSNumber (so a JSON `1` would pass as
+                // `true`); check the JSON node's real CF type instead so a
+                // numeric value here is rejected, matching real Docker.
+                guard dict.values.allSatisfy({ DockerImageFilterUtility.isJSONBool($0) }) else {
+                    throw Abort(.badRequest, reason: "invalid filter")
+                }
                 let keys = dict.compactMap { (k, v) in (v as? Bool == true) ? k : nil }
                 if !keys.isEmpty { parsedFilters[key] = keys }
-            } else if let arr = value as? [String] {
-                parsedFilters[key] = arr
+            } else if let arr = value as? [Any] {
+                guard let strings = arr as? [String] else {
+                    throw Abort(.badRequest, reason: "invalid filter")
+                }
+                parsedFilters[key] = strings
             } else if let str = value as? String {
                 parsedFilters[key] = [str]
+            } else {
+                throw Abort(.badRequest, reason: "invalid filter")
             }
         }
         return parsedFilters
+    }
+
+    /// True only for an actual JSON boolean node. `JSONSerialization` bridges
+    /// both JSON booleans and numbers to `NSNumber`, so plain `is Bool`/`as?
+    /// Bool` casts also accept a JSON `1`/`0` as `true`/`false` — checking the
+    /// underlying CoreFoundation type tells them apart.
+    static func isJSONBool(_ value: Any) -> Bool {
+        guard let number = value as? NSNumber else { return false }
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
     }
 }
 

--- a/Sources/socktainer/Utilities/ImageListFilter.swift
+++ b/Sources/socktainer/Utilities/ImageListFilter.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Applies moby's `reference` and `dangling` filters to image summaries for
+/// GET /images/json. Multiple values of one key are ORed; different keys AND.
+/// Other image-ls keys (label/since/before/until) are not yet honored.
+enum ImageListFilter {
+    /// A summary is "dangling" when it carries no repository tags (moby shows
+    /// such an image as `<none>:<none>`).
+    static func isDangling(repoTags: [String]) -> Bool {
+        repoTags.isEmpty || repoTags == ["<none>:<none>"]
+    }
+
+    /// moby matches `reference=<pattern>` with `reference.FamiliarMatch`, which
+    /// runs `path.Match(pattern, x)` for exactly two forms of each repo tag: the
+    /// familiar string (`alpine:latest`) and the familiar name with no tag or
+    /// digest (`alpine`). The registry/library prefix docker hides is stripped
+    /// for both. So `alpine`, `alpine:latest`, and `alpine:*` match a
+    /// `docker.io/library/alpine:latest` image, but the fully-qualified
+    /// `docker.io/library/alpine` does not (matching moby). Patterns OR together.
+    static func referenceMatches(patterns: [String], repoTags: [String]) -> Bool {
+        patterns.contains { pattern in
+            repoTags.contains { tag in
+                familiarForms(tag).contains { globMatch(pattern: pattern, candidate: $0) }
+            }
+        }
+    }
+
+    /// The two forms moby matches a reference against: the familiar string and
+    /// the familiar name (no tag, no digest).
+    static func familiarForms(_ reference: String) -> [String] {
+        let familiarString = familiarize(reference)
+        // Familiar name: drop the digest first, then the tag.
+        var name = familiarString
+        if let at = name.firstIndex(of: "@") { name = String(name[..<at]) }
+        if let colon = name.lastIndex(of: ":"), !name[name.index(after: colon)...].contains("/") {
+            name = String(name[..<colon])
+        }
+        return name == familiarString ? [familiarString] : [familiarString, name]
+    }
+
+    /// Strips the default registry/namespace docker hides in familiar output:
+    /// `docker.io/library/alpine:latest` -> `alpine:latest`,
+    /// `docker.io/user/app:1` -> `user/app:1`. Other registries are unchanged.
+    private static func familiarize(_ reference: String) -> String {
+        for prefix in ["docker.io/library/", "docker.io/"] where reference.hasPrefix(prefix) {
+            return String(reference.dropFirst(prefix.count))
+        }
+        return reference
+    }
+
+    /// Go's `path.Match` semantics: `*` and `?` never match the path separator
+    /// `/`, so match segment by segment with an equal segment count.
+    static func globMatch(pattern: String, candidate: String) -> Bool {
+        let pSegs = pattern.split(separator: "/", omittingEmptySubsequences: false)
+        let cSegs = candidate.split(separator: "/", omittingEmptySubsequences: false)
+        guard pSegs.count == cSegs.count else { return false }
+        return zip(pSegs, cSegs).allSatisfy { wildcard(Array($0), Array($1)) }
+    }
+
+    /// `*`/`?` wildcard match within a single path segment (no `/`).
+    private static func wildcard(_ p: [Character], _ s: [Character]) -> Bool {
+        var pi = 0
+        var si = 0
+        var star = -1
+        var mark = 0
+        while si < s.count {
+            if pi < p.count && (p[pi] == "?" || p[pi] == s[si]) {
+                pi += 1
+                si += 1
+            } else if pi < p.count && p[pi] == "*" {
+                star = pi
+                mark = si
+                pi += 1
+            } else if star != -1 {
+                pi = star + 1
+                mark += 1
+                si = mark
+            } else {
+                return false
+            }
+        }
+        while pi < p.count && p[pi] == "*" { pi += 1 }
+        return pi == p.count
+    }
+}

--- a/Tests/socktainerTests/Routes/ImageListFilterTests.swift
+++ b/Tests/socktainerTests/Routes/ImageListFilterTests.swift
@@ -111,6 +111,28 @@ struct ImageListFilterTests {
         #expect(kept.map(\.RepoTags) == [["docker.io/library/alpine:latest"]])
     }
 
+    @Test("A present reference key with no values matches nothing, unlike an absent key")
+    func applyReferenceEmptyMatchesNothing() throws {
+        // {"reference":{}} and an all-false map both parse to an empty patterns
+        // array, which must still be a real (if impossible-to-satisfy) filter —
+        // verified live: real Docker returns no images for both.
+        let alpine = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let kept = try ImageListRoute.applyFilters([alpine], filters: ["reference": []])
+        #expect(kept.isEmpty)
+    }
+
+    @Test("A boolean-map reference filter with false-only or mixed entries keeps only the true ones")
+    func parseBooleanMapFalseAndMixedEntries() throws {
+        let logger = Logger(label: "test")
+        let falseOnly = try DockerImageFilterUtility.parseImageListFilters(
+            filterParam: #"{"reference": {"alpine": false}}"#, logger: logger)
+        #expect(falseOnly == ["reference": []], "an all-false map registers the key with zero values, not no filter")
+
+        let mixed = try DockerImageFilterUtility.parseImageListFilters(
+            filterParam: #"{"reference": {"alpine": true, "old": false}}"#, logger: logger)
+        #expect(mixed == ["reference": ["alpine"]], "only the true-valued key survives")
+    }
+
     @Test("reference and dangling AND together")
     func referenceAndDanglingAnd() throws {
         let alpine = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
@@ -174,7 +196,10 @@ struct ImageListFilterTests {
     @Test("isJSONBool tells a real JSON boolean apart from a bridged NSNumber")
     func isJSONBoolDistinguishesFromNumber() throws {
         let data = #"{"a": true, "b": false, "c": 1, "d": 0, "e": "x"}"#.data(using: .utf8)!
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("Expected a JSON object")
+            return
+        }
         #expect(DockerImageFilterUtility.isJSONBool(json["a"]!))
         #expect(DockerImageFilterUtility.isJSONBool(json["b"]!))
         #expect(!DockerImageFilterUtility.isJSONBool(json["c"]!), "a JSON 1 must not bridge to true")

--- a/Tests/socktainerTests/Routes/ImageListFilterTests.swift
+++ b/Tests/socktainerTests/Routes/ImageListFilterTests.swift
@@ -93,14 +93,26 @@ struct ImageListFilterTests {
         #expect(kept.map(\.RepoTags) == [["docker.io/library/alpine:latest"]])
     }
 
-    @Test("An unrecognized or conflicting dangling value is a 400, like moby's GetBoolOrDefault")
-    func applyDanglingInvalid() {
+    @Test(
+        "An unrecognized-only or conflicting dangling value is a 400, like moby's GetBoolOrDefault",
+        arguments: [["maybe"], ["true", "false"], []])
+    func applyDanglingInvalid(values: [String]) {
         let images = [Self.summary(repoTags: [])]
-        for values in [["maybe"], ["true", "false"]] {
-            #expect(throws: Abort.self) {
-                try ImageListRoute.applyFilters(images, filters: ["dangling": values])
-            }
+        let error = #expect(throws: Abort.self) {
+            try ImageListRoute.applyFilters(images, filters: ["dangling": values])
         }
+        #expect(error?.status == .badRequest, "values: \(values)")
+    }
+
+    @Test("An unrecognized value alongside a recognized one does not invalidate the filter, like real Docker")
+    func applyDanglingIgnoresExtraUnrecognizedValue() throws {
+        // Verified live against real Docker: dangling=[true,maybe] behaves as
+        // dangling=true — the unrecognized "maybe" is simply irrelevant once a
+        // real true/false token is present, it does not 400 the request.
+        let tagged = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let untagged = Self.summary(repoTags: [])
+        let kept = try ImageListRoute.applyFilters([tagged, untagged], filters: ["dangling": ["true", "maybe"]])
+        #expect(kept.map(\.RepoTags) == [[]])
     }
 
     @Test("reference filters to matching images")

--- a/Tests/socktainerTests/Routes/ImageListFilterTests.swift
+++ b/Tests/socktainerTests/Routes/ImageListFilterTests.swift
@@ -147,6 +147,41 @@ struct ImageListFilterTests {
         #expect(error?.reason == "invalid filter 'bogus'")
     }
 
+    @Test(
+        "Malformed JSON, a non-object top level, and an unsupported value shape are all a 400, like real Docker",
+        arguments: [
+            "not-json",
+            "[]",
+            #"{"reference": 1}"#,
+            #"{"reference": {"alpine": "yes"}}"#,
+            #"{"reference": {"alpine": 1}}"#,
+            #"{"reference": [1, 2]}"#,
+        ])
+    func parseInvalidShapeIs400(filterParam: String) {
+        let error = #expect(throws: Abort.self) {
+            try DockerImageFilterUtility.parseImageListFilters(filterParam: filterParam, logger: Logger(label: "test"))
+        }
+        #expect(error?.status == .badRequest, "filterParam: \(filterParam)")
+    }
+
+    @Test("An absent or empty filters param means no filter, not an error")
+    func parseAbsentOrEmptyIsNoFilter() throws {
+        let logger = Logger(label: "test")
+        #expect(try DockerImageFilterUtility.parseImageListFilters(filterParam: nil, logger: logger).isEmpty)
+        #expect(try DockerImageFilterUtility.parseImageListFilters(filterParam: "", logger: logger).isEmpty)
+    }
+
+    @Test("isJSONBool tells a real JSON boolean apart from a bridged NSNumber")
+    func isJSONBoolDistinguishesFromNumber() throws {
+        let data = #"{"a": true, "b": false, "c": 1, "d": 0, "e": "x"}"#.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(DockerImageFilterUtility.isJSONBool(json["a"]!))
+        #expect(DockerImageFilterUtility.isJSONBool(json["b"]!))
+        #expect(!DockerImageFilterUtility.isJSONBool(json["c"]!), "a JSON 1 must not bridge to true")
+        #expect(!DockerImageFilterUtility.isJSONBool(json["d"]!), "a JSON 0 must not bridge to false")
+        #expect(!DockerImageFilterUtility.isJSONBool(json["e"]!))
+    }
+
     // MARK: - Helpers
 
     private static func summary(repoTags: [String]) -> RESTImageSummary {

--- a/Tests/socktainerTests/Routes/ImageListFilterTests.swift
+++ b/Tests/socktainerTests/Routes/ImageListFilterTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Logging
+import Testing
+import Vapor
+
+@testable import socktainer
+
+/// GET /images/json must honor moby's `reference` and `dangling` filters.
+/// `reference` matches repo tags in familiar form with path.Match globbing;
+/// `dangling` selects images with no repo tags. Different keys AND together.
+@Suite("ImageListRoute — reference and dangling filters")
+struct ImageListFilterTests {
+
+    // MARK: - dangling
+
+    @Test("isDangling is true only for images with no repo tags")
+    func danglingDetection() {
+        #expect(ImageListFilter.isDangling(repoTags: []))
+        #expect(ImageListFilter.isDangling(repoTags: ["<none>:<none>"]))
+        #expect(!ImageListFilter.isDangling(repoTags: ["docker.io/library/alpine:latest"]))
+    }
+
+    // MARK: - reference familiar-form matching
+
+    @Test("A bare name matches any tag of that repo, in familiar form")
+    func bareNameMatchesFamiliar() {
+        let tags = ["docker.io/library/alpine:latest"]
+        #expect(ImageListFilter.referenceMatches(patterns: ["alpine"], repoTags: tags))
+        #expect(ImageListFilter.referenceMatches(patterns: ["alpine:latest"], repoTags: tags))
+    }
+
+    @Test("A fully-qualified reference does not match (moby matches only familiar forms)")
+    func fullyQualifiedDoesNotMatch() {
+        let tags = ["docker.io/library/alpine:latest"]
+        #expect(!ImageListFilter.referenceMatches(patterns: ["docker.io/library/alpine:latest"], repoTags: tags))
+        #expect(!ImageListFilter.referenceMatches(patterns: ["docker.io/library/alpine"], repoTags: tags))
+    }
+
+    @Test("A user-namespaced image is matched by its familiar name")
+    func userNamespaced() {
+        let tags = ["docker.io/myuser/app:1"]
+        #expect(ImageListFilter.referenceMatches(patterns: ["myuser/app"], repoTags: tags))
+        #expect(ImageListFilter.referenceMatches(patterns: ["myuser/app:1"], repoTags: tags))
+    }
+
+    @Test("A tag glob matches only the intended tags")
+    func tagGlob() {
+        #expect(ImageListFilter.referenceMatches(patterns: ["alpine:3.*"], repoTags: ["docker.io/library/alpine:3.18"]))
+        #expect(!ImageListFilter.referenceMatches(patterns: ["alpine:3.*"], repoTags: ["docker.io/library/alpine:latest"]))
+    }
+
+    @Test("A star does not cross the path separator, like path.Match")
+    func starDoesNotCrossSlash() {
+        // `*` matches a single-segment familiar name but not `user/app`.
+        #expect(ImageListFilter.referenceMatches(patterns: ["*"], repoTags: ["docker.io/library/alpine:latest"]))
+        #expect(!ImageListFilter.referenceMatches(patterns: ["*"], repoTags: ["docker.io/myuser/app:1"]))
+        #expect(ImageListFilter.referenceMatches(patterns: ["*/*"], repoTags: ["docker.io/myuser/app:1"]))
+    }
+
+    @Test("A digest-pinned reference still matches by its familiar name")
+    func digestPinnedMatchesByName() {
+        let tags = ["docker.io/library/alpine@sha256:abc123"]
+        #expect(ImageListFilter.referenceMatches(patterns: ["alpine"], repoTags: tags))
+    }
+
+    @Test("A non-matching reference excludes the image")
+    func nonMatch() {
+        #expect(!ImageListFilter.referenceMatches(patterns: ["nginx"], repoTags: ["docker.io/library/alpine:latest"]))
+        #expect(!ImageListFilter.referenceMatches(patterns: ["alpine"], repoTags: []))
+    }
+
+    @Test("Multiple reference patterns OR together")
+    func multipleReferencesOr() {
+        let tags = ["docker.io/library/redis:7"]
+        #expect(ImageListFilter.referenceMatches(patterns: ["nginx", "redis"], repoTags: tags))
+    }
+
+    // MARK: - applyFilters composition
+
+    @Test("dangling=true keeps only untagged images", arguments: ["true", "1"])
+    func applyDangling(value: String) throws {
+        let tagged = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let untagged = Self.summary(repoTags: [])
+        let kept = try ImageListRoute.applyFilters([tagged, untagged], filters: ["dangling": [value]])
+        #expect(kept.map(\.RepoTags) == [[]])
+    }
+
+    @Test("dangling=false keeps only tagged images", arguments: ["false", "0"])
+    func applyDanglingFalse(value: String) throws {
+        let tagged = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let untagged = Self.summary(repoTags: [])
+        let kept = try ImageListRoute.applyFilters([tagged, untagged], filters: ["dangling": [value]])
+        #expect(kept.map(\.RepoTags) == [["docker.io/library/alpine:latest"]])
+    }
+
+    @Test("An unrecognized or conflicting dangling value is a 400, like moby's GetBoolOrDefault")
+    func applyDanglingInvalid() {
+        let images = [Self.summary(repoTags: [])]
+        for values in [["maybe"], ["true", "false"]] {
+            #expect(throws: Abort.self) {
+                try ImageListRoute.applyFilters(images, filters: ["dangling": values])
+            }
+        }
+    }
+
+    @Test("reference filters to matching images")
+    func applyReference() throws {
+        let alpine = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let redis = Self.summary(repoTags: ["docker.io/library/redis:7"])
+        let kept = try ImageListRoute.applyFilters([alpine, redis], filters: ["reference": ["alpine"]])
+        #expect(kept.map(\.RepoTags) == [["docker.io/library/alpine:latest"]])
+    }
+
+    @Test("reference and dangling AND together")
+    func referenceAndDanglingAnd() throws {
+        let alpine = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let untagged = Self.summary(repoTags: [])
+        // dangling=true excludes alpine, and reference=alpine excludes the untagged one → empty.
+        let kept = try ImageListRoute.applyFilters([alpine, untagged], filters: ["dangling": ["true"], "reference": ["alpine"]])
+        #expect(kept.isEmpty)
+    }
+
+    @Test("No filters returns everything unchanged")
+    func noFilters() throws {
+        let a = Self.summary(repoTags: ["docker.io/library/alpine:latest"])
+        let b = Self.summary(repoTags: [])
+        #expect(try ImageListRoute.applyFilters([a, b], filters: [:]).count == 2)
+    }
+
+    // MARK: - filters query parsing
+
+    @Test("The three JSON filter shapes docker clients send all normalize to [key: [value]]")
+    func parseFilterShapes() throws {
+        let logger = Logger(label: "test")
+        for shape in [#"{"reference": {"alpine:*": true}}"#, #"{"reference": ["alpine:*"]}"#, #"{"reference": "alpine:*"}"#] {
+            let parsed = try DockerImageFilterUtility.parseImageListFilters(filterParam: shape, logger: logger)
+            #expect(parsed == ["reference": ["alpine:*"]])
+        }
+    }
+
+    @Test("An unknown filter key is a 400, like moby's filters.Validate")
+    func parseUnknownKeyIs400() {
+        let error = #expect(throws: Abort.self) {
+            try DockerImageFilterUtility.parseImageListFilters(filterParam: #"{"bogus": ["x"]}"#, logger: Logger(label: "test"))
+        }
+        #expect(error?.status == .badRequest)
+        #expect(error?.reason == "invalid filter 'bogus'")
+    }
+
+    // MARK: - Helpers
+
+    private static func summary(repoTags: [String]) -> RESTImageSummary {
+        RESTImageSummary(
+            Id: "sha256:\(repoTags.first ?? "none")",
+            ParentId: "",
+            RepoTags: repoTags,
+            RepoDigests: [],
+            Created: 0,
+            Size: 0,
+            SharedSize: -1,
+            Labels: [:],
+            Containers: 0,
+            Manifests: nil,
+            Descriptor: nil)
+    }
+}

--- a/Tests/socktainerTests/Routes/ImageListFilterTests.swift
+++ b/Tests/socktainerTests/Routes/ImageListFilterTests.swift
@@ -49,6 +49,14 @@ struct ImageListFilterTests {
         #expect(!ImageListFilter.referenceMatches(patterns: ["alpine:3.*"], repoTags: ["docker.io/library/alpine:latest"]))
     }
 
+    @Test("A ? glob matches exactly one character, like path.Match")
+    func questionMarkGlob() {
+        #expect(ImageListFilter.referenceMatches(patterns: ["alp?ne"], repoTags: ["docker.io/library/alpine:latest"]))
+        #expect(!ImageListFilter.referenceMatches(patterns: ["alp?ne"], repoTags: ["docker.io/library/alpne:latest"]), "? must match exactly one character, not zero")
+        #expect(!ImageListFilter.referenceMatches(patterns: ["alp?ne"], repoTags: ["docker.io/library/alppine:latest"]), "? must match exactly one character, not two")
+        #expect(ImageListFilter.referenceMatches(patterns: ["alpine:3.1?"], repoTags: ["docker.io/library/alpine:3.18"]))
+    }
+
     @Test("A star does not cross the path separator, like path.Match")
     func starDoesNotCrossSlash() {
         // `*` matches a single-segment familiar name but not `user/app`.


### PR DESCRIPTION
## Summary

`GET /images/json` ignored the `filters` query, so `docker images -f reference=...` and `docker images -f dangling=...` returned every image.

It now applies the `reference` and `dangling` filters, matching moby's semantics:

- `reference` uses `reference.FamiliarMatch`: path.Match-style `*` and `?` globbing against exactly two forms of each repo tag, the familiar string (`alpine:latest`) and the familiar name with the tag and digest stripped (`alpine`). The `docker.io/library/` prefix docker hides is stripped for both, and `*`/`?` do not cross the `/` separator. So `alpine`, `alpine:latest`, and `alpine:*` match a `docker.io/library/alpine:latest` image, while the fully-qualified `docker.io/library/alpine` does not, exactly as moby behaves. (Go `path.Match`'s character classes and backslash escapes are not implemented; docker reference globs use `*` and `?`.)
- `dangling=true` selects images with no repo tags; `dangling=false` selects the rest. Like moby's `filters.GetBoolOrDefault`, only `0`/`1`/`true`/`false` are recognized, and an unrecognized or conflicting value is a 400.

Multiple values of one key OR together; different keys AND. The other image-ls keys (`label`, `since`, `before`, `until`) are recognized but not yet filtered, and an unknown key is rejected with 400 `invalid filter '...'`, matching moby's `filters.Validate`. The filters are validated before any listing work.

## Before

```console
# alpine and redis:7 pulled; filters query ignored entirely
$ curl --unix-socket .../container.sock '.../images/json?filters={"reference":["alpine"]}'
[... all 3 images, including redis:7 and the base vminit image ...]   # reference filter ignored

$ curl -o /dev/null -w '%{http_code}\n' --unix-socket .../container.sock '.../images/json?filters={"bogus":["1"]}'
200   # unknown filter key silently accepted
```

## After

```console
$ curl --unix-socket .../container.sock '.../images/json?filters={"reference":["alpine"]}'
[{"RepoTags":["docker.io/library/alpine:latest"], ...}]   # only alpine

$ curl --unix-socket .../container.sock '.../images/json?filters={"bogus":["1"]}'
{"message":"invalid filter 'bogus'", ...}
HTTP 400
```

Every case above, plus the `dangling`/`reference` edge cases in the tests below, was cross-checked against real Docker (orbstack): the `invalid filter 'dangling=[bogus]'` and `invalid filter 'bogus'` messages, the `dangling=TRUE` case-sensitivity rejection, and the fully-qualified-reference non-match all match real Docker's output verbatim.

## Testing

- New unit tests in `Tests/socktainerTests/Routes/ImageListFilterTests.swift`:
  - `dangling` detection and `applyFilters` for dangling true/false (`0`/`1`/`true`/`false`), with a 400 for an unrecognized or conflicting value
  - `reference` familiar-form matching: bare name, name:tag, tag glob, user-namespaced image, digest-pinned reference matched by name
  - moby edge cases: a fully-qualified `docker.io/library/alpine` does not match; `*` does not cross `/`
  - `reference` and `dangling` AND together; no filters returns everything
  - filters query parsing: the three JSON shapes docker clients send, and a 400 for an unknown filter key
- `make fmt`, `make build`, `make test` (854 tests) pass.
