### PR TITLE
fix: warn instead of exiting on Apple Container version mismatch

### DIFF
--- a/Sources/socktainer/Utilities/AppleContainerUtility.swift
+++ b/Sources/socktainer/Utilities/AppleContainerUtility.swift
@@ -93,15 +93,41 @@ public struct AppleContainerVersionCheck {
         return error.isCode(.internalError) && error.message.hasPrefix("XPC timeout for request")
     }
 
+    /// What to do once a `VersionCheckError` has been classified.
+    enum CompatibilityAction: Equatable {
+        case proceedWithWarning(String)
+        case abort(String)
+    }
+
+    static func compatibilityAction(for error: VersionCheckError) -> CompatibilityAction {
+        switch error {
+        case .incompatibleVersion:
+            return .proceedWithWarning(
+                "⚠️  Apple Container compatibility warning:\n"
+                    + "   \(error.localizedDescription)\n"
+                    + "   Continuing anyway — most functionality works across nearby versions, but you may hit issues."
+            )
+        case .versionDetectionFailed, .appleContainerUnavailable:
+            return .abort(
+                "❌ Apple Container compatibility check failed:\n"
+                    + "   Error: \(error.localizedDescription)"
+            )
+        }
+    }
+
     /// Performs compatibility check with user-friendly output and exit if it fails
     public static func performCompatibilityCheck() async {
         do {
             try await checkCompatibility()
             print("✅ Apple Container compatibility check passed")
         } catch let error as VersionCheckError {
-            print("❌ Apple Container compatibility check failed:")
-            print("   Error: \(error.localizedDescription)")
-            exit(1)
+            switch compatibilityAction(for: error) {
+            case .proceedWithWarning(let message):
+                print(message)
+            case .abort(let message):
+                print(message)
+                exit(1)
+            }
         } catch {
             print("⚠️  Warning: Could not verify Apple Container compatibility: \(error)")
         }

--- a/Tests/socktainerTests/Utilities/AppleContainerVersionCheckTests.swift
+++ b/Tests/socktainerTests/Utilities/AppleContainerVersionCheckTests.swift
@@ -99,3 +99,46 @@ struct AppleContainerVersionCheckTests {
         }
     }
 }
+
+@Suite("Apple Container compatibility action")
+struct AppleContainerCompatibilityActionTests {
+
+    @Test("a version mismatch warns and does not abort")
+    func versionMismatchWarnsAndContinues() {
+        let error = AppleContainerVersionCheck.VersionCheckError.incompatibleVersion(
+            detected: "1.2.2",
+            expected: "1.2.0"
+        )
+
+        let action = AppleContainerVersionCheck.compatibilityAction(for: error)
+
+        guard case .proceedWithWarning(let message) = action else {
+            Issue.record("Expected .proceedWithWarning, got \(action)")
+            return
+        }
+        #expect(message.contains("1.2.2"))
+        #expect(message.contains("1.2.0"))
+    }
+
+    @Test("an unreachable Apple Container service still aborts")
+    func unavailableServiceStillAborts() {
+        let action = AppleContainerVersionCheck.compatibilityAction(for: .appleContainerUnavailable)
+
+        guard case .abort = action else {
+            Issue.record("Expected .abort, got \(action)")
+            return
+        }
+    }
+
+    @Test("a version detection failure still aborts")
+    func detectionFailureStillAborts() {
+        let action = AppleContainerVersionCheck.compatibilityAction(
+            for: .versionDetectionFailed("boom")
+        )
+
+        guard case .abort = action else {
+            Issue.record("Expected .abort, got \(action)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
The compatibility check called `exit(1)` unconditionally on any version mismatch between socktainer's pinned `apple/container` dependency and the running `container-apiserver`. Nearby mismatches (e.g. built against 1.2.0, running against 1.2.2) are functionally fine in practice, so this downgrades a version *mismatch* specifically to a warning instead of a hard exit.
## Related Issue
Related to #181 (only the "fatal compatibility check" part — the separate JSON decoding issue for version pairs with actual breaking API changes is not addressed here).
## Changes
- `AppleContainerVersionCheck.performCompatibilityCheck()` now delegates to a new `compatibilityAction(for:)` function that classifies each `VersionCheckError`:
  - `.incompatibleVersion` → warn and continue starting up.
  - `.versionDetectionFailed` / `.appleContainerUnavailable` → still abort, since nothing would work in those cases regardless of the version check.
- Added unit tests covering all three classifications.
## Testing
- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (840/840, including 3 new tests)
- [x] Unit tests added for `compatibilityAction(for:)`
- [x] Manual testing: ran the built binary with no `--no-check-compatibility` flag against a real version mismatch (socktainer built against 1.2.0, `container` 1.2.2 installed) — previously exited immediately, now warns and starts normally. Also verified `docker version`/`ps`/`run`/`network ls` all work correctly across this mismatch before proposing the fix.

## Checklist
- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
