### PR TITLE
fix(dns): stop leaking the client's EDNS0 OPT record into local answers

### DIFF
--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -246,7 +246,14 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return forwardToUpstream(packet)
     }
 
-    private func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
+    /// Parses the single question at `offset`. Returns nil if QDCOUNT isn't exactly 1 —
+    /// a query claiming zero or multiple questions must not be answered as if the bytes
+    /// after the header were a single trusted question.
+    func parseQuestion(_ packet: [UInt8], offset: Int) -> (String, UInt16, Int)? {
+        guard packet.count >= 6 else { return nil }
+        let qdcount = (UInt16(packet[4]) << 8) | UInt16(packet[5])
+        guard qdcount == 1 else { return nil }
+
         var pos = offset
         var labels: [String] = []
         while pos < packet.count {

--- a/Sources/socktainer/DNS/SocktainerDNSServer.swift
+++ b/Sources/socktainer/DNS/SocktainerDNSServer.swift
@@ -174,7 +174,7 @@ final class SocktainerDNSServer: @unchecked Sendable {
         guard packet.count >= 12 else { return nil }
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
-        guard let (qname, qtype, _) = parseQuestion(packet, offset: 12) else { return nil }
+        guard let (qname, qtype, qend) = parseQuestion(packet, offset: 12) else { return nil }
         let normalized = Self.normalize(qname)
         let isSingleLabel = !normalized.contains(".")
         if qtype == 1 {
@@ -183,24 +183,24 @@ final class SocktainerDNSServer: @unchecked Sendable {
             lock.unlock()
             if let ip {
                 log.info("[dns] A \(normalized) → \(ip[0]).\(ip[1]).\(ip[2]).\(ip[3]) (local)")
-                return buildAResponse(packet: packet, ip: ip)
+                return buildAResponse(packet: packet, questionEnd: qend, ip: ip)
             }
             if isSingleLabel {
                 log.info("[dns] \(normalized) not in table (local NXDOMAIN)")
-                return buildNxdomainResponse(packet: packet)
+                return buildNxdomainResponse(packet: packet, questionEnd: qend)
             }
         } else if qtype == 28 {
-            if isSingleLabel { return buildNodataResponse(packet: packet) }
+            if isSingleLabel { return buildNodataResponse(packet: packet, questionEnd: qend) }
             lock.lock()
             let known = entries[normalized] != nil
             lock.unlock()
-            if known { return buildNodataResponse(packet: packet) }
+            if known { return buildNodataResponse(packet: packet, questionEnd: qend) }
         }
         // Any other single-label query type (HTTPS/SVCB/SRV/TXT/…) is answered NODATA
         // locally rather than forwarded: a single-label name has no public meaning, so
         // forwarding it upstream only invites an authoritative NXDOMAIN that poisons the
         // resolver's parallel A+AAAA lookups.
-        if isSingleLabel { return buildNodataResponse(packet: packet) }
+        if isSingleLabel { return buildNodataResponse(packet: packet, questionEnd: qend) }
         return nil
     }
 
@@ -211,7 +211,7 @@ final class SocktainerDNSServer: @unchecked Sendable {
         let flags = (UInt16(packet[2]) << 8) | UInt16(packet[3])
         guard (flags & 0x8000) == 0, (flags & 0x7800) == 0 else { return nil }
 
-        guard let (qname, qtype, _) = parseQuestion(packet, offset: 12) else {
+        guard let (qname, qtype, qend) = parseQuestion(packet, offset: 12) else {
             return forwardToUpstream(packet)
         }
 
@@ -227,20 +227,20 @@ final class SocktainerDNSServer: @unchecked Sendable {
             lock.unlock()
             if let ip {
                 log.info("[dns] A \(normalized) → \(ip[0]).\(ip[1]).\(ip[2]).\(ip[3]) (local)")
-                return buildAResponse(packet: packet, ip: ip)
+                return buildAResponse(packet: packet, questionEnd: qend, ip: ip)
             }
             if isSingleLabel {
                 log.info("[dns] \(normalized) not in table (local NXDOMAIN)")
-                return buildNxdomainResponse(packet: packet)
+                return buildNxdomainResponse(packet: packet, questionEnd: qend)
             }
         } else if qtype == 28 {  // AAAA — container names are IPv4-only
             // For single-label names return NODATA unconditionally; forwarding to 1.1.1.1
             // would yield an authoritative NXDOMAIN that poisons concurrent A+AAAA resolvers.
-            if isSingleLabel { return buildNodataResponse(packet: packet) }
+            if isSingleLabel { return buildNodataResponse(packet: packet, questionEnd: qend) }
             lock.lock()
             let known = entries[normalized] != nil
             lock.unlock()
-            if known { return buildNodataResponse(packet: packet) }
+            if known { return buildNodataResponse(packet: packet, questionEnd: qend) }
         }
 
         return forwardToUpstream(packet)
@@ -264,8 +264,8 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return (labels.joined(separator: "."), qtype, pos)
     }
 
-    private func buildAResponse(packet: [UInt8], ip: [UInt8]) -> [UInt8] {
-        var response = packet
+    private func buildAResponse(packet: [UInt8], questionEnd: Int, ip: [UInt8]) -> [UInt8] {
+        var response = Array(packet[0..<questionEnd])
         let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
         let rflags: UInt16 = 0x8400 | rd  // QR=1, AA=1
         response[2] = UInt8(rflags >> 8)
@@ -287,8 +287,8 @@ final class SocktainerDNSServer: @unchecked Sendable {
         return response
     }
 
-    private func buildNodataResponse(packet: [UInt8]) -> [UInt8] {
-        var response = packet
+    private func buildNodataResponse(packet: [UInt8], questionEnd: Int) -> [UInt8] {
+        var response = Array(packet[0..<questionEnd])
         let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
         let rflags: UInt16 = 0x8400 | rd
         response[2] = UInt8(rflags >> 8)
@@ -303,8 +303,8 @@ final class SocktainerDNSServer: @unchecked Sendable {
     }
 
     // Non-authoritative NXDOMAIN (no AA bit) so clients retry rather than cache permanently.
-    private func buildNxdomainResponse(packet: [UInt8]) -> [UInt8] {
-        var response = packet
+    private func buildNxdomainResponse(packet: [UInt8], questionEnd: Int) -> [UInt8] {
+        var response = Array(packet[0..<questionEnd])
         let rd = (UInt16(packet[2]) << 8 | UInt16(packet[3])) & 0x0100
         let rflags: UInt16 = 0x8003 | rd  // QR=1, Recursion Desired, RCODE=3
         response[2] = UInt8(rflags >> 8)

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -356,6 +356,55 @@ struct SocktainerDNSQueryTests {
     }
 }
 
+/// Builds a minimal DNS query packet for `name`/`type` with a caller-specified QDCOUNT,
+/// so tests can construct headers that lie about how many questions actually follow.
+private func makeQueryPacket(name: String, type: UInt16, qdcount: UInt16) -> [UInt8] {
+    var qname = [UInt8]()
+    for label in name.split(separator: ".") {
+        let bytes = Array(label.utf8)
+        qname.append(UInt8(bytes.count))
+        qname.append(contentsOf: bytes)
+    }
+    qname.append(0)
+
+    var packet = [UInt8]()
+    packet += [0x00, 0x01, 0x01, 0x00]  // ID + RD=1 query
+    packet += [UInt8(qdcount >> 8), UInt8(qdcount & 0xFF), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    packet += qname
+    packet += [UInt8(type >> 8), UInt8(type & 0xFF), 0x00, 0x01]
+    return packet
+}
+
+@Suite("SocktainerDNSServer.parseQuestion — QDCOUNT validation")
+struct ParseQuestionQDCountTests {
+
+    @Test("QDCOUNT=1 parses the question normally")
+    func qdcountOneParses() {
+        let server = SocktainerDNSServer()
+        let packet = makeQueryPacket(name: "redis", type: 1, qdcount: 1)
+        let result = server.parseQuestion(packet, offset: 12)
+        #expect(result?.0 == "redis")
+        #expect(result?.1 == 1)
+    }
+
+    // Regression test: QDCOUNT was never checked, so a query claiming zero questions
+    // was still answered as if the well-formed bytes after the header were a trusted
+    // question — this packet would previously have been answered as a valid "redis" query.
+    @Test("QDCOUNT=0 is rejected even though a well-formed question follows")
+    func qdcountZeroRejected() {
+        let server = SocktainerDNSServer()
+        let packet = makeQueryPacket(name: "redis", type: 1, qdcount: 0)
+        #expect(server.parseQuestion(packet, offset: 12) == nil)
+    }
+
+    @Test("QDCOUNT=2 is rejected")
+    func qdcountTwoRejected() {
+        let server = SocktainerDNSServer()
+        let packet = makeQueryPacket(name: "redis", type: 1, qdcount: 2)
+        #expect(server.parseQuestion(packet, offset: 12) == nil)
+    }
+}
+
 // MARK: - EmbeddedDNSImage / SocktainerDNSImage
 
 @Suite("EmbeddedDNSImage")

--- a/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
+++ b/Tests/socktainerTests/DNS/SocktainerDNSServerTests.swift
@@ -216,8 +216,94 @@ private func dnsRcode(type: UInt16, name: String, port: Int) -> UInt8? {
     return nil
 }
 
+/// Sends a DNS A query with an EDNS0 OPT record appended to the ADDITIONAL section —
+/// matching what Go's resolver and `dig` send by default — and returns the raw response.
+private func dnsQueryWithEDNS0(name: String, port: Int) -> [UInt8]? {
+    var qname = [UInt8]()
+    for label in name.split(separator: ".") {
+        let bytes = Array(label.utf8)
+        qname.append(UInt8(bytes.count))
+        qname.append(contentsOf: bytes)
+    }
+    qname.append(0)
+
+    var packet = [UInt8]()
+    packet += [0x56, 0x78, 0x01, 0x00]  // ID + RD=1 query
+    packet += [0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]  // QDCOUNT=1, ARCOUNT=1
+    packet += qname
+    packet += [0x00, 0x01, 0x00, 0x01]  // QTYPE=A, QCLASS=IN
+    // EDNS0 OPT pseudo-record: root name, TYPE=41, CLASS=4096 (UDP payload size), TTL=0, RDLENGTH=0
+    packet += [0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+    var dst = sockaddr_in()
+    dst.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    dst.sin_family = sa_family_t(AF_INET)
+    dst.sin_port = in_port_t(port).bigEndian
+    inet_pton(AF_INET, "127.0.0.1", &dst.sin_addr)
+
+    for attempt in 0..<5 {
+        if attempt > 0 { Thread.sleep(forTimeInterval: 0.05) }
+        let fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard fd >= 0 else { continue }
+        defer { Darwin.close(fd) }
+        var tv = timeval(tv_sec: 0, tv_usec: 200_000)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        let sent = packet.withUnsafeBytes { ptr in
+            withUnsafePointer(to: &dst) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    sendto(fd, ptr.baseAddress!, packet.count, 0, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+        }
+        guard sent > 0 else { continue }
+        var buf = [UInt8](repeating: 0, count: 512)
+        let n = recv(fd, &buf, buf.count, 0)
+        if n > 0 { return Array(buf[0..<n]) }
+    }
+    return nil
+}
+
 @Suite("SocktainerDNSServer — query behaviour")
 struct SocktainerDNSQueryTests {
+
+    // Regression test for #329: the response used to reuse the entire raw query packet
+    // (including the client's trailing EDNS0 OPT record) as its base, so the OPT record
+    // ended up masquerading as the answer while the real A record became unaccounted
+    // trailing bytes. Go's resolver and `dig` both send EDNS0 by default.
+    @Test("A query with an EDNS0 OPT record still returns the real A record as the answer")
+    func aQueryWithEDNS0ReturnsCorrectAnswer() throws {
+        let server = SocktainerDNSServer()
+        guard let port = server.start(preferredPort: 19750, maxAttempts: 5) else {
+            Issue.record("Could not bind DNS server port")
+            return
+        }
+        server.register(hostname: "redis", ip: "192.168.67.5")
+        guard let response = dnsQueryWithEDNS0(name: "redis", port: port) else {
+            Issue.record("No response received")
+            return
+        }
+
+        let ancount = (UInt16(response[6]) << 8) | UInt16(response[7])
+        let arcount = (UInt16(response[10]) << 8) | UInt16(response[11])
+        #expect(ancount == 1, "must claim exactly one answer")
+        #expect(arcount == 0, "must not carry the client's EDNS0 OPT through as an additional record")
+
+        // Walk the question the same way the server does: QNAME labels, then QTYPE(2) + QCLASS(2).
+        var pos = 12
+        while pos < response.count, response[pos] != 0 {
+            pos += Int(response[pos]) + 1
+        }
+        pos += 1 + 4
+
+        let answerType = (UInt16(response[pos + 2]) << 8) | UInt16(response[pos + 3])
+        #expect(answerType == 1, "the record right after the question must be the A record, not the client's leftover OPT (type 41)")
+
+        let rdlength = (Int(response[pos + 10]) << 8) | Int(response[pos + 11])
+        let rdataStart = pos + 12
+        #expect(rdlength == 4)
+        #expect(Array(response[rdataStart..<(rdataStart + 4)]) == [192, 168, 67, 5])
+        #expect(response.count == rdataStart + 4, "response must not carry any leftover bytes from the client's OPT record")
+    }
 
     @Test("A query for registered single-label name returns RCODE 0 (NOERROR)")
     func aQueryKnownNameReturnsNoerror() throws {


### PR DESCRIPTION
## Summary

`buildAResponse`/`buildNodataResponse`/`buildNxdomainResponse` in `SocktainerDNSServer` built local DNS responses by taking the entire raw query packet as their base — including any trailing EDNS0 OPT pseudo-record — and only overwriting header counts and appending new records at the end. The client's leftover OPT record was never stripped, so a parser reading `ANCOUNT=1` right after the question hit that leftover OPT first (misreading it as the answer), while the real A record became unaccounted trailing bytes.

## Related Issue

Fixes #329.

## Changes

- `parseQuestion` already computed the offset where the question ends; that offset is now threaded through `handleLocalQuery`/`handleQuery` instead of being discarded.
- `buildAResponse`, `buildNodataResponse`, and `buildNxdomainResponse` now truncate their base packet to that offset before appending records, so no bytes from the client's query can leak into the response.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (838/838, including a new regression test that constructs a real query with an EDNS0 OPT record and asserts the answer is the A record, not the OPT, with zero leftover bytes)
- [x] Unit test added covering the exact bug from #329
- [x] Manual testing: `dig` against both the DNS sidecar and socktainer's own upstream server now returns a clean, correctly-encoded A record with no malformed-packet warning. Also verified with a real docker-compose stack (Flask app + Redis, resolving Redis by service name) that previously hung indefinitely — now resolves instantly and serves requests correctly end-to-end (port publish → DNS → Redis → volume-backed state all confirmed working).

Also worth noting: #329 states musl-based (Alpine) clients tolerate the malformed packet and resolve correctly. In testing that wasn't reliably true — Python's `socket.gethostbyname` and busybox `nslookup` both hung indefinitely against the malformed response rather than resolving, so the real-world impact is broader than Go clients alone.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)