### PR TITLE
fix(exec): honor defaultMaxBodySize on POST /containers/{id}/exec

### DIFF
--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -178,7 +178,24 @@ struct ExecRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "Missing container ID")
             }
 
-            let body = try req.content.decode(CreateExecRequest.self)
+            // `req.content.decode` collects the body with no explicit max, which silently
+            // caps at Vapor's 1<<14 (16 KB) default — `defaultMaxBodySize` is only consulted
+            // by Vapor's registered-route collection, which the RegexRouter bypasses. An
+            // exec-create payload carries the full caller environment (Env), which routinely
+            // exceeds 16 KB for real dev tooling (VS Code Dev Containers' bundled Docker
+            // client hits this on every few exec calls it makes during startup — issue #192).
+            // Honor the configured cap explicitly, matching ContainerCreateRoute.
+            guard let bodyData = try await req.body.collect(max: req.application.routes.defaultMaxBodySize.value).get(),
+                let data = bodyData.getData(at: 0, length: bodyData.readableBytes), !data.isEmpty
+            else {
+                throw Abort(.badRequest, reason: "Request body is required")
+            }
+            let body: CreateExecRequest
+            do {
+                body = try JSONDecoder().decode(CreateExecRequest.self, from: data)
+            } catch {
+                throw Abort(.badRequest, reason: "Invalid JSON request body")
+            }
 
             // Docker rejects an exec with no command at create time, before even
             // resolving the container. Without this guard the empty Cmd is stored

--- a/Tests/socktainerTests/Routes/ExecCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ExecCreateRouteTests.swift
@@ -50,12 +50,99 @@ struct ExecCreateRouteTests {
     }
 }
 
+/// Regression tests for the >16 KB request-body fix on `POST /containers/{id}/exec`,
+/// mirroring `ContainerCreateRouteTests`' — see that file for the full explanation of
+/// why `Request.body.collect()` silently caps at 16 KB under socktainer's `RegexRouter`.
+/// An exec-create payload carries the caller's full environment (`Env`), which routinely
+/// exceeds 16 KB for real dev tooling — VS Code Dev Containers' bundled Docker client
+/// hits this on a fraction of the exec calls it makes during startup (issue #192),
+/// surfacing as `422 Unprocessable Entity` from the truncated/malformed JSON.
+///
+/// As with `ContainerCreateRouteTests`, these run against a LIVE server (`.running`) on
+/// an ephemeral port — the in-memory tester delivers an already-collected body, for which
+/// `collect(max:)` ignores the limit, so only a real streamed body exercises the cap.
+@Suite("ExecRoute — request body size")
+struct ExecCreateRouteBodySizeTests {
+
+    @Test("a >16 KB exec-create body (large Env) is collected, not rejected with 422/413")
+    func largeBodyIsAccepted() async throws {
+        let env = (0..<300).map { #""SOME_LONG_ENV_VAR_NAME_\#($0)=some_reasonably_long_value_\#($0)""# }
+        let payload = #"{"Cmd":["echo","hi"],"Env":[\#(env.joined(separator: ","))]}"#
+        #expect(payload.utf8.count > 16_384)
+
+        try await withRunningContainerApp(maxBodySize: "64mb") { app in
+            try await app.testing(method: .running(hostname: "127.0.0.1", port: 0)).test(
+                .POST, "/v1.51/containers/running-ctr/exec",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: payload)
+            ) { res async throws in
+                #expect(res.status == .created, "large body must be collected and decoded, not 422/413")
+                let created = try JSONDecoder().decode(CreateExecResponse.self, from: Data(buffer: res.body))
+                await ExecManager.shared.remove(id: created.Id)
+            }
+        }
+    }
+
+    @Test("the configured body cap is still enforced (a body over the limit is 413)")
+    func bodyOverCapIsRejected() async throws {
+        let payload = #"{"Cmd":["echo","\#(String(repeating: "A", count: 4_096))"]}"#
+        try await withRunningContainerApp(maxBodySize: "1kb") { app in
+            try await app.testing(method: .running(hostname: "127.0.0.1", port: 0)).test(
+                .POST, "/v1.51/containers/running-ctr/exec",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: payload)
+            ) { res async in
+                #expect(res.status == .payloadTooLarge)
+            }
+        }
+    }
+
+    @Test("an empty POST body returns 400, not a crash")
+    func emptyBodyIsBadRequest() async throws {
+        try await withRunningContainerApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(.POST, "/v1.51/containers/running-ctr/exec") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("a malformed JSON body returns 400, not 500")
+    func malformedBodyIsBadRequest() async throws {
+        try await withRunningContainerApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/running-ctr/exec",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: "{ this is not valid json")
+            ) { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+}
+
 // MARK: - Helpers
 
 private func withRunningContainerApp(
     test: @escaping (Application) async throws -> Void
 ) async throws {
     try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+        try app.register(collection: ExecRoute(client: RunningContainerMock()))
+        try await test(app)
+    }
+}
+
+private func withRunningContainerApp(
+    maxBodySize: ByteCount,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    try await withApp(configure: { app in
+        app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+        app.routes.defaultMaxBodySize = maxBodySize
+    }) { app in
         let regexRouter = app.regexRouter(with: app.logger)
         app.setRegexRouter(regexRouter)
         regexRouter.installMiddleware(on: app)


### PR DESCRIPTION
## Summary

`POST /containers/{id}/exec` decoded its body via `req.content.decode(CreateExecRequest.self)`, which collects with no explicit max and silently caps at Vapor's 16 KB default — the same bug class already fixed for `POST /containers/create` in #252, unfixed here. An exec-create payload carries the caller's full environment (`Env`), which routinely exceeds 16 KB for real dev tooling.

## Related Issue

Confirmed root cause of the "No ptyHost heartbeat" hang reported in #192. VS Code Dev Containers' bundled Docker client hits this on a fraction of the exec calls it makes during startup, surfacing as `Abort.422: Unprocessable Entity`.

## Changes

- `ExecRoutes.swift`'s `createExec` now hand-collects the body honoring `req.application.routes.defaultMaxBodySize`, matching `ContainerCreateRoute`'s existing pattern, with the same empty-body/malformed-JSON → 400 handling (instead of the generic 422/500 Vapor would otherwise produce).

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (841/841, including 4 new tests: large body accepted, configured cap still enforced, empty body → 400, malformed JSON → 400)
- [x] Unit tests added covering the fix and its edge cases
- [x] Manual testing: the exact 26,990-byte body that previously returned 422 now returns 201
- [x] **Confirmed this is the actual #192 mechanism, not just a plausible match** — reproduced live via a real VS Code Dev Containers attach (not a synthetic client): the identical `Abort.422` with `userAgent: Docker-Client/29.7.2 (darwin)` appeared during genuine VS Code Server bootstrap traffic against a running container.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)