### PR TITLE
fix(events): emit die for attach-bootstrapped containers

### DIFF
--- a/Sources/socktainer/Events/DieEventOwnership.swift
+++ b/Sources/socktainer/Events/DieEventOwnership.swift
@@ -37,14 +37,41 @@ actor DieEventOwnership {
 
     private var epoch: [String: Int] = [:]
     private var runs: [RunKey: Run] = [:]
+    private var tombstoned: Set<String> = []
 
-    /// Opens a new run for `id` and returns its epoch. The exit it produces is claimable once.
+    /// Opens a run for `id` and returns its epoch, or joins the run already open.
     ///
-    /// Called where the container starts executing — the attach route's bootstrap, a `POST /start`
-    /// that actually started it, `POST /restart`, and a restart-policy restart. It must *not* be
-    /// called for a start against an already-running container: `docker run` attaches (bootstrap)
-    /// and then starts, and both observers have to land on the same run.
+    /// Called where the container starts executing: the attach route's bootstrap and a
+    /// `POST /start` that started it. `docker run` does *both* concurrently — it attaches and
+    /// starts, and whichever request wins the race starts the container while the other gets a
+    /// benign "already booted". Joining an undecided run is what keeps that pair on one run:
+    /// two runs for one physical exit would let each side's observer claim its own and emit a
+    /// `die` apiece. A run whose exit was already reported is finished, so the next start opens
+    /// a fresh one.
     func beginRun(id: String) -> Int {
+        tombstoned.remove(id)
+        let current = epoch[id] ?? 0
+        if let open = runs[RunKey(id: id, epoch: current)], !open.emitterDecided {
+            return current
+        }
+        return openNewRun(id: id)
+    }
+
+    /// Opens a run for a container the caller just stopped and started again — `POST /restart`
+    /// and restart-policy restarts. Unconditional, because the stop ended the previous run even
+    /// if its exit has not been reported yet; joining it would leave the new run unreportable.
+    func beginRestartedRun(id: String) -> Int {
+        tombstoned.remove(id)
+        return openNewRun(id: id)
+    }
+
+    /// The run an observer joins when it did not start the container itself — attaching to an
+    /// already-running container, or a `/start` that found it running.
+    func currentEpoch(id: String) -> Int {
+        epoch[id] ?? 0
+    }
+
+    private func openNewRun(id: String) -> Int {
         let next = (epoch[id] ?? 0) + 1
         epoch[id] = next
         runs[RunKey(id: id, epoch: next)] = Run()
@@ -54,10 +81,27 @@ actor DieEventOwnership {
         return next
     }
 
-    /// The run an observer joins when it did not start the container itself — attaching to an
-    /// already-running container, or a `/start` that found it running.
-    func currentEpoch(id: String) -> Int {
-        epoch[id] ?? 0
+    /// Drops a removed container's die-event bookkeeping.
+    ///
+    /// A run whose exit was already reported is tombstoned: further claims are refused, because
+    /// an observer arriving after the record was dropped would otherwise find no run, take it,
+    /// and emit a second `die` for that exit. That is the `--rm` path, which cleans up *after*
+    /// broadcasting.
+    ///
+    /// A run still open is left claimable instead. `docker rm -f` stops and deletes a running
+    /// container, and its exit monitor resolves the code (behind a flush grace) only after the
+    /// delete has landed — refusing that claim would turn `die` into a race with teardown and
+    /// drop the event Docker does send. Its epoch entry stays so a container recreated under the
+    /// same name cannot be handed the dead run.
+    func forget(id: String) {
+        let current = epoch[id] ?? 0
+        runs.removeValue(forKey: RunKey(id: id, epoch: current - 1))
+
+        let key = RunKey(id: id, epoch: current)
+        guard runs[key]?.emitterDecided ?? true else { return }
+        runs.removeValue(forKey: key)
+        epoch.removeValue(forKey: id)
+        tombstoned.insert(id)
     }
 
     /// Declares that a start-route observer of `generation` will emit this run's `die`.
@@ -74,6 +118,7 @@ actor DieEventOwnership {
     /// broadcast. False means this run was already reported — by the exit monitor, when the
     /// container exited before this observer armed.
     func claimForStart(id: String, epoch runEpoch: Int, generation: Int) -> Bool {
+        guard !tombstoned.contains(id) else { return false }
         let key = RunKey(id: id, epoch: runEpoch)
         var run = runs[key] ?? Run()
         guard !run.emitterDecided, run.reservedGeneration == generation else { return false }
@@ -85,6 +130,7 @@ actor DieEventOwnership {
     /// Called by the attach paths' exit monitor. False means a start-route observer reserved
     /// this run — `docker run` — and will emit the richer event, or the run is already reported.
     func claimForMonitor(id: String, epoch runEpoch: Int) -> Bool {
+        guard !tombstoned.contains(id) else { return false }
         let key = RunKey(id: id, epoch: runEpoch)
         var run = runs[key] ?? Run()
         guard !run.emitterDecided, run.reservedGeneration == nil else { return false }

--- a/Sources/socktainer/Events/DieEventOwnership.swift
+++ b/Sources/socktainer/Events/DieEventOwnership.swift
@@ -15,6 +15,13 @@
 /// observer carries the epoch of the run it watches, so a monitor still resolving a slow exit
 /// cannot claim the *next* run and silence it.
 ///
+/// Epochs come from one counter shared by every container and are never reused, because
+/// container names are: `compose up` after `down` recreates a service's container under the same
+/// name. With per-container numbering the recreated container would be handed epoch 1 again, and
+/// the deleted container's lagging observer could claim it — emitting a stale `die` and leaving
+/// the new run unable to report its own exit. A claim naming a run that is no longer tracked is
+/// refused rather than treated as a fresh one.
+///
 /// Between the two observers the start-route one is preferred: its event carries `execDuration`
 /// and the container's post-start labels, which the monitor cannot see. It therefore *reserves*
 /// the run when it arms, and the monitor defers to that reservation. A redundant `POST /start`
@@ -35,107 +42,115 @@ actor DieEventOwnership {
         let epoch: Int
     }
 
-    private var epoch: [String: Int] = [:]
+    private var nextEpoch = 0
+    private var currentEpochs: [String: Int] = [:]
+    private var previousEpochs: [String: Int] = [:]
     private var runs: [RunKey: Run] = [:]
-    private var tombstoned: Set<String> = []
+    private var pendingForget: Set<RunKey> = []
 
     /// Opens a run for `id` and returns its epoch, or joins the run already open.
     ///
-    /// Called where the container starts executing: the attach route's bootstrap and a
-    /// `POST /start` that started it. `docker run` does *both* concurrently — it attaches and
-    /// starts, and whichever request wins the race starts the container while the other gets a
-    /// benign "already booted". Joining an undecided run is what keeps that pair on one run:
-    /// two runs for one physical exit would let each side's observer claim its own and emit a
-    /// `die` apiece. A run whose exit was already reported is finished, so the next start opens
-    /// a fresh one.
+    /// Called where the container starts executing: the attach route's bootstrap, and a
+    /// `POST /start` whether or not it was the request that started it. `docker run` does both
+    /// concurrently — it attaches and starts, and whichever request wins the race starts the
+    /// container while the other gets a benign "already booted". Joining an open run is what
+    /// keeps that pair on one run: two runs for one physical exit would let each side's observer
+    /// claim its own and emit a `die` apiece. A run whose exit was already reported is finished,
+    /// so the next start opens a fresh one.
     func beginRun(id: String) -> Int {
-        tombstoned.remove(id)
-        let current = epoch[id] ?? 0
-        if let open = runs[RunKey(id: id, epoch: current)], !open.emitterDecided {
-            return current
+        if let epoch = currentEpochs[id], let run = runs[RunKey(id: id, epoch: epoch)], !run.emitterDecided {
+            return epoch
         }
-        return openNewRun(id: id)
+        return openRun(id: id)
     }
 
     /// Opens a run for a container the caller just stopped and started again — `POST /restart`
     /// and restart-policy restarts. Unconditional, because the stop ended the previous run even
     /// if its exit has not been reported yet; joining it would leave the new run unreportable.
     func beginRestartedRun(id: String) -> Int {
-        tombstoned.remove(id)
-        return openNewRun(id: id)
+        openRun(id: id)
     }
 
-    /// The run an observer joins when it did not start the container itself — attaching to an
-    /// already-running container, or a `/start` that found it running.
-    func currentEpoch(id: String) -> Int {
-        epoch[id] ?? 0
-    }
+    private func openRun(id: String) -> Int {
+        nextEpoch += 1
 
-    private func openNewRun(id: String) -> Int {
-        let next = (epoch[id] ?? 0) + 1
-        epoch[id] = next
-        runs[RunKey(id: id, epoch: next)] = Run()
-        // A monitor can still be resolving the previous run's exit code, so its run stays
-        // claimable; anything older than that is unreachable and would otherwise accumulate.
-        runs.removeValue(forKey: RunKey(id: id, epoch: next - 2))
-        return next
-    }
-
-    /// Drops a removed container's die-event bookkeeping.
-    ///
-    /// A run whose exit was already reported is tombstoned: further claims are refused, because
-    /// an observer arriving after the record was dropped would otherwise find no run, take it,
-    /// and emit a second `die` for that exit. That is the `--rm` path, which cleans up *after*
-    /// broadcasting.
-    ///
-    /// A run still open is left claimable instead. `docker rm -f` stops and deletes a running
-    /// container, and its exit monitor resolves the code (behind a flush grace) only after the
-    /// delete has landed — refusing that claim would turn `die` into a race with teardown and
-    /// drop the event Docker does send. Its epoch entry stays so a container recreated under the
-    /// same name cannot be handed the dead run.
-    func forget(id: String) {
-        let current = epoch[id] ?? 0
-        runs.removeValue(forKey: RunKey(id: id, epoch: current - 1))
-
-        let key = RunKey(id: id, epoch: current)
-        guard runs[key]?.emitterDecided ?? true else { return }
-        runs.removeValue(forKey: key)
-        epoch.removeValue(forKey: id)
-        tombstoned.insert(id)
+        // The run before last is unreachable: both its observers have had a full run to report
+        // it. The immediately previous one is kept, because a monitor can still be resolving its
+        // exit code while the container is already running again.
+        if let stale = previousEpochs[id] {
+            runs.removeValue(forKey: RunKey(id: id, epoch: stale))
+        }
+        previousEpochs[id] = currentEpochs[id]
+        currentEpochs[id] = nextEpoch
+        runs[RunKey(id: id, epoch: nextEpoch)] = Run()
+        return nextEpoch
     }
 
     /// Declares that a start-route observer of `generation` will emit this run's `die`.
     /// Supersedes an older generation's reservation, so a redundant `/start` moves the
     /// obligation to the observer that will actually pass its generation check.
-    func reserveForStart(id: String, epoch runEpoch: Int, generation: Int) {
-        let key = RunKey(id: id, epoch: runEpoch)
-        var run = runs[key] ?? Run()
+    func reserveForStart(id: String, epoch: Int, generation: Int) {
+        let key = RunKey(id: id, epoch: epoch)
+        guard var run = runs[key] else { return }
         run.reservedGeneration = generation
         runs[key] = run
     }
 
     /// Called by a start-route observer once its generation check passed and it is about to
     /// broadcast. False means this run was already reported — by the exit monitor, when the
-    /// container exited before this observer armed.
-    func claimForStart(id: String, epoch runEpoch: Int, generation: Int) -> Bool {
-        guard !tombstoned.contains(id) else { return false }
-        let key = RunKey(id: id, epoch: runEpoch)
-        var run = runs[key] ?? Run()
-        guard !run.emitterDecided, run.reservedGeneration == generation else { return false }
+    /// container exited before this observer armed — or is no longer tracked at all.
+    func claimForStart(id: String, epoch: Int, generation: Int) -> Bool {
+        let key = RunKey(id: id, epoch: epoch)
+        guard var run = runs[key], !run.emitterDecided, run.reservedGeneration == generation else { return false }
         run.emitterDecided = true
         runs[key] = run
+        settle(key)
         return true
     }
 
     /// Called by the attach paths' exit monitor. False means a start-route observer reserved
-    /// this run — `docker run` — and will emit the richer event, or the run is already reported.
-    func claimForMonitor(id: String, epoch runEpoch: Int) -> Bool {
-        guard !tombstoned.contains(id) else { return false }
-        let key = RunKey(id: id, epoch: runEpoch)
-        var run = runs[key] ?? Run()
-        guard !run.emitterDecided, run.reservedGeneration == nil else { return false }
+    /// this run — `docker run` — and will emit the richer event, the run is already reported, or
+    /// it is no longer tracked.
+    func claimForMonitor(id: String, epoch: Int) -> Bool {
+        let key = RunKey(id: id, epoch: epoch)
+        guard var run = runs[key], !run.emitterDecided, run.reservedGeneration == nil else { return false }
         run.emitterDecided = true
         runs[key] = run
+        settle(key)
         return true
+    }
+
+    /// Drops a removed container's die-event bookkeeping.
+    ///
+    /// A run whose exit was already reported is dropped outright: a claim naming an untracked run
+    /// is refused, so an observer arriving after the record is gone cannot emit a second `die`
+    /// for that exit. That is the `--rm` path, which cleans up *after* broadcasting.
+    ///
+    /// A run still open keeps its record. `docker rm -f` stops and deletes a running container,
+    /// and its exit monitor resolves the code (behind a flush grace) only after the delete has
+    /// landed — refusing that claim would turn `die` into a race with teardown and drop the event
+    /// Docker does send. The container's name stops pointing at that run either way, so a
+    /// container recreated under the same name opens its own instead of joining a dead one. The
+    /// record is released once the pending observer reports the exit.
+    func forget(id: String) {
+        if let stale = previousEpochs.removeValue(forKey: id) {
+            runs.removeValue(forKey: RunKey(id: id, epoch: stale))
+        }
+
+        guard let epoch = currentEpochs.removeValue(forKey: id) else { return }
+        let key = RunKey(id: id, epoch: epoch)
+        guard runs[key]?.emitterDecided ?? true else {
+            pendingForget.insert(key)
+            return
+        }
+        runs.removeValue(forKey: key)
+    }
+
+    /// Releases a removed container's last record once its exit has been reported, so nothing is
+    /// retained for a container that no longer exists. Keyed by the run rather than the name,
+    /// because a recreated container reuses the name while its runs are distinct.
+    private func settle(_ key: RunKey) {
+        guard pendingForget.remove(key) != nil else { return }
+        runs.removeValue(forKey: key)
     }
 }

--- a/Sources/socktainer/Events/DieEventOwnership.swift
+++ b/Sources/socktainer/Events/DieEventOwnership.swift
@@ -1,4 +1,4 @@
-/// Guarantees exactly one observer broadcasts `die` for a container's current run.
+/// Guarantees exactly one observer broadcasts `die` per container run.
 ///
 /// Two observers can watch the same exit:
 /// - `ContainerStartRoute.observeExit`, armed when `POST /start` returns;
@@ -8,17 +8,88 @@
 /// `docker compose up` attaches to a stopped container and never calls `/start`, so without
 /// the monitor emitting the event nothing does — and Compose's `--abort-on-container-exit`
 /// waits forever for an exit it can never observe.
+///
+/// Ownership is scoped to a *run*, identified by the epoch `beginRun` returns, and the winner
+/// keeps it for the rest of that run: handing it back after broadcasting lets the loser — which
+/// reaches the same exit moments later — take the reopened claim and emit a second `die`. Every
+/// observer carries the epoch of the run it watches, so a monitor still resolving a slow exit
+/// cannot claim the *next* run and silence it.
+///
+/// Between the two observers the start-route one is preferred: its event carries `execDuration`
+/// and the container's post-start labels, which the monitor cannot see. It therefore *reserves*
+/// the run when it arms, and the monitor defers to that reservation. A redundant `POST /start`
+/// arms a newer observer and supersedes the older reservation, so the observer that survives the
+/// generation check is the one that emits.
 actor DieEventOwnership {
     static let shared = DieEventOwnership()
 
-    private var owners: Set<String> = []
-
-    /// Returns true when the caller becomes the sole owner of this container's `die` event.
-    func claim(id: String) -> Bool {
-        owners.insert(id).inserted
+    private struct Run {
+        /// Generation of the start-route observer that intends to emit, if one armed.
+        var reservedGeneration: Int?
+        /// Set once an observer has taken this run's `die` event.
+        var emitterDecided = false
     }
 
-    func release(id: String) {
-        owners.remove(id)
+    private struct RunKey: Hashable {
+        let id: String
+        let epoch: Int
+    }
+
+    private var epoch: [String: Int] = [:]
+    private var runs: [RunKey: Run] = [:]
+
+    /// Opens a new run for `id` and returns its epoch. The exit it produces is claimable once.
+    ///
+    /// Called where the container starts executing — the attach route's bootstrap, a `POST /start`
+    /// that actually started it, `POST /restart`, and a restart-policy restart. It must *not* be
+    /// called for a start against an already-running container: `docker run` attaches (bootstrap)
+    /// and then starts, and both observers have to land on the same run.
+    func beginRun(id: String) -> Int {
+        let next = (epoch[id] ?? 0) + 1
+        epoch[id] = next
+        runs[RunKey(id: id, epoch: next)] = Run()
+        // A monitor can still be resolving the previous run's exit code, so its run stays
+        // claimable; anything older than that is unreachable and would otherwise accumulate.
+        runs.removeValue(forKey: RunKey(id: id, epoch: next - 2))
+        return next
+    }
+
+    /// The run an observer joins when it did not start the container itself — attaching to an
+    /// already-running container, or a `/start` that found it running.
+    func currentEpoch(id: String) -> Int {
+        epoch[id] ?? 0
+    }
+
+    /// Declares that a start-route observer of `generation` will emit this run's `die`.
+    /// Supersedes an older generation's reservation, so a redundant `/start` moves the
+    /// obligation to the observer that will actually pass its generation check.
+    func reserveForStart(id: String, epoch runEpoch: Int, generation: Int) {
+        let key = RunKey(id: id, epoch: runEpoch)
+        var run = runs[key] ?? Run()
+        run.reservedGeneration = generation
+        runs[key] = run
+    }
+
+    /// Called by a start-route observer once its generation check passed and it is about to
+    /// broadcast. False means this run was already reported — by the exit monitor, when the
+    /// container exited before this observer armed.
+    func claimForStart(id: String, epoch runEpoch: Int, generation: Int) -> Bool {
+        let key = RunKey(id: id, epoch: runEpoch)
+        var run = runs[key] ?? Run()
+        guard !run.emitterDecided, run.reservedGeneration == generation else { return false }
+        run.emitterDecided = true
+        runs[key] = run
+        return true
+    }
+
+    /// Called by the attach paths' exit monitor. False means a start-route observer reserved
+    /// this run — `docker run` — and will emit the richer event, or the run is already reported.
+    func claimForMonitor(id: String, epoch runEpoch: Int) -> Bool {
+        let key = RunKey(id: id, epoch: runEpoch)
+        var run = runs[key] ?? Run()
+        guard !run.emitterDecided, run.reservedGeneration == nil else { return false }
+        run.emitterDecided = true
+        runs[key] = run
+        return true
     }
 }

--- a/Sources/socktainer/Events/DieEventOwnership.swift
+++ b/Sources/socktainer/Events/DieEventOwnership.swift
@@ -1,0 +1,24 @@
+/// Guarantees exactly one observer broadcasts `die` for a container's current run.
+///
+/// Two observers can watch the same exit:
+/// - `ContainerStartRoute.observeExit`, armed when `POST /start` returns;
+/// - `ContainerProcessExitMonitor`, which owns containers the attach route bootstrapped.
+///
+/// `docker run` goes through both (attach, then start) and must produce a single `die`.
+/// `docker compose up` attaches to a stopped container and never calls `/start`, so without
+/// the monitor emitting the event nothing does — and Compose's `--abort-on-container-exit`
+/// waits forever for an exit it can never observe.
+actor DieEventOwnership {
+    static let shared = DieEventOwnership()
+
+    private var owners: Set<String> = []
+
+    /// Returns true when the caller becomes the sole owner of this container's `die` event.
+    func claim(id: String) -> Bool {
+        owners.insert(id).inserted
+    }
+
+    func release(id: String) {
+        owners.remove(id)
+    }
+}

--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -331,6 +331,10 @@ extension ContainerAttachRoute {
             }
         }
 
+        // The container is executing now: open a run so this exit's `die` is claimable.
+        // `docker compose up` starts a service entirely through this path, never `POST /start`.
+        let runEpoch = await DieEventOwnership.shared.beginRun(id: container.id)
+
         await ProcessRegistry.shared.set(id: container.id, process: process)
 
         await broadcastAttach(
@@ -366,7 +370,8 @@ extension ContainerAttachRoute {
                             fallbackImage: container.configuration.image.reference,
                             fallbackLabels: LabelNormalization.restore(container.configuration.labels),
                             dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                            broadcaster: req.application.storage[EventBroadcasterKey.self]
+                            broadcaster: req.application.storage[EventBroadcasterKey.self],
+                            runEpoch: runEpoch
                         )
                     }
 
@@ -493,6 +498,9 @@ extension ContainerAttachRoute {
             throw Abort(.internalServerError, reason: "Failed to start main process: \(error.localizedDescription)")
         }
 
+        // Executing now: open a run so this exit's `die` is claimable exactly once.
+        let runEpoch = await DieEventOwnership.shared.beginRun(id: container.id)
+
         await ProcessRegistry.shared.set(id: container.id, process: process)
 
         let broadcaster = req.application.storage[EventBroadcasterKey.self]
@@ -527,7 +535,8 @@ extension ContainerAttachRoute {
                             fallbackImage: container.configuration.image.reference,
                             fallbackLabels: LabelNormalization.restore(container.configuration.labels),
                             dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                            broadcaster: req.application.storage[EventBroadcasterKey.self]
+                            broadcaster: req.application.storage[EventBroadcasterKey.self],
+                            runEpoch: runEpoch
                         )
                     }
 
@@ -776,7 +785,8 @@ extension ContainerAttachRoute {
                         fallbackImage: container.configuration.image.reference,
                         fallbackLabels: LabelNormalization.restore(container.configuration.labels),
                         dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                        broadcaster: req.application.storage[EventBroadcasterKey.self]
+                        broadcaster: req.application.storage[EventBroadcasterKey.self],
+                        runEpoch: runEpoch
                     )
 
                     // DockerTCPHandler owns pipes.stdin!.write after setStdinWriter(); it closes

--- a/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachWSRoute.swift
@@ -110,6 +110,9 @@ extension ContainerAttachWSRoute {
             }
         }
 
+        // Executing now: open a run so this exit's `die` is claimable exactly once.
+        let runEpoch = await DieEventOwnership.shared.beginRun(id: container.id)
+
         await ProcessRegistry.shared.set(id: container.id, process: process)
 
         let broadcaster = req.application.storage[EventBroadcasterKey.self]
@@ -140,7 +143,8 @@ extension ContainerAttachWSRoute {
                     fallbackImage: container.configuration.image.reference,
                     fallbackLabels: LabelNormalization.restore(container.configuration.labels),
                     dnsServer: req.application.storage[SocktainerDNSServerKey.self],
-                    broadcaster: broadcaster
+                    broadcaster: broadcaster,
+                    runEpoch: runEpoch
                 )
 
                 try? await ws.close()

--- a/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerDeleteRoute.swift
@@ -41,6 +41,10 @@ extension ContainerDeleteRoute {
                 // Prevents a container recreated under the same name from inheriting this one's restart-attempt count.
                 await ContainerRestartState.shared.reset(id: eventName)
                 await RestartPolicyOverrideStore.shared.remove(id: eventId)
+                // Releases this container's die-event bookkeeping and refuses later claims: an
+                // exit monitor still resolving the exit of a container that is now gone would
+                // otherwise find no record of the run and emit a `die` for it a second time.
+                await DieEventOwnership.shared.forget(id: eventName)
                 guard let broadcaster = req.application.storage[EventBroadcasterKey.self] else { return }
                 await broadcaster.broadcast(
                     DockerEvent.simpleEvent(

--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -41,6 +41,11 @@ extension ContainerRestartRoute {
                 throw Abort(.internalServerError, reason: "Failed to restart container: \(error)")
             }
 
+            // The restart started a new run of the container. A `die` is claimed per run and the
+            // claim is never handed back, so without opening one here the restarted container's
+            // exit would find the previous run's claim held and go unreported.
+            let runEpoch = await DieEventOwnership.shared.beginRun(id: snapshot?.id ?? id)
+
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
             // Carry the canonical 64-char Docker id, not the raw request
             // reference (name or short id), so clients can correlate this
@@ -76,6 +81,7 @@ extension ContainerRestartRoute {
                     refreshCache: true,
                     restartPolicy: restartPolicy,
                     generation: generation,
+                    runEpoch: runEpoch,
                     broadcaster: broadcaster,
                     dnsServer: dnsServer,
                     healthManager: healthManager,

--- a/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerRestartRoute.swift
@@ -44,7 +44,7 @@ extension ContainerRestartRoute {
             // The restart started a new run of the container. A `die` is claimed per run and the
             // claim is never handed back, so without opening one here the restarted container's
             // exit would find the previous run's claim held and go unreported.
-            let runEpoch = await DieEventOwnership.shared.beginRun(id: snapshot?.id ?? id)
+            let runEpoch = await DieEventOwnership.shared.beginRestartedRun(id: snapshot?.id ?? id)
 
             let broadcaster = req.application.storage[EventBroadcasterKey.self]!
             // Carry the canonical 64-char Docker id, not the raw request

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -176,7 +176,12 @@ extension ContainerStartRoute {
 
             // A redundant /start also arms a second observer on this nativeId; bail before a
             // stale one broadcasts its own "die" for an exit the current observer already owns.
-            guard await ContainerRestartState.shared.isCurrent(id: nativeId, generation: generation) else { return }
+            // Ownership must be released on every exit path, otherwise a later attach-bootstrap
+            // run of the same container would find the claim still held and emit nothing.
+            guard await ContainerRestartState.shared.isCurrent(id: nativeId, generation: generation) else {
+                await DieEventOwnership.shared.release(id: nativeId)
+                return
+            }
 
             let executionDuration = Date().timeIntervalSince(startedAt)
 
@@ -198,6 +203,7 @@ extension ContainerStartRoute {
                 image: image, name: name, labels: attrs
             )
             await broadcaster.broadcast(dieEvent)
+            await DieEventOwnership.shared.release(id: nativeId)
 
             // moby fires `destroy` right after `die` for `--rm` containers. Apple Container
             // reaps them itself (no DELETE arrives), so emit it here. consumeAutoRemove both
@@ -340,6 +346,10 @@ extension ContainerStartRoute {
         // explicitly-stopped; clear it here so the new observer doesn't mistake a manual
         // restart for a stop that should suppress restart-policy enforcement on the next exit.
         _ = await ContainerRestartState.shared.consumeExplicitlyStopped(id: nativeId)
+
+        // Claim the `die` event before the process can exit: the attach route's exit monitor
+        // emits it for containers nothing else observes, and exactly one of them must.
+        _ = await DieEventOwnership.shared.claim(id: nativeId)
 
         ContainerStartRoute.observeExit(
             nativeId: nativeId, eventId: eventId, image: image, name: name, labels: labels,

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -37,6 +37,7 @@ extension ContainerStartRoute {
                 throw Abort(.badRequest, reason: "ambiguous container reference \(reference): matches \(matchList)")
             }
 
+            let runEpoch: Int
             do {
                 guard let container = preStartSnapshot else {
                     throw Abort(.notFound, reason: "No such container: \(id)")
@@ -49,9 +50,16 @@ extension ContainerStartRoute {
                 // If container is already running, return success (Docker CLI behavior)
                 if container.status == .running {
                     req.logger.debug("Container \(id) is already running")
+                    // Deliberately joins the run in progress instead of opening a new one:
+                    // `docker run` bootstraps through attach and then starts, and both observers
+                    // must land on the same run for one of them to lose.
+                    runEpoch = await DieEventOwnership.shared.currentEpoch(id: container.id)
                 } else {
                     // Try to start the container
                     try await client.start(id: id, detachKeys: detachKeys)
+                    // Executing now, and this request caused it: open a run so the exit is
+                    // claimable.
+                    runEpoch = await DieEventOwnership.shared.beginRun(id: container.id)
                     req.logger.debug("Started container \(id)")
                 }
 
@@ -67,6 +75,8 @@ extension ContainerStartRoute {
                     throw Abort(.internalServerError, reason: "Failed to start container: \(error)")
                 }
                 req.logger.debug("Container \(id) was already running or bootstrapped")
+                // Started by whoever won the race — the attach path — so join its run.
+                runEpoch = await DieEventOwnership.shared.currentEpoch(id: preStartSnapshot?.id ?? id)
             }
 
             let startedSnapshot = await ContainerStartRoute.performPostStartSetup(
@@ -136,6 +146,7 @@ extension ContainerStartRoute {
                     refreshCache: false,
                     restartPolicy: restartPolicy,
                     generation: generation,
+                    runEpoch: runEpoch,
                     broadcaster: broadcaster,
                     dnsServer: req.application.storage[SocktainerDNSServerKey.self],
                     healthManager: req.application.storage[HealthCheckManagerKey.self],
@@ -163,7 +174,10 @@ extension ContainerStartRoute {
         restartPolicy: RestartPolicy?,
         client: ClientContainerProtocol,
         logger: Logger,
-        generation: Int
+        generation: Int,
+        /// Run this observer watches, from `DieEventOwnership`. A `die` is claimed per run, so a
+        /// restart's observer must carry the new run's epoch to be able to report its exit.
+        runEpoch: Int
     ) {
         Task.detached {
             let startedAt = Date()
@@ -176,10 +190,9 @@ extension ContainerStartRoute {
 
             // A redundant /start also arms a second observer on this nativeId; bail before a
             // stale one broadcasts its own "die" for an exit the current observer already owns.
-            // Ownership must be released on every exit path, otherwise a later attach-bootstrap
-            // run of the same container would find the claim still held and emit nothing.
+            // The newer /start superseded this observer's reservation, so the claim below would
+            // fail anyway — but returning here also skips its unmount and restart-policy work.
             guard await ContainerRestartState.shared.isCurrent(id: nativeId, generation: generation) else {
-                await DieEventOwnership.shared.release(id: nativeId)
                 return
             }
 
@@ -194,16 +207,21 @@ extension ContainerStartRoute {
                 await VolumeMountEvents.broadcastUnmounts(for: exitSnapshot, containerId: eventId, broadcaster: broadcaster)
             }
 
-            var attrs = labels
-            attrs["exitCode"] = String(code)
-            // moby's die event carries the run duration in whole seconds (daemon/monitor.go).
-            attrs["execDuration"] = String(Int(executionDuration))
-            let dieEvent = DockerEvent.simpleEvent(
-                id: eventId, type: "container", status: "die",
-                image: image, name: name, labels: attrs
-            )
-            await broadcaster.broadcast(dieEvent)
-            await DieEventOwnership.shared.release(id: nativeId)
+            // Take the run only now, after the generation check: the reservation belongs to
+            // whichever observer is current, and a container that exited before this one armed
+            // was already reported by the attach path's exit monitor — that is how
+            // `docker compose up` runs a service. Claiming twice would double every exit.
+            if await DieEventOwnership.shared.claimForStart(id: nativeId, epoch: runEpoch, generation: generation) {
+                var attrs = labels
+                attrs["exitCode"] = String(code)
+                // moby's die event carries the run duration in whole seconds (daemon/monitor.go).
+                attrs["execDuration"] = String(Int(executionDuration))
+                let dieEvent = DockerEvent.simpleEvent(
+                    id: eventId, type: "container", status: "die",
+                    image: image, name: name, labels: attrs
+                )
+                await broadcaster.broadcast(dieEvent)
+            }
 
             // moby fires `destroy` right after `die` for `--rm` containers. Apple Container
             // reaps them itself (no DELETE arrives), so emit it here. consumeAutoRemove both
@@ -279,8 +297,13 @@ extension ContainerStartRoute {
             // /start or /restart landing during the backoff sleep above must not inflate
             // RestartCount for a restart that the generation check just aborted.
             let attempt = await ContainerRestartState.shared.nextAttempt(id: nativeId)
+            let restartedEpoch: Int
             do {
                 try await client.start(id: nativeId, detachKeys: nil)
+                // A restart is a new run: it needs its own claim. The previous run's observer
+                // keeps the claim it broadcast under (so a late exit monitor cannot double-emit),
+                // so without a new run every restart after the first would report no exit at all.
+                restartedEpoch = await DieEventOwnership.shared.beginRun(id: nativeId)
             } catch {
                 await ContainerRestartState.shared.clearPendingRestart(id: nativeId)
                 logger.warning("restart-policy: failed to restart \(nativeId) (attempt \(attempt)): \(error)")
@@ -304,6 +327,7 @@ extension ContainerStartRoute {
                 refreshCache: restartedSnapshot != nil,
                 restartPolicy: restartPolicy,
                 generation: generation,
+                runEpoch: restartedEpoch,
                 broadcaster: broadcaster,
                 dnsServer: dnsServer,
                 healthManager: healthManager,
@@ -332,6 +356,7 @@ extension ContainerStartRoute {
         refreshCache: Bool,
         restartPolicy: RestartPolicy?,
         generation: Int,
+        runEpoch: Int,
         broadcaster: EventBroadcaster,
         dnsServer: SocktainerDNSServer?,
         healthManager: HealthCheckManager?,
@@ -347,14 +372,17 @@ extension ContainerStartRoute {
         // restart for a stop that should suppress restart-policy enforcement on the next exit.
         _ = await ContainerRestartState.shared.consumeExplicitlyStopped(id: nativeId)
 
-        // Claim the `die` event before the process can exit: the attach route's exit monitor
-        // emits it for containers nothing else observes, and exactly one of them must.
-        _ = await DieEventOwnership.shared.claim(id: nativeId)
+        // Reserve the `die` event before the process can exit: the attach route's exit monitor
+        // emits it for containers nothing else observes, and it must defer to this observer,
+        // whose event carries execDuration and the post-start labels. A newer /start replaces
+        // this reservation, keeping the obligation on the observer that stays current.
+        await DieEventOwnership.shared.reserveForStart(id: nativeId, epoch: runEpoch, generation: generation)
 
         ContainerStartRoute.observeExit(
             nativeId: nativeId, eventId: eventId, image: image, name: name, labels: labels,
             broadcaster: broadcaster, dnsServer: dnsServer, healthManager: healthManager,
-            restartPolicy: restartPolicy, client: client, logger: logger, generation: generation
+            restartPolicy: restartPolicy, client: client, logger: logger, generation: generation,
+            runEpoch: runEpoch
         )
     }
 

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -50,10 +50,10 @@ extension ContainerStartRoute {
                 // If container is already running, return success (Docker CLI behavior)
                 if container.status == .running {
                     req.logger.debug("Container \(id) is already running")
-                    // Deliberately joins the run in progress instead of opening a new one:
+                    // Joins the run the attach route opened rather than starting a new one:
                     // `docker run` bootstraps through attach and then starts, and both observers
                     // must land on the same run for one of them to lose.
-                    runEpoch = await DieEventOwnership.shared.currentEpoch(id: container.id)
+                    runEpoch = await DieEventOwnership.shared.beginRun(id: container.id)
                 } else {
                     // Try to start the container
                     try await client.start(id: id, detachKeys: detachKeys)
@@ -76,7 +76,7 @@ extension ContainerStartRoute {
                 }
                 req.logger.debug("Container \(id) was already running or bootstrapped")
                 // Started by whoever won the race — the attach path — so join its run.
-                runEpoch = await DieEventOwnership.shared.currentEpoch(id: preStartSnapshot?.id ?? id)
+                runEpoch = await DieEventOwnership.shared.beginRun(id: preStartSnapshot?.id ?? id)
             }
 
             let startedSnapshot = await ContainerStartRoute.performPostStartSetup(

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -211,7 +211,8 @@ extension ContainerStartRoute {
             // whichever observer is current, and a container that exited before this one armed
             // was already reported by the attach path's exit monitor — that is how
             // `docker compose up` runs a service. Claiming twice would double every exit.
-            if await DieEventOwnership.shared.claimForStart(id: nativeId, epoch: runEpoch, generation: generation) {
+            let ownsExit = await DieEventOwnership.shared.claimForStart(id: nativeId, epoch: runEpoch, generation: generation)
+            if ownsExit {
                 var attrs = labels
                 attrs["exitCode"] = String(code)
                 // moby's die event carries the run duration in whole seconds (daemon/monitor.go).
@@ -224,10 +225,11 @@ extension ContainerStartRoute {
             }
 
             // moby fires `destroy` right after `die` for `--rm` containers. Apple Container
-            // reaps them itself (no DELETE arrives), so emit it here. consumeAutoRemove both
-            // gates on the --rm flag and dedups against the foreground attach path, so a
-            // container attached in the foreground does not get a second destroy.
-            if await ContainerInfoCache.shared.consumeAutoRemove(id: nativeId) {
+            // reaps them itself (no DELETE arrives), so emit it here. Only the observer that
+            // reported the exit does it: the other one reaches this point while the owner is
+            // still inside its output-flush grace, and would publish `destroy` before the `die`
+            // it belongs to — clients that treat `destroy` as terminal would miss the exit.
+            if ownsExit, await ContainerInfoCache.shared.consumeAutoRemove(id: nativeId) {
                 await ContainerAutoRemoveCleanup.perform(
                     hexId: eventId,
                     nativeId: nativeId,

--- a/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerStartRoute.swift
@@ -300,10 +300,10 @@ extension ContainerStartRoute {
             let restartedEpoch: Int
             do {
                 try await client.start(id: nativeId, detachKeys: nil)
-                // A restart is a new run: it needs its own claim. The previous run's observer
-                // keeps the claim it broadcast under (so a late exit monitor cannot double-emit),
-                // so without a new run every restart after the first would report no exit at all.
-                restartedEpoch = await DieEventOwnership.shared.beginRun(id: nativeId)
+                // A restart is a new run: it needs its own claim. The exit that triggered it
+                // ended the previous run, whose observer keeps the claim it broadcast under, so
+                // this must not join it — every restart after the first would go unreported.
+                restartedEpoch = await DieEventOwnership.shared.beginRestartedRun(id: nativeId)
             } catch {
                 await ContainerRestartState.shared.clearPendingRestart(id: nativeId)
                 logger.warning("restart-policy: failed to restart \(nativeId) (attempt \(attempt)): \(error)")

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -144,7 +144,9 @@ extension ContainerWaitRoute {
                     if let code = await ContainerExitCodeStore.shared.get(id: containerId) {
                         return RESTContainerWait(statusCode: Int64(code))
                     }
-                    try? await Task.sleep(nanoseconds: waitPollIntervalNs)
+                    // Cancellation must end this loop: swallowing it would keep polling for the
+                    // rest of the timeout after a sibling source already answered.
+                    guard await sleepUnlessCancelled(waitPollIntervalNs) else { return nil }
                 }
                 return nil
             }
@@ -165,7 +167,27 @@ extension ContainerWaitRoute {
                     return waitResult
                 }
             }
-            return RESTContainerWait(statusCode: 0)
+            // Every source gave up without observing a stop. Reporting `StatusCode: 0` here
+            // would claim a clean exit: Compose would treat a service that never ran as a
+            // successful one. Docker carries the failure alongside the status, so clients
+            // surface the message instead of trusting the code.
+            return RESTContainerWait(
+                statusCode: -1,
+                error: ContainerWaitExitError(
+                    Message: "no exit observed for container \(containerId)"
+                )
+            )
+        }
+    }
+
+    /// Returns false when the surrounding task was cancelled, so a polling loop can stop
+    /// instead of running out its full budget after a sibling already produced a result.
+    private static func sleepUnlessCancelled(_ nanoseconds: UInt64) async -> Bool {
+        do {
+            try await Task.sleep(nanoseconds: nanoseconds)
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -204,17 +226,18 @@ extension ContainerWaitRoute {
         let maxPolls = Int(storeTimeoutNs / waitPollIntervalNs)
 
         for _ in 0..<maxPolls {
+            if Task.isCancelled { return nil }
             let container = try? await client.getContainer(id: containerId)
             if container?.status == .running {
                 sawRunning = true
             } else if sawRunning {
                 // The container ran and is no longer running: give the recorder a moment to
                 // publish the real code before falling back to a clean exit.
-                try? await Task.sleep(nanoseconds: stoppedGraceNs)
+                guard await sleepUnlessCancelled(stoppedGraceNs) else { return nil }
                 let code = await ContainerExitCodeStore.shared.get(id: containerId) ?? 0
                 return RESTContainerWait(statusCode: Int64(code))
             }
-            try? await Task.sleep(nanoseconds: waitPollIntervalNs)
+            guard await sleepUnlessCancelled(waitPollIntervalNs) else { return nil }
         }
         return nil
     }

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -81,33 +81,15 @@ struct ContainerWaitRoute: RouteCollection {
                     } else if condition == .removed {
                         result = try await client.wait(id: containerId, condition: condition)
                     } else {
-                        // Race native wait against ContainerExitCodeStore polling.
-                        // Pipe-bootstrapped containers (docker run) may not surface
-                        // their exit through client.wait(), so we poll the store in
-                        // parallel and take whichever resolves first.
-                        result = await withTaskGroup(of: RESTContainerWait?.self) { group in
-                            group.addTask {
-                                try? await client.wait(id: containerId, condition: condition)
-                            }
-                            group.addTask {
-                                let pollIntervalNs: UInt64 = 100_000_000
-                                let maxPolls = Int(30_000_000_000 / pollIntervalNs)
-                                for _ in 0..<maxPolls {
-                                    if let code = await ContainerExitCodeStore.shared.get(id: containerId) {
-                                        return RESTContainerWait(statusCode: Int64(code))
-                                    }
-                                    try? await Task.sleep(nanoseconds: pollIntervalNs)
-                                }
-                                return nil
-                            }
-                            for await waitResult in group {
-                                if let waitResult {
-                                    group.cancelAll()
-                                    return waitResult
-                                }
-                            }
-                            return RESTContainerWait(statusCode: 0)
-                        }
+                        // Subscribe before returning so a die event fired during the wait is
+                        // never missed by this listener.
+                        let events = await req.application.storage[EventBroadcasterKey.self]?.stream()
+                        result = await resolveNotRunning(
+                            containerId: containerId,
+                            client: client,
+                            condition: condition,
+                            events: events
+                        )
                     }
                 } catch {
                     result = RESTContainerWait(statusCode: 0)
@@ -123,5 +105,117 @@ struct ContainerWaitRoute: RouteCollection {
 
             return Response(status: .ok, headers: headers, body: body)
         }
+    }
+}
+
+extension ContainerWaitRoute {
+    /// Poll interval shared by the exit-code and stopped-state watchers.
+    static let waitPollIntervalNs: UInt64 = 100_000_000
+    /// How long the stopped-state watcher gives the recorder to publish an exit code.
+    static let stoppedGraceNs: UInt64 = 750_000_000
+
+    /// Resolves `condition=not-running` from whichever source answers first.
+    ///
+    /// No single source is reliable:
+    /// - the native wait is authoritative while the runtime client is attached;
+    /// - `ContainerExitCodeStore` is populated by the attach paths' exit monitor;
+    /// - the `die` event fires for every container, including ones that exit before the
+    ///   wait was issued;
+    /// - the container's own state is the last resort.
+    ///
+    /// The state watcher only reports a result after it has seen the container `running`.
+    /// `docker compose up` issues `POST /wait` before `POST /start`, so a created container
+    /// is *not* running yet — reporting that as a clean exit would tell Compose the service
+    /// finished successfully before it ever started.
+    static func resolveNotRunning(
+        containerId: String,
+        client: ClientContainerProtocol,
+        condition: ContainerWaitCondition = .notRunning,
+        events: AsyncStream<DockerEvent>? = nil,
+        storeTimeoutNs: UInt64 = 30_000_000_000
+    ) async -> RESTContainerWait {
+        await withTaskGroup(of: RESTContainerWait?.self) { group in
+            group.addTask {
+                try? await client.wait(id: containerId, condition: condition)
+            }
+            group.addTask {
+                let maxPolls = Int(storeTimeoutNs / waitPollIntervalNs)
+                for _ in 0..<maxPolls {
+                    if let code = await ContainerExitCodeStore.shared.get(id: containerId) {
+                        return RESTContainerWait(statusCode: Int64(code))
+                    }
+                    try? await Task.sleep(nanoseconds: waitPollIntervalNs)
+                }
+                return nil
+            }
+            group.addTask {
+                await dieEventResult(containerId: containerId, events: events)
+            }
+            group.addTask {
+                await stoppedStateResult(
+                    containerId: containerId,
+                    client: client,
+                    storeTimeoutNs: storeTimeoutNs
+                )
+            }
+
+            for await waitResult in group {
+                if let waitResult {
+                    group.cancelAll()
+                    return waitResult
+                }
+            }
+            return RESTContainerWait(statusCode: 0)
+        }
+    }
+
+    /// The `die` event carries the authoritative exit code and fires even when the container
+    /// exits before this wait was issued.
+    private static func dieEventResult(
+        containerId: String,
+        events: AsyncStream<DockerEvent>?
+    ) async -> RESTContainerWait? {
+        guard let events else { return nil }
+
+        for await event in events {
+            guard event.Type == "container", event.Action == "die" else { continue }
+            guard event.Actor.ID == containerId
+                || event.Actor.ID.hasPrefix(containerId)
+                || event.Actor.Attributes["name"] == containerId
+            else { continue }
+
+            if let exitCode = event.Actor.Attributes["exitCode"], let code = Int64(exitCode) {
+                return RESTContainerWait(statusCode: code)
+            }
+            let recorded = await ContainerExitCodeStore.shared.get(id: containerId)
+            return RESTContainerWait(statusCode: Int64(recorded ?? 0))
+        }
+        return nil
+    }
+
+    /// Last-resort watcher: only terminal once the container has been observed running, so a
+    /// created-but-not-started container is never mistaken for a finished one.
+    private static func stoppedStateResult(
+        containerId: String,
+        client: ClientContainerProtocol,
+        storeTimeoutNs: UInt64
+    ) async -> RESTContainerWait? {
+        var sawRunning = false
+        let maxPolls = Int(storeTimeoutNs / waitPollIntervalNs)
+
+        for _ in 0..<maxPolls {
+            let container = try? await client.getContainer(id: containerId)
+            if container?.status == .running {
+                sawRunning = true
+            } else if sawRunning {
+                // The container ran and is no longer running: give the recorder a moment to
+                // publish the real code before falling back to a clean exit.
+                try? await Task.sleep(nanoseconds: stoppedGraceNs)
+                let code = await ContainerExitCodeStore.shared.get(id: containerId) ?? 0
+                return RESTContainerWait(statusCode: Int64(code))
+            }
+            try? await Task.sleep(nanoseconds: waitPollIntervalNs)
+        }
+        return nil
     }
 }

--- a/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerWaitRoute.swift
@@ -201,9 +201,10 @@ extension ContainerWaitRoute {
 
         for await event in events {
             guard event.Type == "container", event.Action == "die" else { continue }
-            guard event.Actor.ID == containerId
-                || event.Actor.ID.hasPrefix(containerId)
-                || event.Actor.Attributes["name"] == containerId
+            guard
+                event.Actor.ID == containerId
+                    || event.Actor.ID.hasPrefix(containerId)
+                    || event.Actor.Attributes["name"] == containerId
             else { continue }
 
             if let exitCode = event.Actor.Attributes["exitCode"], let code = Int64(exitCode) {

--- a/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
+++ b/Sources/socktainer/Utilities/ContainerAutoRemoveCleanup.swift
@@ -36,5 +36,9 @@ enum ContainerAutoRemoveCleanup {
         }
         await ContainerInfoCache.shared.remove(id: hexId)
         await RestartPolicyOverrideStore.shared.remove(id: hexId)
+        // `--rm` containers are reaped here instead of through DELETE, so this is where their
+        // die-event bookkeeping is released. It also refuses later claims: a second observer
+        // still resolving the same exit would otherwise find no record and emit another `die`.
+        await DieEventOwnership.shared.forget(id: cached?.nativeId ?? nativeId)
     }
 }

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -21,8 +21,7 @@ enum ContainerProcessExitMonitor {
         fallbackLabels: [String: String],
         dnsServer: SocktainerDNSServer?,
         broadcaster: EventBroadcaster?,
-        /// Epoch of the run being watched, from `DieEventOwnership.beginRun` (or `currentEpoch`
-        /// when attaching to a container this process did not start).
+        /// Epoch of the run being watched, from `DieEventOwnership.beginRun`.
         runEpoch: Int,
         outputFlushGraceNs: UInt64 = ContainerProcessExitMonitor.outputFlushGraceNs,
         exitCodeRetryDelayNs: UInt64 = 100_000_000

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -27,11 +27,41 @@ enum ContainerProcessExitMonitor {
         let code = await ContainerExitCodeStore.resolveExitCode(retryDelayNs: exitCodeRetryDelayNs, wait: wait)
         await ProcessRegistry.shared.remove(id: nativeId)
 
+        // Claim before the flush grace: the start-route observer claims when `POST /start`
+        // returns, so claiming after a 200ms sleep would hand it the event by timing rather
+        // than by ownership.
+        let ownsDieEvent: Bool
+        if broadcaster != nil {
+            ownsDieEvent = await DieEventOwnership.shared.claim(id: nativeId)
+        } else {
+            ownsDieEvent = false
+        }
+
         // Sleep before recording the code: lets this attachment's own output flush before
         // any die observer wakes and races ahead.
         try? await Task.sleep(nanoseconds: outputFlushGraceNs)
         await ContainerExitCodeStore.shared.set(id: nativeId, code: code)
         await ContainerExitCodeStore.shared.set(id: hexId, code: code)
+
+        // Emit `die` when no start-route observer owns this exit. The attach route bootstraps
+        // stopped containers, which is how `docker compose up` starts a service: it never calls
+        // `POST /start`, so nothing else would ever report the exit and Compose's
+        // --abort-on-container-exit would wait forever.
+        if let broadcaster, ownsDieEvent {
+            var attributes = fallbackLabels
+            attributes["exitCode"] = String(code)
+            await broadcaster.broadcast(
+                DockerEvent.simpleEvent(
+                    id: hexId,
+                    type: "container",
+                    status: "die",
+                    image: fallbackImage,
+                    name: nativeId,
+                    labels: attributes
+                )
+            )
+            await DieEventOwnership.shared.release(id: nativeId)
+        }
 
         // --rm: Apple Container reaps the container itself, so DELETE never arrives to
         // fire ContainerDeleteRoute's cleanup. consumeAutoRemove both gates on --rm and

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -71,9 +71,11 @@ enum ContainerProcessExitMonitor {
         }
 
         // --rm: Apple Container reaps the container itself, so DELETE never arrives to
-        // fire ContainerDeleteRoute's cleanup. consumeAutoRemove both gates on --rm and
-        // dedups against a second observer racing the same exit.
-        if await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
+        // fire ContainerDeleteRoute's cleanup. Only the observer that reported the exit does it,
+        // so `destroy` cannot precede the `die` it belongs to; with no broadcaster at all there
+        // is no ordering to keep and this monitor is the only thing that can clean up.
+        // consumeAutoRemove still gates on --rm and dedups a second observer racing the exit.
+        if ownsDieEvent || broadcaster == nil, await ContainerInfoCache.shared.consumeAutoRemove(id: hexId) {
             await ContainerAutoRemoveCleanup.perform(
                 hexId: hexId,
                 nativeId: nativeId,

--- a/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
+++ b/Sources/socktainer/Utilities/ContainerProcessExitMonitor.swift
@@ -21,18 +21,22 @@ enum ContainerProcessExitMonitor {
         fallbackLabels: [String: String],
         dnsServer: SocktainerDNSServer?,
         broadcaster: EventBroadcaster?,
+        /// Epoch of the run being watched, from `DieEventOwnership.beginRun` (or `currentEpoch`
+        /// when attaching to a container this process did not start).
+        runEpoch: Int,
         outputFlushGraceNs: UInt64 = ContainerProcessExitMonitor.outputFlushGraceNs,
         exitCodeRetryDelayNs: UInt64 = 100_000_000
     ) async -> Int32 {
         let code = await ContainerExitCodeStore.resolveExitCode(retryDelayNs: exitCodeRetryDelayNs, wait: wait)
         await ProcessRegistry.shared.remove(id: nativeId)
 
-        // Claim before the flush grace: the start-route observer claims when `POST /start`
-        // returns, so claiming after a 200ms sleep would hand it the event by timing rather
-        // than by ownership.
+        // Claim before the flush grace: the start-route observer reserves the run when
+        // `POST /start` returns, so claiming after a 200ms sleep would decide ownership by
+        // timing rather than by who is responsible for the event. The claim names this
+        // container's run, so a slow exit resolution cannot silence the next one.
         let ownsDieEvent: Bool
         if broadcaster != nil {
-            ownsDieEvent = await DieEventOwnership.shared.claim(id: nativeId)
+            ownsDieEvent = await DieEventOwnership.shared.claimForMonitor(id: nativeId, epoch: runEpoch)
         } else {
             ownsDieEvent = false
         }
@@ -47,6 +51,10 @@ enum ContainerProcessExitMonitor {
         // stopped containers, which is how `docker compose up` starts a service: it never calls
         // `POST /start`, so nothing else would ever report the exit and Compose's
         // --abort-on-container-exit would wait forever.
+        //
+        // The claim is deliberately not released after broadcasting: it stays held for the rest
+        // of this run so a start-route observer arriving moments later cannot take it and emit
+        // a second `die` for the same exit. The next run reopens it (`beginRun`).
         if let broadcaster, ownsDieEvent {
             var attributes = fallbackLabels
             attributes["exitCode"] = String(code)
@@ -60,7 +68,6 @@ enum ContainerProcessExitMonitor {
                     labels: attributes
                 )
             )
-            await DieEventOwnership.shared.release(id: nativeId)
         }
 
         // --rm: Apple Container reaps the container itself, so DELETE never arrives to

--- a/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
+++ b/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
@@ -8,39 +8,143 @@ import Testing
 /// while `docker run`, which goes through both attach and start, must still emit exactly one.
 @Suite("DieEventOwnership")
 struct DieEventOwnershipTests {
-    @Test("only the first claimer owns the die event")
-    func singleOwner() async {
+    @Test("the monitor owns an exit nothing else reserved: the compose flow")
+    func monitorOwnsUnreservedRun() async {
         let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
 
-        #expect(await ownership.claim(id: "c1"))
-        #expect(await ownership.claim(id: "c1") == false)
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
     }
 
-    @Test("ownership is reusable after release, so later runs still emit die")
-    func releaseAllowsNextRun() async {
+    @Test("the monitor defers to a start-route reservation: the docker run flow")
+    func startReservationWinsOverMonitor() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
+
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run) == false)
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1))
+    }
+
+    @Test("a redundant /start moves the obligation to the observer that stays current")
+    func newerGenerationSupersedesReservation() async {
+        let ownership = DieEventOwnership()
+        // A redundant /start finds the container already running, so it joins the same run.
+        let run = await ownership.beginRun(id: "c1")
+        #expect(await ownership.currentEpoch(id: "c1") == run)
+
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 2)
+
+        // The stale observer must not emit even if its generation check somehow passed.
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1) == false)
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 2))
+    }
+
+    @Test("a claimed run stays claimed, so a late observer cannot double-emit")
+    func ownershipSurvivesTheRun() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+        // Both losers arrive after the winner already broadcast. Handing the run back after a
+        // broadcast would let either emit a second `die` for the same exit.
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run) == false)
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1) == false)
+    }
+
+    @Test("a monitor still resolving one exit cannot silence the next run")
+    func staleMonitorCannotClaimTheNextRun() async {
+        let ownership = DieEventOwnership()
+        let first = await ownership.beginRun(id: "c1")
+
+        // The container exits and restarts while the first run's monitor is still inside
+        // `process.wait()`; it must land on its own run, not steal the live one.
+        let second = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: first))
+        #expect(
+            await ownership.claimForMonitor(id: "c1", epoch: second),
+            "the current run must still be claimable after a lagging observer reports an older one"
+        )
+    }
+
+    @Test("each run is claimable again, including consecutive restart-policy restarts")
+    func newRunReopensTheClaim() async {
         let ownership = DieEventOwnership()
 
-        #expect(await ownership.claim(id: "c1"))
-        await ownership.release(id: "c1")
-        #expect(await ownership.claim(id: "c1"), "a container's second run must be claimable again")
+        for generation in 1...3 {
+            let run = await ownership.beginRun(id: "c1")
+            await ownership.reserveForStart(id: "c1", epoch: run, generation: generation)
+            #expect(
+                await ownership.claimForStart(id: "c1", epoch: run, generation: generation),
+                "restart \(generation) must be able to report its own exit"
+            )
+        }
+    }
+
+    @Test("a new run does not inherit the previous run's reservation")
+    func beginRunClearsReservation() async {
+        let ownership = DieEventOwnership()
+        let first = await ownership.beginRun(id: "c1")
+        await ownership.reserveForStart(id: "c1", epoch: first, generation: 1)
+
+        // Re-attached without a /start: the monitor is the only observer of the new run.
+        let second = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: second))
     }
 
     @Test("claims are independent per container")
     func independentContainers() async {
         let ownership = DieEventOwnership()
+        let first = await ownership.beginRun(id: "c1")
+        let second = await ownership.beginRun(id: "c2")
 
-        #expect(await ownership.claim(id: "c1"))
-        #expect(await ownership.claim(id: "c2"))
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: first))
+        #expect(await ownership.claimForMonitor(id: "c2", epoch: second))
+    }
+
+    @Test("a container this process never started is claimable at its implicit run")
+    func attachedToForeignContainer() async {
+        let ownership = DieEventOwnership()
+        // Attaching to a container started before socktainer came up: no beginRun ever ran.
+        let run = await ownership.currentEpoch(id: "c1")
+
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run) == false)
     }
 }
 
 @Suite("ContainerProcessExitMonitor die event")
 struct ContainerProcessExitMonitorDieTests {
+    /// Reads the stream with a deadline: a regression that stops emitting `die` must fail the
+    /// test, not hang the suite waiting for an event that never arrives.
+    private static func firstDieEvent(
+        in stream: AsyncStream<DockerEvent>,
+        withinNs: UInt64 = 2_000_000_000
+    ) async -> DockerEvent? {
+        await withTaskGroup(of: DockerEvent?.self) { group in
+            group.addTask {
+                for await event in stream where event.Action == "die" {
+                    return event
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: withinNs)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
+
     @Test("emits die with the exit code when nothing else owns the exit")
     func emitsDieWhenUnowned() async {
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
-        await DieEventOwnership.shared.release(id: "monitor-die")
+        let run = await DieEventOwnership.shared.beginRun(id: "monitor-die")
 
         _ = await ContainerProcessExitMonitor.run(
             wait: { 7 },
@@ -50,14 +154,11 @@ struct ContainerProcessExitMonitorDieTests {
             fallbackLabels: ["com.docker.compose.project": "demo"],
             dnsServer: nil,
             broadcaster: broadcaster,
+            runEpoch: run,
             outputFlushGraceNs: 1_000_000
         )
 
-        var seen: DockerEvent?
-        for await event in stream where event.Action == "die" {
-            seen = event
-            break
-        }
+        let seen = await Self.firstDieEvent(in: stream)
 
         #expect(seen?.Actor.Attributes["exitCode"] == "7")
         #expect(seen?.Actor.ID == "abc123")
@@ -66,11 +167,12 @@ struct ContainerProcessExitMonitorDieTests {
         await ContainerExitCodeStore.shared.remove(id: "abc123")
     }
 
-    @Test("stays silent when the start route already owns the exit")
-    func silentWhenOwned() async {
+    @Test("stays silent when a start-route observer reserved the exit")
+    func silentWhenReserved() async {
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
-        #expect(await DieEventOwnership.shared.claim(id: "monitor-owned"))
+        let run = await DieEventOwnership.shared.beginRun(id: "monitor-owned")
+        await DieEventOwnership.shared.reserveForStart(id: "monitor-owned", epoch: run, generation: 1)
 
         _ = await ContainerProcessExitMonitor.run(
             wait: { 0 },
@@ -80,30 +182,42 @@ struct ContainerProcessExitMonitorDieTests {
             fallbackLabels: [:],
             dnsServer: nil,
             broadcaster: broadcaster,
+            runEpoch: run,
             outputFlushGraceNs: 1_000_000
         )
 
-        // Drain with a bounded read instead of a background collector: the stream stays open,
-        // so a plain loop would block forever waiting for an event that must never arrive.
-        let dieSeen = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                for await event in stream where event.Action == "die" {
-                    return true
-                }
-                return false
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 300_000_000)
-                return false
-            }
-            let first = await group.next() ?? false
-            group.cancelAll()
-            return first
-        }
+        let seen = await Self.firstDieEvent(in: stream, withinNs: 300_000_000)
 
-        #expect(dieSeen == false)
-        await DieEventOwnership.shared.release(id: "monitor-owned")
+        #expect(seen == nil)
         await ContainerExitCodeStore.shared.remove(id: "monitor-owned")
         await ContainerExitCodeStore.shared.remove(id: "def456")
+    }
+
+    @Test("the monitor's claim survives its broadcast, blocking a late start observer")
+    func monitorKeepsOwnershipAfterBroadcast() async {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let run = await DieEventOwnership.shared.beginRun(id: "monitor-keeps")
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 3 },
+            hexId: "keeps123",
+            nativeId: "monitor-keeps",
+            fallbackImage: "alpine:3.20",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: broadcaster,
+            runEpoch: run,
+            outputFlushGraceNs: 1_000_000
+        )
+
+        #expect(await Self.firstDieEvent(in: stream)?.Actor.Attributes["exitCode"] == "3")
+
+        // A /start arriving after the container already exited must not emit a second event.
+        await DieEventOwnership.shared.reserveForStart(id: "monitor-keeps", epoch: run, generation: 1)
+        #expect(await DieEventOwnership.shared.claimForStart(id: "monitor-keeps", epoch: run, generation: 1) == false)
+
+        await ContainerExitCodeStore.shared.remove(id: "monitor-keeps")
+        await ContainerExitCodeStore.shared.remove(id: "keeps123")
     }
 }

--- a/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
+++ b/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
@@ -31,7 +31,7 @@ struct DieEventOwnershipTests {
         let ownership = DieEventOwnership()
         // A redundant /start finds the container already running, so it joins the same run.
         let run = await ownership.beginRun(id: "c1")
-        #expect(await ownership.currentEpoch(id: "c1") == run)
+        #expect(await ownership.beginRun(id: "c1") == run)
 
         await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
         await ownership.reserveForStart(id: "c1", epoch: run, generation: 2)
@@ -185,14 +185,87 @@ struct DieEventOwnershipTests {
         #expect(await ownership.claimForMonitor(id: "c2", epoch: second))
     }
 
-    @Test("a container this process never started is claimable at its implicit run")
+    @Test("a container this process never started opens a run when an observer joins it")
     func attachedToForeignContainer() async {
         let ownership = DieEventOwnership()
-        // Attaching to a container started before socktainer came up: no beginRun ever ran.
-        let run = await ownership.currentEpoch(id: "c1")
+        // Attaching to a container started before socktainer came up: no run was ever opened.
+        let run = await ownership.beginRun(id: "c1")
 
         #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
         #expect(await ownership.claimForMonitor(id: "c1", epoch: run) == false)
+    }
+
+    @Test("a recreated container does not inherit the deleted one's run")
+    func recreationDoesNotReuseAnEpoch() async {
+        let ownership = DieEventOwnership()
+        let deleted = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: deleted))
+        await ownership.forget(id: "c1")
+
+        // `compose up` after `down` recreates the service's container under the same name. With
+        // per-container numbering it would be handed the same epoch, and the deleted container's
+        // lagging observer could claim it — emitting a stale `die` and leaving this run mute.
+        let recreated = await ownership.beginRun(id: "c1")
+        #expect(recreated != deleted)
+        #expect(
+            await ownership.claimForMonitor(id: "c1", epoch: deleted) == false,
+            "the deleted container's observer must not be able to claim the recreated run"
+        )
+        #expect(
+            await ownership.claimForMonitor(id: "c1", epoch: recreated),
+            "the recreated container must still be able to report its own exit"
+        )
+    }
+
+    @Test("a container recreated after rm -f does not join the dead container's open run")
+    func recreationAfterForceRemoveOpensItsOwnRun() async {
+        let ownership = DieEventOwnership()
+        let dead = await ownership.beginRun(id: "c1")
+
+        // `docker rm -f` deletes a running container: its record stays claimable because the
+        // exit monitor still has to report that exit. The *name* must stop pointing at it, or a
+        // container recreated under the same name shares a run with a dead one — whoever claims
+        // first wins and the other exit is never reported.
+        await ownership.forget(id: "c1")
+
+        let recreated = await ownership.beginRun(id: "c1")
+        #expect(recreated != dead)
+        #expect(
+            await ownership.claimForMonitor(id: "c1", epoch: dead),
+            "the removed container's pending observer must still report its exit"
+        )
+        #expect(
+            await ownership.claimForMonitor(id: "c1", epoch: recreated),
+            "and the recreated container must be able to report its own"
+        )
+        // The removed container's record is released once its exit was reported, so a second
+        // observer of that same exit finds nothing to claim.
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: dead) == false)
+    }
+
+    @Test("a claim naming a run that is no longer tracked is refused")
+    func untrackedRunIsNotClaimable() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+        await ownership.forget(id: "c1")
+
+        // Treating an unknown run as a fresh one is what would let a late observer emit a second
+        // `die` for an exit that was already reported.
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run) == false)
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1) == false)
+    }
+
+    @Test("epochs are unique across containers, not just across a container's runs")
+    func epochsAreGloballyUnique() async {
+        let ownership = DieEventOwnership()
+
+        let first = await ownership.beginRun(id: "c1")
+        let second = await ownership.beginRun(id: "c2")
+        let third = await ownership.beginRestartedRun(id: "c1")
+
+        #expect(Set([first, second, third]).count == 3)
     }
 }
 

--- a/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
+++ b/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
@@ -278,6 +278,7 @@ struct ContainerProcessExitMonitorDieTests {
     func monitorKeepsOwnershipAfterBroadcast() async {
         let broadcaster = EventBroadcaster()
         let stream = await broadcaster.stream()
+
         let run = await DieEventOwnership.shared.beginRun(id: "monitor-keeps")
 
         _ = await ContainerProcessExitMonitor.run(
@@ -300,5 +301,62 @@ struct ContainerProcessExitMonitorDieTests {
 
         await ContainerExitCodeStore.shared.remove(id: "monitor-keeps")
         await ContainerExitCodeStore.shared.remove(id: "keeps123")
+    }
+    @Test("the loser of the exit claim leaves --rm cleanup to the winner")
+    func onlyTheExitOwnerRunsAutoRemove() async {
+        // `destroy` must follow the `die` it belongs to. The claim loser reaches the auto-remove
+        // gate while the winner is still inside its output-flush grace, so if it performed the
+        // cleanup it would publish `destroy` first and a client treating that as terminal — like
+        // Compose's --abort-on-container-exit — would never see the exit.
+        let broadcaster = EventBroadcaster()
+        let run = await DieEventOwnership.shared.beginRun(id: "monitor-loses-rm")
+        await DieEventOwnership.shared.reserveForStart(id: "monitor-loses-rm", epoch: run, generation: 1)
+        await ContainerInfoCache.shared.markAutoRemove(hexId: "rm123", nativeId: "monitor-loses-rm")
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 0 },
+            hexId: "rm123",
+            nativeId: "monitor-loses-rm",
+            fallbackImage: "alpine:3.20",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: broadcaster,
+            runEpoch: run,
+            outputFlushGraceNs: 1_000_000
+        )
+
+        #expect(
+            await ContainerInfoCache.shared.consumeAutoRemove(id: "rm123"),
+            "the --rm mark must be left for the observer that reports the exit"
+        )
+        await ContainerExitCodeStore.shared.remove(id: "monitor-loses-rm")
+        await ContainerExitCodeStore.shared.remove(id: "rm123")
+    }
+
+    @Test("with no broadcaster the monitor still performs --rm cleanup")
+    func autoRemoveStillRunsWithoutABroadcaster() async {
+        // Nothing can emit events, so there is no ordering to protect — but the container must
+        // still be reaped, since Apple Container never delivers a DELETE for it.
+        let run = await DieEventOwnership.shared.beginRun(id: "no-broadcaster-rm")
+        await ContainerInfoCache.shared.markAutoRemove(hexId: "rm456", nativeId: "no-broadcaster-rm")
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 0 },
+            hexId: "rm456",
+            nativeId: "no-broadcaster-rm",
+            fallbackImage: "alpine:3.20",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: nil,
+            runEpoch: run,
+            outputFlushGraceNs: 1_000_000
+        )
+
+        #expect(
+            await ContainerInfoCache.shared.consumeAutoRemove(id: "rm456") == false,
+            "the monitor must have consumed the --rm mark itself"
+        )
+        await ContainerExitCodeStore.shared.remove(id: "no-broadcaster-rm")
+        await ContainerExitCodeStore.shared.remove(id: "rm456")
     }
 }

--- a/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
+++ b/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
@@ -54,6 +54,46 @@ struct DieEventOwnershipTests {
         #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1) == false)
     }
 
+    @Test("the concurrent attach and start of docker run land on one run")
+    func concurrentAttachAndStartShareARun() async {
+        let ownership = DieEventOwnership()
+
+        // `docker run` attaches and starts concurrently; whichever request reaches the runtime
+        // first starts the container and the other gets a benign "already booted", so both sides
+        // open a run. Two runs for one exit would let each side's observer emit its own `die`.
+        let started = await ownership.beginRun(id: "c1")
+        let attached = await ownership.beginRun(id: "c1")
+        #expect(started == attached)
+
+        await ownership.reserveForStart(id: "c1", epoch: started, generation: 1)
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: attached) == false)
+        #expect(await ownership.claimForStart(id: "c1", epoch: started, generation: 1))
+    }
+
+    @Test("a finished run is not joined: the next start opens a fresh one")
+    func decidedRunIsNotJoined() async {
+        let ownership = DieEventOwnership()
+        let first = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: first))
+
+        let second = await ownership.beginRun(id: "c1")
+        #expect(second != first)
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: second))
+    }
+
+    @Test("a restart always opens its own run, even before the old exit was reported")
+    func restartNeverJoinsTheStoppedRun() async {
+        let ownership = DieEventOwnership()
+        let first = await ownership.beginRun(id: "c1")
+
+        // `docker restart` of a running container: the stop ends run 1 whether or not its exit
+        // has been reported yet, and the restarted container needs a reportable run of its own.
+        let second = await ownership.beginRestartedRun(id: "c1")
+        #expect(second != first)
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: first), "run 1's exit is still reportable")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: second), "so is the restarted run's")
+    }
+
     @Test("a monitor still resolving one exit cannot silence the next run")
     func staleMonitorCannotClaimTheNextRun() async {
         let ownership = DieEventOwnership()
@@ -61,7 +101,7 @@ struct DieEventOwnershipTests {
 
         // The container exits and restarts while the first run's monitor is still inside
         // `process.wait()`; it must land on its own run, not steal the live one.
-        let second = await ownership.beginRun(id: "c1")
+        let second = await ownership.beginRestartedRun(id: "c1")
         #expect(await ownership.claimForMonitor(id: "c1", epoch: first))
         #expect(
             await ownership.claimForMonitor(id: "c1", epoch: second),
@@ -69,12 +109,12 @@ struct DieEventOwnershipTests {
         )
     }
 
-    @Test("each run is claimable again, including consecutive restart-policy restarts")
+    @Test("each restart is claimable again, including consecutive restart-policy restarts")
     func newRunReopensTheClaim() async {
         let ownership = DieEventOwnership()
 
         for generation in 1...3 {
-            let run = await ownership.beginRun(id: "c1")
+            let run = await ownership.beginRestartedRun(id: "c1")
             await ownership.reserveForStart(id: "c1", epoch: run, generation: generation)
             #expect(
                 await ownership.claimForStart(id: "c1", epoch: run, generation: generation),
@@ -84,14 +124,55 @@ struct DieEventOwnershipTests {
     }
 
     @Test("a new run does not inherit the previous run's reservation")
-    func beginRunClearsReservation() async {
+    func newRunClearsReservation() async {
         let ownership = DieEventOwnership()
         let first = await ownership.beginRun(id: "c1")
         await ownership.reserveForStart(id: "c1", epoch: first, generation: 1)
+        #expect(await ownership.claimForStart(id: "c1", epoch: first, generation: 1))
 
         // Re-attached without a /start: the monitor is the only observer of the new run.
         let second = await ownership.beginRun(id: "c1")
         #expect(await ownership.claimForMonitor(id: "c1", epoch: second))
+    }
+
+    @Test("a removed container's reported exit refuses later claims")
+    func forgetRefusesLateClaimsForAReportedRun() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+
+        // The `--rm` path cleans up after broadcasting, so a second observer of the same exit
+        // must find nothing to claim — otherwise the dropped record hands it a fresh run and it
+        // emits a duplicate `die`.
+        await ownership.forget(id: "c1")
+
+        await ownership.reserveForStart(id: "c1", epoch: run, generation: 1)
+        #expect(await ownership.claimForStart(id: "c1", epoch: run, generation: 1) == false)
+    }
+
+    @Test("docker rm -f still lets the pending observer report the exit")
+    func forgetKeepsAnOpenRunClaimable() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+
+        // `docker rm -f` stops and deletes a running container; its exit monitor resolves the
+        // code only after the delete lands. Docker sends `die` for that exit, so refusing the
+        // claim would make the event a race with teardown instead of dropping a duplicate.
+        await ownership.forget(id: "c1")
+
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+    }
+
+    @Test("recreating a container under the same name reports its exits again")
+    func recreatedContainerIsClaimableAgain() async {
+        let ownership = DieEventOwnership()
+        let run = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: run))
+        await ownership.forget(id: "c1")
+
+        // `compose down` then `compose up` reuses the service's container name.
+        let recreated = await ownership.beginRun(id: "c1")
+        #expect(await ownership.claimForMonitor(id: "c1", epoch: recreated))
     }
 
     @Test("claims are independent per container")

--- a/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
+++ b/Tests/socktainerTests/Events/DieEventOwnershipTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// `docker compose up` starts a service by attaching to a stopped container; it never calls
+/// `POST /start`. Only the attach route's exit monitor sees that exit, so it must emit `die` —
+/// while `docker run`, which goes through both attach and start, must still emit exactly one.
+@Suite("DieEventOwnership")
+struct DieEventOwnershipTests {
+    @Test("only the first claimer owns the die event")
+    func singleOwner() async {
+        let ownership = DieEventOwnership()
+
+        #expect(await ownership.claim(id: "c1"))
+        #expect(await ownership.claim(id: "c1") == false)
+    }
+
+    @Test("ownership is reusable after release, so later runs still emit die")
+    func releaseAllowsNextRun() async {
+        let ownership = DieEventOwnership()
+
+        #expect(await ownership.claim(id: "c1"))
+        await ownership.release(id: "c1")
+        #expect(await ownership.claim(id: "c1"), "a container's second run must be claimable again")
+    }
+
+    @Test("claims are independent per container")
+    func independentContainers() async {
+        let ownership = DieEventOwnership()
+
+        #expect(await ownership.claim(id: "c1"))
+        #expect(await ownership.claim(id: "c2"))
+    }
+}
+
+@Suite("ContainerProcessExitMonitor die event")
+struct ContainerProcessExitMonitorDieTests {
+    @Test("emits die with the exit code when nothing else owns the exit")
+    func emitsDieWhenUnowned() async {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        await DieEventOwnership.shared.release(id: "monitor-die")
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 7 },
+            hexId: "abc123",
+            nativeId: "monitor-die",
+            fallbackImage: "alpine:3.20",
+            fallbackLabels: ["com.docker.compose.project": "demo"],
+            dnsServer: nil,
+            broadcaster: broadcaster,
+            outputFlushGraceNs: 1_000_000
+        )
+
+        var seen: DockerEvent?
+        for await event in stream where event.Action == "die" {
+            seen = event
+            break
+        }
+
+        #expect(seen?.Actor.Attributes["exitCode"] == "7")
+        #expect(seen?.Actor.ID == "abc123")
+        #expect(seen?.Actor.Attributes["com.docker.compose.project"] == "demo")
+        await ContainerExitCodeStore.shared.remove(id: "monitor-die")
+        await ContainerExitCodeStore.shared.remove(id: "abc123")
+    }
+
+    @Test("stays silent when the start route already owns the exit")
+    func silentWhenOwned() async {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        #expect(await DieEventOwnership.shared.claim(id: "monitor-owned"))
+
+        _ = await ContainerProcessExitMonitor.run(
+            wait: { 0 },
+            hexId: "def456",
+            nativeId: "monitor-owned",
+            fallbackImage: "alpine:3.20",
+            fallbackLabels: [:],
+            dnsServer: nil,
+            broadcaster: broadcaster,
+            outputFlushGraceNs: 1_000_000
+        )
+
+        // Drain with a bounded read instead of a background collector: the stream stays open,
+        // so a plain loop would block forever waiting for an event that must never arrive.
+        let dieSeen = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await event in stream where event.Action == "die" {
+                    return true
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        #expect(dieSeen == false)
+        await DieEventOwnership.shared.release(id: "monitor-owned")
+        await ContainerExitCodeStore.shared.remove(id: "monitor-owned")
+        await ContainerExitCodeStore.shared.remove(id: "def456")
+    }
+}

--- a/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerRestartPolicyPostStartTests.swift
@@ -56,6 +56,108 @@ struct ContainerRestartPolicyPostStartTests {
         await ContainerExitCodeStore.shared.remove(id: nativeId)
     }
 
+    @Test("Every restart-policy restart reports its own exit, not just the first")
+    func consecutiveAutomaticRestartsEachEmitDie() async throws {
+        // A `die` event is claimed per run and the claim is never handed back, so a restarted
+        // container has to open a new run — otherwise the second exit finds the first run's
+        // claim still held and reports nothing, leaving `docker wait` and Compose blocked.
+        let nativeId = "restart-consecutive-die-ctr"
+        let ip = "192.168.65.70"
+        let network = "myapp_default"
+
+        let mock = RestartMock(snapshot: try makeSnapshot(nativeId: nativeId, ip: ip, network: network, restartPolicyName: "always"))
+        let broadcaster = EventBroadcaster()
+        let collector = EventCollector()
+        let stream = await broadcaster.stream()
+        let captureTask = Task {
+            for await event in stream where event.Action == "die" {
+                await collector.add(event)
+            }
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerStartRoute(client: mock))
+
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+
+            // First crash: the observer armed by /start reports it and the always-policy
+            // restarts the container, arming a fresh observer.
+            await ContainerExitCodeStore.shared.set(id: nativeId, code: 1)
+            let firstDie = try await pollUntil(timeoutSeconds: 3) { await collector.events.count >= 1 }
+            #expect(firstDie, "the first exit must be reported")
+            let restarted = try await pollUntil(timeoutSeconds: 3) { await mock.startCallCount() >= 2 }
+            #expect(restarted, "the always-policy must restart the container")
+
+            // Second crash of the restarted container.
+            await ContainerExitCodeStore.shared.remove(id: nativeId)
+            await ContainerExitCodeStore.shared.set(id: nativeId, code: 2)
+            let secondDie = try await pollUntil(timeoutSeconds: 6) { await collector.events.count >= 2 }
+            #expect(secondDie, "the restarted container's exit must be reported too")
+        }
+
+        captureTask.cancel()
+        #expect(await collector.events.compactMap { $0.Actor.Attributes["exitCode"] }.prefix(2) == ["1", "2"])
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
+
+    @Test("POST /restart reports the restarted container's own exit")
+    func manualRestartEmitsDieForTheNewRun() async throws {
+        // `/restart` starts a new run without going through `/start`, so it has to open its own
+        // `die` claim: the previous run's claim is never handed back, and inheriting it would
+        // leave `docker restart` followed by an exit completely silent.
+        let nativeId = "restart-route-die-ctr"
+        let ip = "192.168.65.80"
+        let network = "myapp_default"
+
+        let mock = RestartMock(snapshot: try makeSnapshot(nativeId: nativeId, ip: ip, network: network, restartPolicyName: "no"))
+        let broadcaster = EventBroadcaster()
+        let collector = EventCollector()
+        let stream = await broadcaster.stream()
+        let captureTask = Task {
+            for await event in stream where event.Action == "die" {
+                await collector.add(event)
+            }
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: ContainerStartRoute(client: mock))
+            try app.register(collection: ContainerRestartRoute(client: mock))
+
+            // First run and its exit, which claims that run's die event.
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/start") { res async in
+                #expect(res.status == .noContent)
+            }
+            await ContainerExitCodeStore.shared.set(id: nativeId, code: 1)
+            #expect(try await pollUntil(timeoutSeconds: 3) { await collector.events.count >= 1 })
+
+            // Restart, then let the restarted container exit.
+            try await app.testing().test(.POST, "/v1.51/containers/\(nativeId)/restart") { res async in
+                #expect(res.status == .noContent)
+            }
+            await ContainerExitCodeStore.shared.set(id: nativeId, code: 5)
+            let secondDie = try await pollUntil(timeoutSeconds: 3) { await collector.events.count >= 2 }
+            #expect(secondDie, "the restarted run's exit must be reported")
+        }
+
+        captureTask.cancel()
+        #expect(await collector.events.compactMap { $0.Actor.Attributes["exitCode"] }.prefix(2) == ["1", "5"])
+
+        await ContainerRestartState.shared.reset(id: nativeId)
+        await ContainerExitCodeStore.shared.remove(id: nativeId)
+    }
+
     @Test("A manual /start during the backoff window supersedes the pending automatic restart")
     func manualStartDuringBackoffSupersedesPendingRestart() async throws {
         let nativeId = "restart-race-ctr"

--- a/Tests/socktainerTests/Routes/ContainerWaitStoppedTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerWaitStoppedTests.swift
@@ -1,0 +1,152 @@
+import ContainerAPIClient
+import ContainerResource
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// `docker compose up` issues `POST /wait` before `POST /start`, exactly as the Docker CLI does.
+/// A container that exits immediately used to leave Compose blocked for the full 30s store poll,
+/// because the native wait throws once the runtime client is gone. These tests pin both halves of
+/// the contract: a finished container resolves fast, a not-yet-started one keeps waiting.
+@Suite("ContainerWaitRoute.resolveNotRunning")
+struct ContainerWaitStoppedTests {
+    /// Reports `running` for the first `runningPolls` state queries, then `stopped`.
+    private actor LifecycleClient: ClientContainerProtocol {
+        private let running: ContainerSnapshot
+        private let stopped: ContainerSnapshot
+        private let runningPolls: Int
+        private var polls = 0
+
+        init(running: ContainerSnapshot, stopped: ContainerSnapshot, runningPolls: Int) {
+            self.running = running
+            self.stopped = stopped
+            self.runningPolls = runningPolls
+        }
+
+        func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [stopped] }
+
+        func getContainer(id: String) async throws -> ContainerSnapshot? {
+            polls += 1
+            return polls <= runningPolls ? running : stopped
+        }
+
+        nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
+        func start(id: String, detachKeys: String?) async throws {}
+        func stop(id: String, signal: String?, timeout: Int?) async throws {}
+        func restart(id: String, signal: String?, timeout: Int?) async throws {}
+        func kill(id: String, signal: String?) async throws {}
+        func delete(id: String) async throws {}
+
+        /// Mirrors the real failure: the runtime client is gone, so the native wait throws.
+        func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+            throw ClientContainerError.notRunning(id: id)
+        }
+
+        func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+            ([], 0)
+        }
+    }
+
+    private func snapshot(id: String, status: RuntimeStatus) throws -> ContainerSnapshot {
+        try makeContainerSnapshot(
+            nativeId: id,
+            networks: [(network: "default", ip: "192.168.64.5")],
+            labels: [:],
+            status: status
+        )
+    }
+
+    @Test("a container observed running then stopped resolves without waiting out the store poll")
+    func exitedContainerResolvesQuickly() async throws {
+        let identifier = "wait-exited"
+        await ContainerExitCodeStore.shared.remove(id: identifier)
+
+        let client = LifecycleClient(
+            running: try snapshot(id: identifier, status: .running),
+            stopped: try snapshot(id: identifier, status: .stopped),
+            runningPolls: 1
+        )
+
+        let started = Date()
+        let result = await ContainerWaitRoute.resolveNotRunning(
+            containerId: identifier,
+            client: client,
+            storeTimeoutNs: 30_000_000_000
+        )
+
+        #expect(result.StatusCode == 0)
+        #expect(Date().timeIntervalSince(started) < 5, "must not wait out the 30s store poll")
+    }
+
+    @Test("a recorded exit code is reported instead of a clean exit")
+    func recordedExitCodeIsReported() async throws {
+        let identifier = "wait-exit-3"
+        await ContainerExitCodeStore.shared.set(id: identifier, code: 3)
+        defer { Task { await ContainerExitCodeStore.shared.remove(id: identifier) } }
+
+        let client = LifecycleClient(
+            running: try snapshot(id: identifier, status: .running),
+            stopped: try snapshot(id: identifier, status: .stopped),
+            runningPolls: 1
+        )
+
+        let result = await ContainerWaitRoute.resolveNotRunning(
+            containerId: identifier,
+            client: client,
+            storeTimeoutNs: 30_000_000_000
+        )
+
+        #expect(result.StatusCode == 3)
+    }
+
+    /// The dangerous regression: Compose waits before starting, so "not running yet" must never
+    /// be reported as a finished container.
+    @Test("a created container that never ran keeps waiting")
+    func createdContainerDoesNotResolveEarly() async throws {
+        let identifier = "wait-created"
+        await ContainerExitCodeStore.shared.remove(id: identifier)
+
+        let stopped = try snapshot(id: identifier, status: .stopped)
+        let client = LifecycleClient(running: stopped, stopped: stopped, runningPolls: 0)
+
+        let started = Date()
+        _ = await ContainerWaitRoute.resolveNotRunning(
+            containerId: identifier,
+            client: client,
+            storeTimeoutNs: 1_000_000_000
+        )
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(elapsed >= 0.9, "resolved after \(elapsed)s; a never-started container must keep waiting")
+    }
+
+    @Test("a die event resolves the wait with its exit code")
+    func dieEventResolvesWait() async throws {
+        let identifier = "wait-die-event"
+        await ContainerExitCodeStore.shared.remove(id: identifier)
+
+        let stopped = try snapshot(id: identifier, status: .stopped)
+        let client = LifecycleClient(running: stopped, stopped: stopped, runningPolls: 0)
+
+        let (stream, continuation) = AsyncStream.makeStream(of: DockerEvent.self)
+        continuation.yield(
+            DockerEvent.simpleEvent(
+                id: identifier,
+                type: "container",
+                status: "die",
+                extraAttributes: ["exitCode": "7"]
+            )
+        )
+
+        let result = await ContainerWaitRoute.resolveNotRunning(
+            containerId: identifier,
+            client: client,
+            events: stream,
+            storeTimeoutNs: 30_000_000_000
+        )
+
+        #expect(result.StatusCode == 7)
+        continuation.finish()
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerProcessExitMonitorTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerProcessExitMonitorTests.swift
@@ -28,6 +28,7 @@ struct ContainerProcessExitMonitorTests {
             fallbackLabels: [:],
             dnsServer: nil,
             broadcaster: nil,
+            runEpoch: 0,
             outputFlushGraceNs: 0,
             exitCodeRetryDelayNs: 0
         )
@@ -54,6 +55,7 @@ struct ContainerProcessExitMonitorTests {
             fallbackLabels: [:],
             dnsServer: nil,
             broadcaster: nil,
+            runEpoch: 0,
             outputFlushGraceNs: 0,
             exitCodeRetryDelayNs: 0
         )
@@ -81,6 +83,7 @@ struct ContainerProcessExitMonitorTests {
             fallbackLabels: [:],
             dnsServer: nil,
             broadcaster: nil,
+            runEpoch: 0,
             outputFlushGraceNs: 0,
             exitCodeRetryDelayNs: 0
         )


### PR DESCRIPTION
## Problem

`docker compose up` starts a service by attaching to a stopped container — it issues `POST /containers/{id}/attach` and never calls `POST /start`. The attach route bootstraps the container, so it runs and exits normally, but `die` is broadcast only by `ContainerStartRoute.observeExit`, which was never armed.

Compose subscribes to `/events` and waits for that exit, so `docker compose up --abort-on-container-exit` hung indefinitely against socktainer while the container had already finished. Reproduced with Compose v5.1.2 and Apple Container 1.2.2:

```
POST /v1.51/containers/<id>/attach
GET  /v1.51/containers/json
GET  /v1.51/events          <- compose waits here forever
```

`POST /wait` did not rescue it either: the native wait throws `no runtime client exists: container is stopped` for a container that exited before the wait was issued, so the route polled `ContainerExitCodeStore` for the full 30 s.

## Change

- `ContainerProcessExitMonitor` broadcasts `die` with the real exit code, covering every container the attach route bootstraps.
- `DieEventOwnership` guarantees exactly one `die` when both observers exist (`docker run` attaches *and* starts). Ownership is released on every exit path, including `observeExit`'s generation guard, so a container's second run is claimable again.
- `POST /wait` (`condition=not-running`) now races four sources: the native wait, the exit-code store, the `die` event, and the container's own state. The state watcher only reports after it has seen the container **running**, so a created-but-unstarted container — exactly what Compose waits on, since it waits before starting — is never reported as a clean exit.

## Verification

New tests: `DieEventOwnershipTests`, `ContainerProcessExitMonitorDieTests`, `ContainerWaitStoppedTests` (including the regression guard that a never-started container keeps waiting). Full suite: 877 tests pass.

Live, against Apple Container 1.2.2 on macOS 26.2:

| Case | Before | After |
|---|---|---|
| `compose up --abort-on-container-exit` | hung until killed | exits in 3 s, `hello-1 exited with code 0` |
| same, second run | hung | 1 s |
| `docker run --rm alpine echo` | one die | one die (no duplicate) |
| `compose up -d` with ports and volumes | ok | ok, `0.0.0.0:18080->80/tcp` |
