### PR TITLE
fix(server): reject an unknown type on system df with a 400

### DIFF
--- a/Sources/socktainer/Routes/Server/SystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Server/SystemDFRoute.swift
@@ -59,6 +59,10 @@ struct SystemDFRoute: RouteCollection {
 
     func handler(_ req: Request) async throws -> Response {
         let query = try req.query.decode(SystemDFQuery.self)
+        // moby rejects an unknown object type with a 400 instead of silently
+        // returning an all-null document. Validate the raw ordered list so the
+        // reported value is the first unknown in query order, as moby does.
+        try Self.validateTypes(query.type ?? [])
         let requestedTypes = Set(query.type ?? [])
         let includeAll = requestedTypes.isEmpty
 
@@ -131,6 +135,19 @@ struct SystemDFRoute: RouteCollection {
         )
 
         return try await response.encodeResponse(status: .ok, for: req)
+    }
+
+    /// The object types moby's GET /system/df accepts. An unknown value is a 400,
+    /// matching moby's getDiskUsage type switch default.
+    static let validTypes: Set<String> = ["container", "image", "volume", "build-cache"]
+
+    /// Rejects the first unrecognized type in query order (matching moby, which
+    /// reports the first bad value it iterates, not an alphabetically-sorted one
+    /// — verified live: `type=zzz&type=aaa` reports `zzz`).
+    static func validateTypes(_ types: [String]) throws {
+        if let unknown = types.first(where: { !validTypes.contains($0) }) {
+            throw Abort(.badRequest, reason: "unknown object type: \(unknown)")
+        }
     }
 }
 

--- a/Tests/socktainerTests/Routes/SystemDFTypeValidationTests.swift
+++ b/Tests/socktainerTests/Routes/SystemDFTypeValidationTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Vapor
+
+@testable import socktainer
+
+/// GET /system/df must reject an unknown `type` value with a 400, matching
+/// moby's getDiskUsage (its type switch returns invalidRequestError for
+/// anything other than container/image/volume/build-cache). The previous
+/// implementation silently ignored unknown types and returned an all-null
+/// document with 200.
+@Suite("SystemDFRoute — type validation")
+struct SystemDFTypeValidationTests {
+
+    @Test("Valid types and an empty set pass validation")
+    func validTypesPass() throws {
+        try SystemDFRoute.validateTypes([])
+        try SystemDFRoute.validateTypes(["image"])
+        try SystemDFRoute.validateTypes(["container", "image", "volume", "build-cache"])
+    }
+
+    @Test("An unknown type throws a 400 naming the offending value")
+    func unknownTypeThrows() {
+        let error = #expect(throws: Abort.self) {
+            try SystemDFRoute.validateTypes(["bogus"])
+        }
+        #expect(error?.status == .badRequest)
+        #expect(error?.reason.contains("unknown object type: bogus") == true)
+    }
+
+    @Test("A mix of valid and invalid types still rejects")
+    func mixedTypesReject() {
+        #expect(throws: Abort.self) {
+            try SystemDFRoute.validateTypes(["image", "nope"])
+        }
+    }
+
+    @Test("With several unknown types, the first in query order is reported (like moby)")
+    func firstUnknownInQueryOrderReported() {
+        // Verified live against real Docker: `type=zzz&type=aaa` reports `zzz`,
+        // i.e. the first unknown as iterated, not the alphabetically-first one.
+        let error = #expect(throws: Abort.self) {
+            try SystemDFRoute.validateTypes(["zzz", "aaa"])
+        }
+        #expect(error?.reason == "unknown object type: zzz")
+    }
+
+    @Test("A valid type before an unknown one still reports the unknown")
+    func unknownAfterValidReported() {
+        let error = #expect(throws: Abort.self) {
+            try SystemDFRoute.validateTypes(["container", "bogus"])
+        }
+        #expect(error?.reason == "unknown object type: bogus")
+    }
+
+    @Test("An empty type value is unknown, reported verbatim (like moby)")
+    func emptyTypeValueRejected() {
+        // Real Docker 400s `type=` with `unknown object type: ` (empty value).
+        let error = #expect(throws: Abort.self) {
+            try SystemDFRoute.validateTypes([""])
+        }
+        #expect(error?.reason == "unknown object type: ")
+    }
+}


### PR DESCRIPTION
## Summary

`GET /system/df` silently ignored an unknown `type` query value and returned an all-null document with 200. moby's `getDiskUsage` accepts only `container`, `image`, `volume`, and `build-cache`, and rejects anything else with a 400 ("unknown object type: X").

The route now validates the requested types before doing any backend work, so an invalid type returns 400 without listing images, containers, and volumes. When several unknown types are given, the first one in query order is reported, matching moby (which reports the first bad value it iterates, not an alphabetically-sorted one).

## Before

```console
$ curl -s -o /dev/null -w '%{http_code}\n' --unix-socket ... '.../system/df?type=bogus'
200          # all-null document, unknown type silently ignored
```

## After

```console
$ curl -s -w '\n%{http_code}\n' --unix-socket ... '.../system/df?type=bogus'
{"message":"unknown object type: bogus"}
400

# first unknown in query order is reported (not the alphabetically-first)
$ curl -s -w '\n%{http_code}\n' --unix-socket ... '.../system/df?type=zzz&type=aaa'
{"message":"unknown object type: zzz"}
400

# a valid type still returns its section with 200
$ curl -s -o /dev/null -w '%{http_code}\n' --unix-socket ... '.../system/df?type=container'
200
```

Every case above was cross-checked against real Docker (orbstack): the `unknown object type: bogus` / `unknown object type: zzz` messages, the query-order (not alphabetical) reporting, an empty `type=` value 400ing verbatim, and a valid type returning 200 all match real Docker's output.

## Testing

- New unit tests in `Tests/socktainerTests/Routes/SystemDFTypeValidationTests.swift`:
  - valid types and an empty set pass
  - an unknown type throws a 400 naming the offending value
  - a mix of valid and invalid types still rejects
  - with several unknown types, the first in query order is reported (not the alphabetically-first)
  - a valid type before an unknown one still reports the unknown
  - an empty type value is unknown, reported verbatim
- `make fmt`, `make build`, `make test` (874 tests) pass.

Note: this endpoint is not exercised by the docker CLI (it sends no `type`), so the difference is visible via the API directly or through SDK clients / testcontainers.
