### PR TITLE
fix(containers): use Docker's exact "No such container: <id>" phrasing

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerAttachRoute.swift
@@ -419,7 +419,9 @@ extension ContainerAttachRoute {
         let shouldUpgrade = connectionHeader?.contains("upgrade") == true && upgradeHeader == "tcp"
 
         guard let currentContainer = try await client.getContainer(id: container.id) else {
-            throw Abort(.notFound, reason: "Container not found")
+            // Docker phrasing ("No such container: <id>") is load-bearing — see the
+            // matching comment in ContainerInspectRoute.
+            throw Abort(.notFound, reason: "No such container: \(container.id)")
         }
 
         // NOTE: For true docker run -it behavior, we need to control the main process stdio,

--- a/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerInspectRoute.swift
@@ -52,7 +52,14 @@ extension ContainerInspectRoute {
             }
 
             guard let container = try await client.getContainer(id: id) else {
-                throw Abort(.notFound, reason: "Container not found")
+                // Docker phrasing ("No such container: <id>") is load-bearing, not
+                // cosmetic: the Supabase CLI's `legacyIsContainerNotFoundMessage`
+                // (and docker-py's ImageNotFound-style handling elsewhere in this
+                // codebase) pattern-matches on this exact text to distinguish a
+                // fresh-install "doesn't exist yet" from a real failure. A generic
+                // "Container not found" doesn't match, so callers propagate it as a
+                // hard error instead of proceeding to create the container.
+                throw Abort(.notFound, reason: "No such container: \(id)")
             }
 
             let exposedPorts = Dictionary(

--- a/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerLogsRoute.swift
@@ -28,7 +28,9 @@ extension ContainerLogsRoute {
             }
 
             guard let container = try await client.getContainer(id: id) else {
-                throw Abort(.notFound, reason: "Container not found")
+                // Docker phrasing ("No such container: <id>") is load-bearing — see the
+                // matching comment in ContainerInspectRoute.
+                throw Abort(.notFound, reason: "No such container: \(id)")
             }
 
             // `tail=<N>` limits the backlog to the last N lines; "all" (the

--- a/Sources/socktainer/Routes/Containers/ExecRoutes.swift
+++ b/Sources/socktainer/Routes/Containers/ExecRoutes.swift
@@ -188,7 +188,9 @@ struct ExecRoute: RouteCollection {
             }
 
             guard let container = try await client.getContainer(id: containerId) else {
-                throw Abort(.notFound, reason: "Container not found")
+                // Docker phrasing ("No such container: <id>") is load-bearing — see the
+                // matching comment in ContainerInspectRoute.
+                throw Abort(.notFound, reason: "No such container: \(containerId)")
             }
 
             do {
@@ -262,7 +264,9 @@ struct ExecRoute: RouteCollection {
             }
 
             guard let container = try await client.getContainer(id: config.containerId) else {
-                throw Abort(.notFound, reason: "Container not found")
+                // Docker phrasing ("No such container: <id>") is load-bearing — see the
+                // matching comment in ContainerInspectRoute.
+                throw Abort(.notFound, reason: "No such container: \(config.containerId)")
             }
 
             try client.enforceContainerRunning(container: container)

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -381,6 +381,50 @@ struct ContainerInspectRouteRestartPolicyTests {
     }
 }
 
+/// Regression test: the 404 for a missing container must use Docker's exact phrasing
+/// ("No such container: <id>"), not a generic message. This is load-bearing, not
+/// cosmetic — the Supabase CLI's `legacyIsContainerNotFoundMessage` (and docker-py's
+/// equivalent handling for images elsewhere in this codebase) pattern-matches on this
+/// exact text to distinguish "doesn't exist yet, proceed to create it" from a real
+/// failure. A generic "Container not found" doesn't match, so `supabase start` failed
+/// at its very first preflight check against socktainer, before pulling a single image.
+@Suite("ContainerInspectRoute — missing container message")
+struct ContainerInspectRouteMissingContainerTests {
+
+    @Test("A missing container 404s with Docker's exact phrasing")
+    func missingContainerUsesDockerPhrasing() async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: ContainerInspectRoute(client: EmptyContainerClient()))
+
+            try await app.testing().test(.GET, "/v1.51/containers/does-not-exist/json") { res async in
+                #expect(res.status == .notFound)
+                #expect(res.body.string.lowercased().contains("no such container"))
+                #expect(res.body.string.contains("does-not-exist"))
+            }
+        }
+    }
+}
+
+private struct EmptyContainerClient: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}
+
 // MARK: - Mock
 
 /// Mock that returns `snapshot` for any `getContainer` call.

--- a/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerInspectRouteTests.swift
@@ -399,10 +399,10 @@ struct ContainerInspectRouteMissingContainerTests {
             regexRouter.installMiddleware(on: app)
             try app.register(collection: ContainerInspectRoute(client: EmptyContainerClient()))
 
-            try await app.testing().test(.GET, "/v1.51/containers/does-not-exist/json") { res async in
+            try await app.testing().test(.GET, "/v1.51/containers/does-not-exist/json") { res async throws in
                 #expect(res.status == .notFound)
-                #expect(res.body.string.lowercased().contains("no such container"))
-                #expect(res.body.string.contains("does-not-exist"))
+                let body = try JSONSerialization.jsonObject(with: Data(buffer: res.body)) as? [String: Any]
+                #expect(body?["reason"] as? String == "No such container: does-not-exist")
             }
         }
     }


### PR DESCRIPTION
## Summary

Five call sites (`ContainerInspectRoute`, `ContainerAttachRoute`, `ContainerLogsRoute`, and both container-lookup guards in `ExecRoutes`) threw a generic `"Container not found"` instead of matching moby's exact phrasing. This codebase already documents the identical class of issue for images (`ImageInspectRoute`: *"Docker phrasing ('No such image: <ref>') is load-bearing: docker-py only maps a 404 to ImageNotFound when the message contains 'no such image'"*) — the same applies to containers.

## Related Issue

Root cause of `supabase start` failing at its very first preflight check against socktainer, before pulling a single image (see #253). The Supabase CLI's `legacyIsContainerNotFoundMessage` only recognizes `/no such container/i`, `/no such object/i`, or `/no container with name or id/i` — a generic `"Container not found"` matches none of them, so a fresh install's expected "doesn't exist yet" 404 was treated as a hard failure instead of proceeding to create the container.

## Changes

- All 5 call sites now throw `"No such container: <id>"`, matching the convention already established for images.

## Testing

- [x] `make fmt` passes
- [x] `make test` passes (838/838, including a new regression test)
- [x] Manual/live verification: `supabase start` against socktainer now proceeds past the preflight check and pulls all 12 stack images successfully (previously failed immediately, zero images pulled).

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)