### PR TITLE
fix(containers): honor HostConfig.Privileged by granting all capabilities

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -99,7 +99,7 @@ extension ContainerCreateRoute {
             let normalizedCapabilities: (capAdd: [String], capDrop: [String])
             do {
                 normalizedCapabilities = try Parser.capabilities(
-                    capAdd: body.HostConfig?.CapAdd ?? [],
+                    capAdd: ContainerCreateRoute.requestedCapAdd(hostConfig: body.HostConfig),
                     capDrop: body.HostConfig?.CapDrop ?? [])
             } catch {
                 throw Abort(.badRequest, reason: "invalid capability: \(error)")
@@ -794,6 +794,19 @@ extension ContainerCreateRoute {
             name: container.id,
             labels: LabelNormalization.restore(container.configuration.labels)
         )
+    }
+
+    /// Docker's `--privileged` has no direct Apple Containerization equivalent; granting
+    /// every capability (the same "ALL" grant `ClientBuilderService` already uses for its
+    /// own builder container) is what actually unblocks the rbind mounts buildx's
+    /// docker-container driver needs (issue #361) — `Privileged` was previously decoded
+    /// but never consulted anywhere, so it was silently dropped.
+    static func requestedCapAdd(hostConfig: HostConfig?) -> [String] {
+        var capAdd = hostConfig?.CapAdd ?? []
+        if hostConfig?.Privileged == true, !capAdd.contains(where: { $0.uppercased() == "ALL" }) {
+            capAdd.append("ALL")
+        }
+        return capAdd
     }
 
     /// Mirrors moby's daemon_unix.go cpu subsystem checks (v28.5.2): NanoCpus and the CFS

--- a/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerCreateRouteTests.swift
@@ -400,6 +400,61 @@ struct CapabilityValidationTests {
     }
 }
 
+/// Regression tests for issue #361: `HostConfig.Privileged` was decoded but never
+/// consulted, so `docker run --privileged` (and buildx's docker-container driver,
+/// which creates its buildkit container with `Privileged: true` rather than
+/// `CapAdd`) silently ran without the capabilities buildkitd needs to rbind-mount
+/// its build context.
+@Suite("ContainerCreateRoute.requestedCapAdd")
+struct PrivilegedCapAddTests {
+
+    private func decodeHostConfig(_ json: String) -> HostConfig {
+        try! JSONDecoder().decode(HostConfig.self, from: Data(json.utf8))
+    }
+
+    @Test("Privileged with no CapAdd grants ALL, matching ClientBuilderService's own builder container")
+    func privilegedGrantsAll() {
+        let hostConfig = decodeHostConfig(#"{"Privileged":true}"#)
+        #expect(ContainerCreateRoute.requestedCapAdd(hostConfig: hostConfig) == ["ALL"])
+    }
+
+    @Test("Privileged alongside an explicit CapAdd list still grants ALL")
+    func privilegedWithExplicitCapAddStillGrantsAll() {
+        let hostConfig = decodeHostConfig(#"{"Privileged":true,"CapAdd":["NET_ADMIN"]}"#)
+        #expect(ContainerCreateRoute.requestedCapAdd(hostConfig: hostConfig) == ["NET_ADMIN", "ALL"])
+    }
+
+    @Test("Privileged with CapAdd already containing ALL does not duplicate it")
+    func privilegedWithAllAlreadyPresentIsNotDuplicated() {
+        let hostConfig = decodeHostConfig(#"{"Privileged":true,"CapAdd":["ALL"]}"#)
+        #expect(ContainerCreateRoute.requestedCapAdd(hostConfig: hostConfig) == ["ALL"])
+    }
+
+    @Test("Privileged false leaves CapAdd untouched")
+    func nonPrivilegedLeavesCapAddUntouched() {
+        let hostConfig = decodeHostConfig(#"{"Privileged":false,"CapAdd":["NET_ADMIN"]}"#)
+        #expect(ContainerCreateRoute.requestedCapAdd(hostConfig: hostConfig) == ["NET_ADMIN"])
+    }
+
+    @Test("No HostConfig yields no capabilities")
+    func nilHostConfigYieldsEmpty() {
+        #expect(ContainerCreateRoute.requestedCapAdd(hostConfig: nil) == [])
+    }
+
+    @Test("A privileged create request reaches the image stage instead of being rejected")
+    func privilegedCreateRequestReachesImageStage() async throws {
+        try await withCreateRouteApp(maxBodySize: "64mb") { app in
+            try await app.testing().test(
+                .POST, "/v1.51/containers/create?name=privileged",
+                headers: ["Content-Type": "application/json"],
+                body: ByteBuffer(string: #"{"Image":"socktainer-nonexistent-test-image:missing","HostConfig":{"Privileged":true}}"#)
+            ) { res async in
+                expectReachedImageStage(res)
+            }
+        }
+    }
+}
+
 @Suite("ContainerCreateRoute.vCpus")
 struct VCpusConversionTests {
 


### PR DESCRIPTION
## Summary

- `HostConfig.Privileged` was decoded on `POST /containers/create` but never read anywhere else in the codebase — a `docker run --privileged` request silently ran unprivileged.
- This specifically breaks buildx's `docker-container` driver: it creates its `buildx_buildkit_*` container via the generic create endpoint with `Privileged: true` (not `CapAdd`), so buildkitd never gets `CAP_SYS_ADMIN` and its `runc-native` snapshotter can't rbind-mount the build context. `docker compose build`, Dev Containers, and DDEV hit the same path.
- Apple Containerization has no direct `--privileged` equivalent, so a privileged request now folds `"ALL"` into the requested capability-add list before `Parser.capabilities` normalizes it — the same grant `ClientBuilderService` already uses for its own builder container (`config.capAdd = ["ALL"]`).

Fixes #361.

## Changes

- `ContainerCreateRoute.swift`: extracted the capability-add computation into a new `ContainerCreateRoute.requestedCapAdd(hostConfig:)`, which now also folds in `"ALL"` when `Privileged == true` (and doesn't duplicate `"ALL"` if the caller already sent it explicitly).
- `ContainerCreateRouteTests.swift`: added a `PrivilegedCapAddTests` suite covering the new function directly (privileged + no CapAdd, privileged + explicit CapAdd, privileged + CapAdd already containing ALL, non-privileged, nil HostConfig), plus one route-level test confirming a privileged create request reaches the image-existence stage instead of being rejected.

## Testing

- `make fmt` — no drift.
- `make test` — 874 tests passed, including the new suite.
- Confirmed the root cause empirically: `grep` for `.Privileged` outside the request-model decoder returns no other usage in `Sources/socktainer/`, matching the issue's diagnosis exactly (`docker inspect` on the buildkit container shows no `Privileged`/`CapAdd` in `HostConfig` before this fix).

## Scope note

This PR is scoped to the confirmed regression (the create-time capability grant). The issue's "longer term" idea (advertising `BuildkitVersion` in `/info` so buildx can use the `docker` driver directly against Apple's own BuildKit-based builder) is a separate, larger design question and isn't part of this change.