### PR TITLE
fix(images): emit a terminal pull status docker-java accepts

### DIFF
--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -307,6 +307,7 @@ struct ClientImageService: ClientImageProtocol {
                     )
                     logger.info("Successfully pulled image \(reference) for platform \(platform.description)")
                     continuation.yield(.message("Image digest: \(image.digest)"))
+                    continuation.yield(.message(ClientImageService.pulledStatusMessage(for: reference)))
                     continuation.finish()
                 } catch {
                     // On arm64 hosts: if the image has no arm64 variant, fall back to amd64 (Rosetta).
@@ -328,6 +329,7 @@ struct ClientImageService: ClientImageProtocol {
                             try await fallbackImage.unpack(platform: amd64, progressUpdate: nil)
                             logger.info("Successfully pulled \(reference) for amd64 (Rosetta)")
                             continuation.yield(.message("Image digest: \(fallbackImage.digest)"))
+                            continuation.yield(.message(ClientImageService.pulledStatusMessage(for: reference)))
                             continuation.finish()
                         } catch let fallbackError {
                             logger.error("amd64 fallback also failed for \(reference): \(fallbackError)")
@@ -817,5 +819,15 @@ struct ClientImageService: ClientImageProtocol {
         } catch {
             return .malformed(reason: String(describing: error))
         }
+    }
+
+    /// docker-java's `PullImageResultCallback.checkDockerClientPullSuccessful` only accepts
+    /// a stream ending in one of a handful of exact terminal phrases; the real Docker daemon
+    /// always emits one, but `pull()`'s prior last line ("Image digest: …") matches none of
+    /// them, so every pull under Testcontainers/docker-java failed even though the image was
+    /// fetched correctly (issue #359). `pull()` doesn't distinguish a fresh fetch from an
+    /// already-cached image, so this is used unconditionally — docker-java accepts it either way.
+    static func pulledStatusMessage(for reference: String) -> String {
+        "Status: Downloaded newer image for \(reference)"
     }
 }

--- a/Tests/socktainerTests/Clients/ClientImageServicePullStatusTests.swift
+++ b/Tests/socktainerTests/Clients/ClientImageServicePullStatusTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+@testable import socktainer
+
+/// Regression tests for issue #359: `POST /images/create` never emitted a terminal
+/// status docker-java's `PullImageResultCallback.checkDockerClientPullSuccessful`
+/// recognizes ("Status: Downloaded newer image for …", "Status: Image is up to
+/// date for …", or "Download complete"), so every pull under Testcontainers failed
+/// even though the image was fetched correctly.
+@Suite("ClientImageService.pulledStatusMessage")
+struct ClientImageServicePullStatusTests {
+
+    @Test("produces the exact phrase docker-java's terminal-status check accepts")
+    func matchesDockerJavaAcceptedPhrase() {
+        let message = ClientImageService.pulledStatusMessage(for: "docker.io/library/hello-world:latest")
+        #expect(message == "Status: Downloaded newer image for docker.io/library/hello-world:latest")
+        #expect(message.hasPrefix("Status: Downloaded newer image for "))
+    }
+
+    @Test("round-trips whatever reference string it's given, tag and all")
+    func preservesReferenceVerbatim() {
+        #expect(ClientImageService.pulledStatusMessage(for: "redis:7-alpine") == "Status: Downloaded newer image for redis:7-alpine")
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /images/create`'s pull stream ended on `"Image digest: <digest>"`, which the real Docker CLI accepts but docker-java's `PullImageResultCallback.checkDockerClientPullSuccessful` does not — it only recognizes `"Status: Downloaded newer image for …"`, `"Status: Image is up to date for …"`, or `"Download complete"`.
- Result: every pull was reported as a failure to docker-java clients (including Testcontainers) even though the image was fetched and unpacked correctly, surfacing one layer up as `ContainerFetchException` / `ContainerLaunchException` for any image not already cached locally.

Fixes #359.

## Changes

- `ClientImageService.swift`: added `ClientImageService.pulledStatusMessage(for:)`, a small pure function producing the terminal phrase. Wired into both `pull()`'s success paths — the primary pull and the arm64→amd64 (Rosetta) fallback — right before the stream finishes, alongside the existing `"Image digest: …"` line.
- `pull()` doesn't currently distinguish a freshly-fetched image from an already-cached one, so the message is emitted unconditionally (`"Downloaded newer image for …"`); docker-java's check accepts this regardless, matching the issue's suggested minimal fix.

## Testing

- `make fmt` — no drift.
- `make test` — 870 tests passed, including the new `ClientImageServicePullStatusTests` suite.
- `pull()` itself talks to a live `container-apiserver`/registry and isn't unit-testable in this environment (same constraint as the rest of `ClientImageService`, e.g. `PullByteCounter` is tested the same way — as an isolated pure unit, not through a full `pull()` run) — the new tests cover the exact terminal phrase the fix adds directly.