### PR TITLE
fix(containers): honor [container] cpus and memory from Apple Container config

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ContainerBuild", package: "container"),
                 .product(name: "ContainerAPIClient", package: "container"),
+                .product(name: "ContainerPersistence", package: "container"),
                 .product(name: "ContainerNetworkClient", package: "container"),
                 .product(name: "ContainerPersistence", package: "container"),
                 .product(name: "ContainerResource", package: "container"),

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -654,12 +654,24 @@ extension ContainerCreateRoute {
 
             containerConfiguration.mounts = resolvedMounts
 
-            if let memoryBytes = resolveMemoryInBytes(body.HostConfig?.Memory) {
+            // Fall back to Apple Container's own `[container]` configuration when the
+            // request carries no explicit limits, so `container system property set
+            // container.cpus` / `container.memory` applies to containers created through
+            // the Docker API too. Without this they were always sized 4 CPUs / 1 GiB.
+            let configuredDefaults = await ContainerResourceDefaults.shared.current(logger: req.logger)
+
+            if let memoryBytes = ContainerResourceResolution.memoryInBytes(
+                requested: body.HostConfig?.Memory,
+                configured: configuredDefaults
+            ) {
                 containerConfiguration.resources.memoryInBytes = memoryBytes
             }
 
-            if let nanoCpus = body.HostConfig?.NanoCpus, nanoCpus > 0 {
-                containerConfiguration.resources.cpus = ContainerCreateRoute.vCpus(fromNanoCpus: nanoCpus)
+            if let cpus = ContainerResourceResolution.cpus(
+                requestedNanoCpus: body.HostConfig?.NanoCpus,
+                configured: configuredDefaults
+            ) {
+                containerConfiguration.resources.cpus = cpus
             }
 
             let options = ContainerCreateOptions(autoRemove: body.HostConfig?.AutoRemove ?? false)

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -658,17 +658,27 @@ extension ContainerCreateRoute {
             // request carries no explicit limits, so `container system property set
             // container.cpus` / `container.memory` applies to containers created through
             // the Docker API too. Without this they were always sized 4 CPUs / 1 GiB.
-            let configuredDefaults = await ContainerResourceDefaults.shared.current(logger: req.logger)
+            //
+            // Only loaded when at least one limit is missing: the first load pings the
+            // daemon with a 10s timeout, and a create that specifies both limits would
+            // otherwise wait on a configuration read whose result it never uses.
+            let requestedMemory = body.HostConfig?.Memory
+            let requestedNanoCpus = body.HostConfig?.NanoCpus
+            let needsConfiguredDefaults = !((requestedMemory ?? 0) > 0 && (requestedNanoCpus ?? 0) > 0)
+            let configuredDefaults =
+                needsConfiguredDefaults
+                ? await ContainerResourceDefaults.shared.current(logger: req.logger)
+                : nil
 
             if let memoryBytes = ContainerResourceResolution.memoryInBytes(
-                requested: body.HostConfig?.Memory,
+                requested: requestedMemory,
                 configured: configuredDefaults
             ) {
                 containerConfiguration.resources.memoryInBytes = memoryBytes
             }
 
             if let cpus = ContainerResourceResolution.cpus(
-                requestedNanoCpus: body.HostConfig?.NanoCpus,
+                requestedNanoCpus: requestedNanoCpus,
                 configured: configuredDefaults
             ) {
                 containerConfiguration.resources.cpus = cpus

--- a/Sources/socktainer/Utilities/ContainerResourceDefaults.swift
+++ b/Sources/socktainer/Utilities/ContainerResourceDefaults.swift
@@ -1,0 +1,96 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Logging
+import SystemPackage
+
+/// Supplies the `[container]` defaults from Apple Container's own configuration.
+///
+/// A container created through the Docker API without explicit limits used to be
+/// sized by whatever `ContainerConfiguration` happened to default to — a fixed
+/// 4 CPUs and 1 GiB — so `container system property set container.cpus`/`memory`
+/// had no effect on anything created through socktainer. Only the unset case was
+/// affected; `docker run -m 4g --cpus 2` was always honoured.
+///
+/// The values are read the same way the `container` CLI reads them, via
+/// `ClientHealthCheck` for the roots and `ConfigurationLoader` for the files.
+///
+/// Loaded once per process. Apple Container requires an engine restart for a
+/// changed `[container]` block to take effect, and socktainer is restarted with
+/// the engine, so a longer-lived cache cannot go stale in practice.
+actor ContainerResourceDefaults {
+    static let shared = ContainerResourceDefaults()
+
+    private var cached: ContainerPersistence.ContainerConfig?
+    private var attempted = false
+
+    /// The configured `[container]` defaults, or `nil` if they cannot be read.
+    ///
+    /// Qualified because socktainer declares its own Docker REST `ContainerConfig`,
+    /// which shadows this one inside the module.
+    ///
+    /// Returns `nil` rather than throwing: failing to read an optional default is
+    /// not a reason to fail container creation. The caller then leaves the
+    /// configuration untouched, which is the previous behaviour.
+    func current(logger: Logger) async -> ContainerPersistence.ContainerConfig? {
+        if let cached {
+            return cached
+        }
+        guard !attempted else {
+            return nil
+        }
+        attempted = true
+
+        do {
+            let health = try await ClientHealthCheck.ping(timeout: .seconds(10))
+            let appRoot = FilePath(health.appRoot.path(percentEncoded: false))
+            let installRoot = FilePath(health.installRoot.path(percentEncoded: false))
+            let config: ContainerSystemConfig = try await ConfigurationLoader.load(
+                configurationFiles: [
+                    ConfigurationLoader.configurationFile(in: appRoot, of: .appRoot),
+                    ConfigurationLoader.configurationFile(in: installRoot, of: .installRoot),
+                ]
+            )
+            cached = config.container
+            logger.debug(
+                "[container] defaults loaded: cpus=\(config.container.cpus) memory=\(config.container.memory.toUInt64(unit: .bytes)) bytes"
+            )
+            return cached
+        } catch {
+            logger.warning(
+                "could not read Apple Container's [container] configuration (\(error)); containers created without explicit limits keep the built-in defaults"
+            )
+            return nil
+        }
+    }
+}
+
+/// Chooses the resources a container is created with.
+///
+/// Kept separate from the loading above so the precedence rules are testable
+/// without an Apple Container daemon: an explicit value from the request always
+/// wins, the configured `[container]` default applies when the request is silent,
+/// and `nil` means "leave the configuration alone" — the behaviour before the
+/// `[container]` block was consulted at all.
+enum ContainerResourceResolution {
+    /// Memory in bytes, or `nil` to leave `ContainerConfiguration` untouched.
+    static func memoryInBytes(
+        requested: Int?,
+        configured: ContainerPersistence.ContainerConfig?
+    ) -> UInt64? {
+        if let requested, requested > 0 {
+            return UInt64(requested)
+        }
+        return configured?.memory.toUInt64(unit: .bytes)
+    }
+
+    /// vCPU count, or `nil` to leave `ContainerConfiguration` untouched.
+    static func cpus(
+        requestedNanoCpus: Int?,
+        configured: ContainerPersistence.ContainerConfig?
+    ) -> Int? {
+        if let requestedNanoCpus, requestedNanoCpus > 0 {
+            return max(1, requestedNanoCpus / 1_000_000_000)
+        }
+        return configured?.cpus
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerResourceResolutionTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerResourceResolutionTests.swift
@@ -1,0 +1,88 @@
+import ContainerPersistence
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// Regression tests for socktainer#368.
+///
+/// A container created through the Docker API without explicit limits was sized
+/// by `ContainerConfiguration`'s built-in defaults — a fixed 4 CPUs and 1 GiB —
+/// so Apple Container's `[container] cpus` / `memory` had no effect on anything
+/// created through socktainer, while `container run` honoured them. Only the
+/// unset case was affected; `docker run -m … --cpus …` always worked.
+///
+/// Without the fix, every "falls back to the configured default" case below
+/// returns nil and the container keeps the built-in 4 CPUs / 1 GiB.
+@Suite("ContainerResourceResolution — [container] defaults (socktainer#368)")
+struct ContainerResourceResolutionTests {
+
+    /// Explicitly typed so the comparisons below cannot pick a different integer
+    /// type for the literal — an untyped `4 * 1024 * 1024 * 1024` compared unequal
+    /// to the `UInt64` result while printing the same number.
+    private let fourGiB: UInt64 = 4 * 1024 * 1024 * 1024
+    private let twoGiB: UInt64 = 2 * 1024 * 1024 * 1024
+
+    private func configured(cpus: Int, memory: String) throws -> ContainerPersistence.ContainerConfig {
+        ContainerPersistence.ContainerConfig(cpus: cpus, memory: try MemorySize(memory))
+    }
+
+    @Test("memory falls back to the configured [container] default when the request omits it")
+    func memoryUsesConfiguredDefault() throws {
+        let resolved = ContainerResourceResolution.memoryInBytes(
+            requested: nil,
+            configured: try configured(cpus: 6, memory: "4gb")
+        )
+        #expect(resolved == fourGiB)
+    }
+
+    @Test("cpus falls back to the configured [container] default when the request omits it")
+    func cpusUsesConfiguredDefault() throws {
+        let resolved = ContainerResourceResolution.cpus(
+            requestedNanoCpus: nil,
+            configured: try configured(cpus: 6, memory: "4gb")
+        )
+        #expect(resolved == 6)
+    }
+
+    @Test("an explicit memory request still wins over the configured default")
+    func explicitMemoryWins() throws {
+        let resolved = ContainerResourceResolution.memoryInBytes(
+            requested: Int(twoGiB),
+            configured: try configured(cpus: 6, memory: "4gb")
+        )
+        #expect(resolved == twoGiB)
+    }
+
+    @Test("an explicit cpu request still wins over the configured default")
+    func explicitCpusWins() throws {
+        let resolved = ContainerResourceResolution.cpus(
+            requestedNanoCpus: 2_000_000_000,
+            configured: try configured(cpus: 6, memory: "4gb")
+        )
+        #expect(resolved == 2)
+    }
+
+    @Test("a sub-1 CPU request is clamped to one vCPU, as before")
+    func fractionalCpusClampToOne() throws {
+        let resolved = ContainerResourceResolution.cpus(
+            requestedNanoCpus: 500_000_000,
+            configured: try configured(cpus: 6, memory: "4gb")
+        )
+        #expect(resolved == 1)
+    }
+
+    @Test("zero and negative requests are treated as absent, not as a limit")
+    func nonPositiveRequestsFallBack() throws {
+        let config = try configured(cpus: 6, memory: "4gb")
+        #expect(ContainerResourceResolution.memoryInBytes(requested: 0, configured: config) == fourGiB)
+        #expect(ContainerResourceResolution.memoryInBytes(requested: -1, configured: config) == fourGiB)
+        #expect(ContainerResourceResolution.cpus(requestedNanoCpus: 0, configured: config) == 6)
+    }
+
+    @Test("configuration left untouched when the defaults cannot be read")
+    func noConfiguredDefaultsLeavesConfigurationAlone() {
+        #expect(ContainerResourceResolution.memoryInBytes(requested: nil, configured: nil) == nil)
+        #expect(ContainerResourceResolution.cpus(requestedNanoCpus: nil, configured: nil) == nil)
+    }
+}

--- a/Tests/socktainerTests/Utilities/ContainerResourceResolutionTests.swift
+++ b/Tests/socktainerTests/Utilities/ContainerResourceResolutionTests.swift
@@ -78,6 +78,7 @@ struct ContainerResourceResolutionTests {
         #expect(ContainerResourceResolution.memoryInBytes(requested: 0, configured: config) == fourGiB)
         #expect(ContainerResourceResolution.memoryInBytes(requested: -1, configured: config) == fourGiB)
         #expect(ContainerResourceResolution.cpus(requestedNanoCpus: 0, configured: config) == 6)
+        #expect(ContainerResourceResolution.cpus(requestedNanoCpus: -1, configured: config) == 6)
     }
 
     @Test("configuration left untouched when the defaults cannot be read")


### PR DESCRIPTION
## Summary

A container created through the Docker API without explicit limits was sized by whatever `ContainerConfiguration` defaulted to — a fixed 4 CPUs and 1 GiB — so Apple Container's `[container] cpus` / `memory` had no effect on anything created through socktainer, while `container run` honoured them. This reads that configuration the same way the CLI does and applies it when the request is silent. Explicit per-container limits are unchanged.

## Related Issue

Fixes #368

## Changes

- `ContainerCreateRoute` assigned `resources.memoryInBytes` / `resources.cpus` only when the request supplied them, so the configured block was never consulted. It now falls back to `[container]` when the request omits a value.
- New `ContainerResourceDefaults` loads the configuration exactly as `Application.loadContainerSystemConfig()` does — `ClientHealthCheck` for `appRoot` / `installRoot`, then `ConfigurationLoader`.
- Precedence lives in a separate `ContainerResourceResolution` so it is testable without a running apiserver.
- `Package.swift` gains `ContainerPersistence`, already a product of the pinned `container` 1.2.0 — no version change.

Two decisions worth a maintainer's eye:

- **Loaded once per process.** Apple Container needs an engine restart for a changed `[container]` block to take effect, and socktainer is restarted alongside the engine, so a longer-lived cache cannot go stale in practice; a per-request load would add an XPC round trip to every create. Happy to switch to a per-request read or a TTL if you would rather.
- **Failure returns `nil` rather than throwing.** An optional default that cannot be read is not a reason to fail container creation; the caller then leaves the configuration untouched, which is the previous behaviour. It logs a warning.

## Testing

Verified against the reproduction in #368, with `[container] memory = "4gb"`:

| | CPUS | MEMORY |
|---|---|---|
| `container run`, no limits (reference) | 4 | 4096 MB |
| `docker run`, no limits — before | 4 | **1024 MB** |
| `docker run`, no limits — after | 4 | **4096 MB** |
| `docker run -m 2g --cpus 2` — after | 2 | 2048 MB |

CPUs read 4 throughout because the configured value is also 4. I tried to set a distinctive `cpus = 6` to exercise that path end-to-end, but the daemon rewrote `config.toml` back to 4 on the next `container system start`, so the CPU path is covered by unit tests rather than a live measurement.

The unit tests fail without the fix — each "falls back to the configured default" case returns `nil` and the container keeps 4 CPUs / 1 GiB.

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes — 890 tests in 156 suites
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed (if applicable)

Environment: macOS 26.5 arm64, Apple Container 1.2.2, socktainer built from this branch, Swift 6.3.3.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
