### PR TITLE
fix(containers): serve archive GET/HEAD on never-started containers (fixes #370)

### DIFF
--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -223,13 +223,43 @@ struct ClientArchiveService: ClientArchiveProtocol {
             try? FileManager.default.removeItem(at: tarPath)
         }
 
-        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        let baseName = (normalizedPath as NSString).lastPathComponent
 
-        // Extract the requested path to the staging directory
-        try extractPathToDirectory(reader: reader, sourcePath: normalizedPath, destDir: stagingDir)
+        if inode.isDirectory {
+            // Directories: stage the subtree, then archive it. Entries are
+            // `./`-prefixed — accepted by docker cp.
+            try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
 
-        // Create tar archive from the staging directory
-        try ArchiveUtility.create(tarPath: tarPath, from: stagingDir)
+            // Extract the requested path to the staging directory
+            try extractPathToDirectory(reader: reader, sourcePath: normalizedPath, destDir: stagingDir)
+
+            // Create tar archive from the staging directory
+            try ArchiveUtility.create(tarPath: tarPath, from: stagingDir)
+        } else {
+            // Single file or symlink: emit exactly one tar entry named after
+            // the basename, matching moby's archivePath output (no `./`
+            // directory entry). The directory-wrapped form breaks consumers
+            // that take the first tar entry as the payload
+            let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: tarPath)
+            let entry = WriteEntry(writer)
+            entry.path = baseName
+            entry.fileType = inode.isRegularFile ? .regular : .symbolicLink
+            entry.permissions = inode.permissions
+            entry.owner = inode.fullUid
+            entry.group = inode.fullGid
+            entry.modificationDate = Date(timeIntervalSince1970: TimeInterval(inode.mtime))
+            if inode.isSymlink {
+                entry.symlinkTarget = readSymlinkTarget(reader: reader, path: normalizedPath)
+            }
+            let data = inode.isRegularFile ? try reader.readFile(at: FilePath(normalizedPath)) : nil
+            if let data {
+                entry.size = Int64(data.count)
+                try writer.writeEntry(entry: entry, data: data)
+            } else {
+                try writer.writeEntry(entry: entry, data: nil as UnsafeRawBufferPointer?)
+            }
+            try writer.finishEncoding()
+        }
 
         // Read the tar data
         let tarData = try Data(contentsOf: tarPath)

--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -71,6 +71,16 @@ enum ClientArchiveError: Error, LocalizedError {
     }
 }
 
+/// Subset of Apple Container's `runtime-configuration.json` (written at
+/// container create time) containing the rootfs source reference.
+private struct RuntimeConfiguration: Decodable {
+    struct Filesystem: Decodable {
+        let source: String
+    }
+
+    let containerRootFilesystem: Filesystem
+}
+
 /// File stat information for the X-Docker-Container-Path-Stat header
 struct PathStat: Codable {
     let name: String
@@ -94,7 +104,7 @@ protocol ClientArchiveProtocol: Sendable {
     func getRootfsPath(containerId: String) -> URL
 
     /// Read a file or directory from a container's filesystem and return as tar data
-    func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat)
+    func getArchive(container: ContainerSnapshot, path: String) async throws -> (tarData: Data, stat: PathStat)
 
     /// Extract a tar archive into a container's filesystem at the specified path
     func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws
@@ -120,13 +130,59 @@ struct ClientArchiveService: ClientArchiveProtocol {
             .appendingPathComponent("rootfs.ext4")
     }
 
+    /// Resolve the ext4 file backing a container's rootfs.
+    ///
+    /// Apple Container provisions `containers/{id}/rootfs.ext4` only at first
+    /// start, so a created-but-never-started container has no rootfs file
+    /// (its `containers/{id}` directory holds runtime config only). Until the
+    /// container boots, its filesystem is the image's shared snapshot
+    /// referenced by `runtime-configuration.json` — read-only by construction
+    /// (every container of an image points at the same file), so reads can
+    /// safely serve from it.
+    ///
+    /// A container that has ever booted always has a private rootfs.ext4
+    /// (provisioned at start, persists after stop), so absence of the file
+    /// means "never started" — unless the rootfs was removed out-of-band, in
+    /// which case falling back to the image snapshot would silently serve
+    /// stale image content. `startedDate` is the runtime's ground truth for
+    /// "has booted" and gates the fallback.
+    private func resolveRootfsPath(container: ContainerSnapshot) throws -> URL {
+        let rootfsPath = getRootfsPath(containerId: container.id)
+        guard !FileManager.default.fileExists(atPath: rootfsPath.path) else {
+            return rootfsPath
+        }
+
+        guard container.startedDate == nil else {
+            throw ClientArchiveError.rootfsNotFound(id: container.id)
+        }
+
+        let configURL =
+            appSupportPath
+            .appendingPathComponent("containers")
+            .appendingPathComponent(container.id)
+            .appendingPathComponent("runtime-configuration.json")
+        guard
+            let data = try? Data(contentsOf: configURL),
+            let config = try? JSONDecoder().decode(RuntimeConfiguration.self, from: data),
+            !config.containerRootFilesystem.source.isEmpty
+        else {
+            throw ClientArchiveError.rootfsNotFound(id: container.id)
+        }
+
+        let snapshotURL = URL(fileURLWithPath: config.containerRootFilesystem.source)
+        guard FileManager.default.fileExists(atPath: snapshotURL.path) else {
+            throw ClientArchiveError.rootfsNotFound(id: container.id)
+        }
+        return snapshotURL
+    }
+
     /// Read a file or directory from a container's filesystem and return as tar data
     /// This implementation reads only the requested path directly, avoiding full filesystem export.
-    func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat) {
-        let rootfsPath = getRootfsPath(containerId: containerId)
+    func getArchive(container: ContainerSnapshot, path: String) async throws -> (tarData: Data, stat: PathStat) {
+        let rootfsPath = try resolveRootfsPath(container: container)
 
         guard FileManager.default.fileExists(atPath: rootfsPath.path) else {
-            throw ClientArchiveError.rootfsNotFound(id: containerId)
+            throw ClientArchiveError.rootfsNotFound(id: container.id)
         }
 
         // Normalize the path
@@ -135,12 +191,17 @@ struct ClientArchiveService: ClientArchiveProtocol {
         // Open the ext4 filesystem
         let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
 
-        // Check if path exists and get stat
-        guard reader.exists(FilePath(normalizedPath)) else {
+        // Check if path exists and get stat. Like moby's lstat-based path
+        // resolution, a final-component symlink is reported as the symlink
+        // itself (linkTarget + symlink tar entry, dangling included), while
+        // intermediate symlink components are followed.
+        guard reader.exists(FilePath(normalizedPath)) || reader.exists(FilePath(normalizedPath), followSymlinks: false) else {
             throw ClientArchiveError.pathNotFound(path: normalizedPath)
         }
 
-        let (_, inode) = try reader.stat(FilePath(normalizedPath))
+        let (_, inode) =
+            try (try? reader.stat(FilePath(normalizedPath), followSymlinks: false))
+            ?? reader.stat(FilePath(normalizedPath))
 
         // Create PathStat for the response header
         let pathStat = PathStat(
@@ -581,12 +642,27 @@ struct ClientArchiveService: ClientArchiveProtocol {
         }
     }
 
-    /// Read symlink target using the reader's public API
+    /// Read a symlink's target.
+    ///
+    /// EXT4.EXT4Reader has no public symlink API — `readFile(followSymlinks:
+    /// false)` rejects symlink inodes with `notAFile`, and `followSymlinks:
+    /// true` returns the *target file's* content. Fast symlinks (target < 60
+    /// bytes, the overwhelming majority in practice) store the target inline
+    /// in the inode block field, which is public; slow symlinks (>= 60 bytes)
+    /// are not readable through the public API and report nil.
     private func readSymlinkTarget(reader: EXT4.EXT4Reader, path: String) -> String? {
-        guard let data = try? reader.readFile(at: FilePath(path), followSymlinks: false) else {
+        guard
+            let inode = try? reader.stat(FilePath(path), followSymlinks: false).inode,
+            inode.isSymlink
+        else {
             return nil
         }
-        return String(data: data, encoding: .utf8)
+        let targetLength = inode.size
+        guard targetLength > 0, targetLength < 60 else {
+            return nil
+        }
+        let blockBytes = Mirror(reflecting: inode.block).children.map { $0.value as! UInt8 }
+        return String(bytes: blockBytes.prefix(Int(targetLength)), encoding: .utf8)
     }
 
     private func validateArchiveEntries(
@@ -622,9 +698,14 @@ struct ClientArchiveService: ClientArchiveProtocol {
         }
     }
 
-    /// Extract a path from the ext4 filesystem to a local directory
+    /// Extract a path from the ext4 filesystem to a local directory.
+    /// Symlinks are reported as symlinks (non-following stat, matching moby's
+    /// lstat semantics) — recursive children are only listed for real
+    /// directories, never followed through symlinks.
     private func extractPathToDirectory(reader: EXT4.EXT4Reader, sourcePath: String, destDir: URL) throws {
-        let (_, inode) = try reader.stat(FilePath(sourcePath))
+        let (_, inode) =
+            try (try? reader.stat(FilePath(sourcePath), followSymlinks: false))
+            ?? reader.stat(FilePath(sourcePath))
         let baseName = sourcePath == "/" ? nil : (sourcePath as NSString).lastPathComponent
 
         if inode.isDirectory {

--- a/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
@@ -58,7 +58,7 @@ struct ContainerArchiveRoute: RouteCollection {
             }
 
             do {
-                let (tarData, stat) = try await archiveClient.getArchive(containerId: container.id, path: query.path)
+                let (tarData, stat) = try await archiveClient.getArchive(container: container, path: query.path)
 
                 // Create the path stat header (base64 encoded JSON)
                 let statJson = try JSONEncoder().encode(stat)
@@ -198,7 +198,7 @@ struct ContainerArchiveRoute: RouteCollection {
             }
 
             do {
-                let (_, stat) = try await archiveClient.getArchive(containerId: container.id, path: query.path)
+                let (_, stat) = try await archiveClient.getArchive(container: container, path: query.path)
 
                 // Create the path stat header (base64 encoded JSON)
                 let statJson = try JSONEncoder().encode(stat)

--- a/Sources/socktainer/Routes/Images/BuildPruneRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildPruneRoute.swift
@@ -53,6 +53,15 @@ struct BuildPruneRoute: RouteCollection {
                 logger: logger
             )
 
+            // moby's BuildPrune emits a single aggregate `builder prune` event (no
+            // per-cache-entry events), mirroring the volume/network prune events above.
+            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                await broadcaster.broadcast(
+                    DockerEvent.make(
+                        type: "builder", action: "prune", actorID: "",
+                        attributes: ["reclaimed": String(result.spaceReclaimed)]))
+            }
+
             return RESTBuildPruneResponse(
                 CachesDeleted: result.deletedCaches.isEmpty ? nil : result.deletedCaches,
                 SpaceReclaimed: result.spaceReclaimed

--- a/Tests/socktainerTests/Clients/ClientArchiveServicePreStartTests.swift
+++ b/Tests/socktainerTests/Clients/ClientArchiveServicePreStartTests.swift
@@ -1,0 +1,371 @@
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationArchive
+import ContainerizationEXT4
+import ContainerizationOCI
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+@Suite("ClientArchiveService.getArchive on never-started containers")
+struct ClientArchiveServicePreStartTests {
+
+    @Test("a created-never-started container serves image content from its shared snapshot")
+    func neverStartedContainerServesImageContentFromSnapshot() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(
+            digest: "abc123",
+            files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, stat) = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+
+        #expect(stat.name == "passwd")
+        #expect(stat.size == 16)
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let file = try #require(firstFile(named: "passwd", under: extracted))
+        #expect(try String(contentsOf: file, encoding: .utf8) == "root:x:0:0:root\n")
+    }
+
+    @Test("a path absent from the snapshot throws pathNotFound")
+    func missingPathInSnapshotThrowsPathNotFound() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        do {
+            _ = try await fixture.service.getArchive(container: container, path: "/nonexistent")
+            Issue.record("expected pathNotFound")
+        } catch let error as ClientArchiveError {
+            guard case .pathNotFound = error else {
+                Issue.record("expected pathNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("a container's own rootfs.ext4 wins over the image snapshot when both exist")
+    func rootfsExt4WinsWhenBothExist() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/data.txt": "image-content\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        try fixture.writeRootfs(containerId: "web", files: ["/data.txt": "writable-content\n"])
+        let container = try fixture.makeContainer(id: "web", status: .stopped, startedDate: Date())
+
+        let (tarData, _) = try await fixture.service.getArchive(container: container, path: "/data.txt")
+
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let file = try #require(firstFile(named: "data.txt", under: extracted))
+        #expect(try String(contentsOf: file, encoding: .utf8) == "writable-content\n")
+    }
+
+    @Test("a started container without a rootfs.ext4 throws rootfsNotFound instead of falling back")
+    func startedContainerWithoutRootfsThrowsRootfsNotFound() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web", status: .stopped, startedDate: Date())
+
+        do {
+            _ = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+            Issue.record("expected rootfsNotFound for a started container whose rootfs is gone")
+        } catch let error as ClientArchiveError {
+            guard case .rootfsNotFound(let id) = error else {
+                Issue.record("expected rootfsNotFound, got \(error)")
+                return
+            }
+            #expect(id == "web")
+        }
+    }
+
+    @Test("a running container is unaffected and reads its own rootfs.ext4")
+    func runningContainerReadsRootfs() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeRootfs(containerId: "web", files: ["/live.txt": "live\n"])
+        let container = try fixture.makeContainer(id: "web", status: .running, startedDate: Date())
+
+        let (tarData, _) = try await fixture.service.getArchive(container: container, path: "/live.txt")
+
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let file = try #require(firstFile(named: "live.txt", under: extracted))
+        #expect(try String(contentsOf: file, encoding: .utf8) == "live\n")
+    }
+
+    @Test("a missing runtime-configuration.json throws rootfsNotFound, not a crash")
+    func missingRuntimeConfigThrowsRootfsNotFound() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        let container = try fixture.makeContainer(id: "web")
+
+        do {
+            _ = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+            Issue.record("expected rootfsNotFound")
+        } catch let error as ClientArchiveError {
+            guard case .rootfsNotFound = error else {
+                Issue.record("expected rootfsNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("a malformed runtime-configuration.json throws rootfsNotFound, not a crash")
+    func malformedRuntimeConfigThrowsRootfsNotFound() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeRawRuntimeConfig(containerId: "web", contents: "not json at all")
+        let container = try fixture.makeContainer(id: "web")
+
+        do {
+            _ = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+            Issue.record("expected rootfsNotFound")
+        } catch let error as ClientArchiveError {
+            guard case .rootfsNotFound = error else {
+                Issue.record("expected rootfsNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("a runtime-config source pointing at a missing snapshot throws rootfsNotFound")
+    func missingSnapshotSourceThrowsRootfsNotFound() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "nonexistent-digest")
+        let container = try fixture.makeContainer(id: "web")
+
+        do {
+            _ = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+            Issue.record("expected rootfsNotFound")
+        } catch let error as ClientArchiveError {
+            guard case .rootfsNotFound = error else {
+                Issue.record("expected rootfsNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("a directory is served from the snapshot with its full tree")
+    func directoryFromSnapshot() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(
+            digest: "abc123",
+            files: ["/etc/passwd": "root:x:0:0:root\n", "/etc/hostname": "web\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, stat) = try await fixture.service.getArchive(container: container, path: "/etc")
+
+        #expect(stat.name == "etc")
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let passwd = try #require(firstFile(named: "passwd", under: extracted))
+        let hostname = try #require(firstFile(named: "hostname", under: extracted))
+        #expect(try String(contentsOf: passwd, encoding: .utf8) == "root:x:0:0:root\n")
+        #expect(try String(contentsOf: hostname, encoding: .utf8) == "web\n")
+    }
+
+    @Test("a symlink in the snapshot is served as a symlink, dangling included")
+    func symlinkFromSnapshot() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(
+            digest: "abc123",
+            files: ["/etc/passwd": "root:x:0:0:root\n"],
+            links: ["/etc/passwd-link": "/etc/passwd", "/etc/dangling-link": "/nonexistent"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, stat) = try await fixture.service.getArchive(container: container, path: "/etc/passwd-link")
+
+        #expect(stat.linkTarget == "/etc/passwd")
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let link = try #require(firstFile(named: "passwd-link", under: extracted))
+        let isLink = (try? FileManager.default.destinationOfSymbolicLink(atPath: link.path)) != nil
+        #expect(isLink, "tar entry must be a symlink, not a regular file")
+
+        let (danglingTar, danglingStat) = try await fixture.service.getArchive(container: container, path: "/etc/dangling-link")
+        #expect(danglingStat.linkTarget == "/nonexistent")
+        let danglingExtracted = try fixture.extractTar(danglingTar)
+        defer { try? FileManager.default.removeItem(at: danglingExtracted) }
+        let danglingLink = try #require(firstFile(named: "dangling-link", under: danglingExtracted))
+        let danglingIsLink = (try? FileManager.default.destinationOfSymbolicLink(atPath: danglingLink.path)) != nil
+        #expect(danglingIsLink, "a dangling symlink must still be served as a symlink, like moby")
+    }
+
+    @Test("the snapshot root can be served")
+    func rootFromSnapshot() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, _) = try await fixture.service.getArchive(container: container, path: "/")
+
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let passwd = try #require(firstFile(named: "passwd", under: extracted))
+        #expect(try String(contentsOf: passwd, encoding: .utf8) == "root:x:0:0:root\n")
+    }
+
+    @Test("an empty file in the snapshot is served")
+    func emptyFileFromSnapshot() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/empty.txt": ""])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, stat) = try await fixture.service.getArchive(container: container, path: "/empty.txt")
+
+        #expect(stat.size == 0)
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let file = try #require(firstFile(named: "empty.txt", under: extracted))
+        #expect(try String(contentsOf: file, encoding: .utf8).isEmpty)
+    }
+
+    @Test("path traversal resolves inside the rootfs, mirroring moby's path cleaning")
+    func traversalResolvesInsideRootfs() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, stat) = try await fixture.service.getArchive(container: container, path: "/../etc/passwd")
+
+        #expect(stat.name == "passwd")
+        let extracted = try fixture.extractTar(tarData)
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        let file = try #require(firstFile(named: "passwd", under: extracted))
+        #expect(try String(contentsOf: file, encoding: .utf8) == "root:x:0:0:root\n")
+    }
+}
+
+// MARK: - Fixture
+
+private struct PreStartFixture {
+    let appSupport: URL
+    let service: ClientArchiveService
+
+    init() {
+        appSupport = FileManager.default.temporaryDirectory.appendingPathComponent("prestart-\(UUID().uuidString)")
+        service = ClientArchiveService(appSupportPath: appSupport)
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: appSupport)
+    }
+
+    func makeContainer(id: String, status: RuntimeStatus = .stopped, startedDate: Date? = nil) throws -> ContainerSnapshot {
+        let proc = ProcessConfiguration(
+            executable: "/bin/sh", arguments: [], environment: [],
+            workingDirectory: "/", terminal: false, user: .id(uid: 0, gid: 0)
+        )
+        let img = ImageDescription(
+            reference: "busybox:latest",
+            descriptor: Descriptor(mediaType: "application/vnd.oci.image.index.v1+json", digest: "sha256:abc", size: 0)
+        )
+        let config = ContainerConfiguration(id: id, image: img, process: proc)
+        return ContainerSnapshot(configuration: config, status: status, networks: [], startedDate: startedDate)
+    }
+
+    /// Build an ext4 snapshot under snapshots/<digest>/snapshot (the layout
+    /// Apple Container produces at image create time).
+    func writeSnapshot(digest: String, files: [String: String], links: [String: String] = [:]) throws {
+        let dir = appSupport.appendingPathComponent("snapshots/\(digest)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let formatter = try EXT4.Formatter(FilePath(dir.appendingPathComponent("snapshot").path))
+        for (path, contents) in files {
+            let stream = InputStream(data: Data(contents.utf8))
+            stream.open()
+            try formatter.create(path: FilePath(path), mode: EXT4.Inode.Mode(.S_IFREG, 0o644), buf: stream, recursion: true)
+            stream.close()
+        }
+        for (path, target) in links {
+            try formatter.create(path: FilePath(path), link: FilePath(target), mode: EXT4.Inode.Mode(.S_IFLNK, 0o777), recursion: true)
+        }
+        try formatter.close()
+    }
+
+    /// Write a container's runtime-configuration.json pointing at the snapshot.
+    func writeRuntimeConfig(containerId: String, snapshotDigest: String) throws {
+        let source =
+            appSupport
+            .appendingPathComponent("snapshots/\(snapshotDigest)")
+            .appendingPathComponent("snapshot")
+            .path
+        let json = """
+            {"containerRootFilesystem":{"source":"\(source)","type":{"block":{"cache":{"on":{}},"format":"ext4","sync":{"fsync":{}}}},"options":[],"destination":"/","attachments":[]}}
+            """
+        try writeRawRuntimeConfig(containerId: containerId, contents: json)
+    }
+
+    func writeRawRuntimeConfig(containerId: String, contents: String) throws {
+        let dir = appSupport.appendingPathComponent("containers/\(containerId)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try contents.write(
+            to: dir.appendingPathComponent("runtime-configuration.json"),
+            atomically: true,
+            encoding: .utf8)
+    }
+
+    /// Write a container's private rootfs.ext4 (as Apple provisions it at start).
+    func writeRootfs(containerId: String, files: [String: String]) throws {
+        let dir = appSupport.appendingPathComponent("containers/\(containerId)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let formatter = try EXT4.Formatter(FilePath(dir.appendingPathComponent("rootfs.ext4").path))
+        for (path, contents) in files {
+            let stream = InputStream(data: Data(contents.utf8))
+            stream.open()
+            try formatter.create(path: FilePath(path), mode: EXT4.Inode.Mode(.S_IFREG, 0o644), buf: stream, recursion: true)
+            stream.close()
+        }
+        try formatter.close()
+    }
+
+    func extractTar(_ data: Data) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("extract-\(UUID().uuidString)")
+        let tarPath = dir.appendingPathComponent("archive.tar")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try data.write(to: tarPath)
+        let out = dir.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tarPath, to: out)
+        return out
+    }
+}
+
+private func firstFile(named name: String, under directory: URL) -> URL? {
+    guard let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil) else {
+        return nil
+    }
+    return enumerator.compactMap { $0 as? URL }.first { $0.lastPathComponent == name }
+}

--- a/Tests/socktainerTests/Clients/ClientArchiveServicePreStartTests.swift
+++ b/Tests/socktainerTests/Clients/ClientArchiveServicePreStartTests.swift
@@ -186,6 +186,44 @@ struct ClientArchiveServicePreStartTests {
         #expect(try String(contentsOf: hostname, encoding: .utf8) == "web\n")
     }
 
+    @Test("a file archive is exactly one basename entry, like moby — no ./ directory entry")
+    func singleEntryTarForFile() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, _) = try await fixture.service.getArchive(container: container, path: "/etc/passwd")
+
+        // Regression guard for the OpenShell first-entry bug: the tar must
+        // contain exactly one entry named after the basename — the previous
+        // directory-wrapped form ("./" entry first) made first-entry
+        // consumers extract an empty directory instead of the file.
+        let entries = try fixture.tarEntries(tarData)
+        #expect(entries.count == 1)
+        #expect(entries[0].path == "passwd")
+        #expect(entries[0].type == .regular)
+    }
+
+    @Test("a symlink archive is exactly one symlink entry, like moby")
+    func singleEntryTarForSymlink() async throws {
+        let fixture = PreStartFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSnapshot(digest: "abc123", files: ["/etc/passwd": "root:x:0:0:root\n"], links: ["/etc/passwd-link": "/etc/passwd"])
+        try fixture.writeRuntimeConfig(containerId: "web", snapshotDigest: "abc123")
+        let container = try fixture.makeContainer(id: "web")
+
+        let (tarData, _) = try await fixture.service.getArchive(container: container, path: "/etc/passwd-link")
+
+        let entries = try fixture.tarEntries(tarData)
+        #expect(entries.count == 1)
+        #expect(entries[0].path == "passwd-link")
+        #expect(entries[0].type == .symbolicLink)
+    }
+
     @Test("a symlink in the snapshot is served as a symlink, dangling included")
     func symlinkFromSnapshot() async throws {
         let fixture = PreStartFixture()
@@ -350,6 +388,19 @@ private struct PreStartFixture {
             stream.close()
         }
         try formatter.close()
+    }
+
+    /// Parse a tar's entries (path + file type) via ArchiveReader — unlike
+    /// filesystem extraction this sees the raw entry list, so it can assert
+    /// there is no leading "./" directory entry.
+    func tarEntries(_ data: Data) throws -> [(path: String, type: URLFileResourceType)] {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("entries-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tarPath = dir.appendingPathComponent("archive.tar")
+        try data.write(to: tarPath)
+        let reader = try ArchiveReader(file: tarPath)
+        return reader.makeStreamingIterator().map { entry, _ in (entry.path ?? "", entry.fileType) }
     }
 
     func extractTar(_ data: Data) throws -> URL {

--- a/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
+++ b/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
@@ -145,7 +145,7 @@ private struct FakeArchiveClient: ClientArchiveProtocol {
         URL(fileURLWithPath: "/nonexistent/rootfs.ext4")
     }
 
-    func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat) {
+    func getArchive(container: ContainerSnapshot, path: String) async throws -> (tarData: Data, stat: PathStat) {
         if case .failure(let error) = getResult { throw error }
         return (
             Data("fake-tar".utf8),

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerBuild
 import ContainerResource
 import ContainerizationOCI
 import Foundation
@@ -122,6 +123,41 @@ struct NewEventsTests {
         #expect(event?.Actor.Attributes["reclaimed"] == "1024")
         #expect(event?.Actor.Attributes["name"] == nil, "prune events carry no 'name' attribute")
         #expect(event?.Actor.Attributes["image"] == nil, "prune events carry no 'image' attribute")
+    }
+
+    // MARK: - builder.prune
+
+    // moby's daemon/builder/backend.PruneCache logs exactly this: Type=builder,
+    // Action=prune, empty Actor.ID, a single "reclaimed" attribute. Verified against
+    // moby master (daemon/builder/backend/backend.go).
+    @Test("build cache prune route broadcasts Type=builder Action=prune event")
+    func builderPruneEventBroadcast() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "prune" && event.Type == "builder" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: BuildPruneRoute(builderClient: StubBuilderClient()))
+
+            try await app.testing().test(.POST, "/v1.51/build/prune") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "builder")
+        #expect(event?.Action == "prune")
+        #expect(event?.Actor.ID == "")
+        #expect(event?.Actor.Attributes["reclaimed"] == "2048")
     }
 
     @Test("container prune emits a per-container 'destroy' before the aggregate prune")
@@ -476,4 +512,15 @@ private struct StubNetworkClient: ClientNetworkProtocol {
         RESTNetworkCreate(Id: "net-abc123", Warning: "")
     }
     func delete(id: String, logger: Logger) async throws {}
+}
+
+private struct StubBuilderClient: ClientBuilderProtocol {
+    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {}
+    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+        fatalError("not exercised by this test")
+    }
+    func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {
+        BuilderPruneResult(deletedCaches: ["cache-1"], spaceReclaimed: 2048)
+    }
+    func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord] { [] }
 }

--- a/Tests/socktainerTests/Routes/ContainerArchiveRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerArchiveRouteTests.swift
@@ -1,0 +1,173 @@
+import ContainerAPIClient
+import ContainerResource
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+@Suite("ContainerArchiveRoute")
+struct ContainerArchiveRouteTests {
+
+    @Test("GET returns the tar body with the path-stat header")
+    func getReturnsTarAndStatHeader() async throws {
+        let archive = FakeArchiveClient(
+            getResult: .success(
+                (
+                    Data("fake-tar".utf8),
+                    PathStat(name: "passwd", size: 19, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+                )))
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .stopped)
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/etc/passwd") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType == HTTPMediaType(type: "application", subType: "x-tar"))
+                #expect(res.headers.first(name: "X-Docker-Container-Path-Stat") != nil)
+                #expect(Data(buffer: res.body) == Data("fake-tar".utf8))
+            }
+        }
+    }
+
+    @Test("HEAD returns only the path-stat header with an empty body")
+    func headReturnsStatHeaderOnly() async throws {
+        let archive = FakeArchiveClient(
+            getResult: .success(
+                (
+                    Data("fake-tar".utf8),
+                    PathStat(name: "passwd", size: 19, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+                )))
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .stopped)
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive) { app in
+            try await app.testing().test(.HEAD, "/v1.51/containers/web/archive?path=/etc/passwd") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "X-Docker-Container-Path-Stat") != nil)
+                #expect(res.body.readableBytes == 0)
+            }
+        }
+    }
+
+    @Test("GET on an unknown container returns 404")
+    func unknownContainer() async throws {
+        let archive = FakeArchiveClient(
+            getResult: .success(
+                (
+                    Data("fake-tar".utf8),
+                    PathStat(name: "passwd", size: 19, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+                )))
+
+        try await withArchiveApp(snapshot: nil, archive: archive) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/ghost/archive?path=/etc/passwd") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("a missing path in the container maps to 404")
+    func missingPath() async throws {
+        let archive = FakeArchiveClient(getResult: .failure(.pathNotFound(path: "/nonexistent")))
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .stopped)
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/nonexistent") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("a missing rootfs maps to 404")
+    func missingRootfs() async throws {
+        let archive = FakeArchiveClient(getResult: .failure(.rootfsNotFound(id: "web")))
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .stopped)
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/etc/passwd") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("an unexpected archive failure maps to 500")
+    func unexpectedFailure() async throws {
+        let archive = FakeArchiveClient(getResult: .failure(.operationFailed(message: "corrupted filesystem")))
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .stopped)
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive) { app in
+            try await app.testing().test(.GET, "/v1.51/containers/web/archive?path=/etc/passwd") { res async in
+                #expect(res.status == .internalServerError)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func withArchiveApp(
+    snapshot: ContainerSnapshot?,
+    archive: FakeArchiveClient,
+    test: @escaping (Application) async throws -> Void
+) async throws {
+    let client: ClientContainerProtocol = snapshot.map { FixedSnapshotClientMock(snapshot: $0) } ?? EmptyClientMock()
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        app.storage[EventBroadcasterKey.self] = EventBroadcaster()
+        try app.register(collection: ContainerArchiveRoute(containerClient: client, archiveClient: archive))
+        try await test(app)
+    }
+}
+
+private struct FakeArchiveClient: ClientArchiveProtocol {
+    var getResult: Result<(tarData: Data, stat: PathStat), ClientArchiveError>
+
+    func getRootfsPath(containerId: String) -> URL {
+        URL(fileURLWithPath: "/nonexistent/rootfs.ext4")
+    }
+
+    func getArchive(container: ContainerSnapshot, path: String) async throws -> (tarData: Data, stat: PathStat) {
+        if case .failure(let error) = getResult { throw error }
+        if case .success(let value) = getResult { return value }
+        throw ClientArchiveError.operationFailed(message: "unreachable")
+    }
+
+    func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws {}
+
+    func exportRootfs(containerId: String) async throws -> URL {
+        throw ClientArchiveError.operationFailed(message: "not under test")
+    }
+}
+
+private struct FixedSnapshotClientMock: ClientContainerProtocol {
+    let snapshot: ContainerSnapshot
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [snapshot] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { snapshot }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) { ([], 0) }
+}
+
+private struct EmptyClientMock: ClientContainerProtocol {
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) { ([], 0) }
+}

--- a/Tests/socktainerTests/Routes/ContainerExportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerExportRouteTests.swift
@@ -143,7 +143,7 @@ private actor FakeArchiveClient: ClientArchiveProtocol {
         URL(fileURLWithPath: "/nonexistent/rootfs.ext4")
     }
 
-    func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat) {
+    func getArchive(container: ContainerSnapshot, path: String) async throws -> (tarData: Data, stat: PathStat) {
         throw ClientArchiveError.operationFailed(message: "not under test")
     }
 

--- a/Tests/socktainerTests/Utilities/SocketUtilityTests.swift
+++ b/Tests/socktainerTests/Utilities/SocketUtilityTests.swift
@@ -98,7 +98,9 @@ struct SocketUtilityPermissionsTests {
 
     private func boundUnixSocket(at path: String) throws -> Int32 {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        try #require(fd >= 0)
+        guard fd >= 0 else {
+            throw POSIXError(.EIO)
+        }
 
         var address = sockaddr_un()
         address.sun_family = sa_family_t(AF_UNIX)


### PR DESCRIPTION
## Summary

`GET/HEAD /containers/{id}/archive` now works on created-but-never-started containers by serving from the image's shared snapshot, mirroring Docker. Also fixes the response tar format for file paths so first-entry consumers (e.g. OpenShell's supervisor extraction) receive the file.

## Related Issue

Fixes #370

## Changes

- **Pre-start archive reads** (`ClientArchiveService`): when a container has no `rootfs.ext4` and has never started (`startedDate == nil` — the runtime reports created containers as `.stopped`, so status alone can't discriminate), the archive service reads the image snapshot referenced by `containers/{id}/runtime-configuration.json → containerRootFilesystem.source` (`snapshots/<digest>/snapshot`). Read-only by construction (all containers of an image share it). A container that ever booted keeps its private rootfs.
- **Single-entry tar for files**: file/symlink archive GETs now emit exactly one tar entry named after the basename, matching moby's `archivePath` (no leading `./` directory entry). The previous directory-wrapped form broke clients that take the first tar entry as the payload — OpenShell extracted the empty `./` directory instead of the 16 MB supervisor binary and failed with `failed to fill whole buffer`. Directories keep the staged recursive form.
- **Symlink semantics**: final-component symlinks are served as symlinks (non-following stat, `linkTarget` populated, dangling links included) instead of being read as regular files.
- `SocketUtilityTests`: replaced `try #require(fd >= 0)`, broken by the current Swift 6.2 toolchain, which blocked the entire test suite.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (902 tests, incl. 18 new: `ClientArchiveServicePreStartTests`, `ContainerArchiveRouteTests`)
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed:
  - `docker create busybox` (never started) → `docker cp :/etc/passwd` works (was `Rootfs not found`); missing paths → 404; GET/HEAD stat headers correct
  - Running container: `docker cp` shows live writes; stopped-after-run serves its own rootfs (regression)
  - Real OpenShell flow: `docker cp :/openshell-sandbox` from the NVIDIA supervisor image returns the full 16,238,496-byte ELF as a single basename tar entry

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))

## Known Limitation: special file types

Non-regular, non-directory inodes (char/block devices, FIFOs, sockets — e.g.
`docker cp c:/dev/null`) currently fall into the symlink branch
(`entry.fileType = inode.isRegularFile ? .regular : .symbolicLink`), producing
a symlink entry with an empty target instead of a proper device entry. Moby
emits `characterSpecial`/`blockSpecial`/`namedPipe` entries (`WriteEntry` in
ContainerizationArchive supports all three). Fixing this properly is a
dedicated change — explicit inode-type switch, or `operationFailed` for
unsupported types, never defaulting to symlink. Out of scope here since it
does not affect the regular file extraction.