### PR TITLE
feat(events): broadcast a builder prune event on POST /build/prune

### DIFF
--- a/Sources/socktainer/Routes/Images/BuildPruneRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildPruneRoute.swift
@@ -53,6 +53,15 @@ struct BuildPruneRoute: RouteCollection {
                 logger: logger
             )
 
+            // moby's BuildPrune emits a single aggregate `builder prune` event (no
+            // per-cache-entry events), mirroring the volume/network prune events above.
+            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                await broadcaster.broadcast(
+                    DockerEvent.make(
+                        type: "builder", action: "prune", actorID: "",
+                        attributes: ["reclaimed": String(result.spaceReclaimed)]))
+            }
+
             return RESTBuildPruneResponse(
                 CachesDeleted: result.deletedCaches.isEmpty ? nil : result.deletedCaches,
                 SpaceReclaimed: result.spaceReclaimed

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerBuild
 import ContainerResource
 import ContainerizationOCI
 import Foundation
@@ -122,6 +123,41 @@ struct NewEventsTests {
         #expect(event?.Actor.Attributes["reclaimed"] == "1024")
         #expect(event?.Actor.Attributes["name"] == nil, "prune events carry no 'name' attribute")
         #expect(event?.Actor.Attributes["image"] == nil, "prune events carry no 'image' attribute")
+    }
+
+    // MARK: - builder.prune
+
+    // moby's daemon/builder/backend.PruneCache logs exactly this: Type=builder,
+    // Action=prune, empty Actor.ID, a single "reclaimed" attribute. Verified against
+    // moby master (daemon/builder/backend/backend.go).
+    @Test("build cache prune route broadcasts Type=builder Action=prune event")
+    func builderPruneEventBroadcast() async throws {
+        let broadcaster = EventBroadcaster()
+        let stream = await broadcaster.stream()
+        let captureTask = Task<DockerEvent?, Never> {
+            for await event in stream where event.Action == "prune" && event.Type == "builder" { return event }
+            return nil
+        }
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[EventBroadcasterKey.self] = broadcaster
+            try app.register(collection: BuildPruneRoute(builderClient: StubBuilderClient()))
+
+            try await app.testing().test(.POST, "/v1.51/build/prune") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let event = await withTimeout(captureTask)
+        captureTask.cancel()
+
+        #expect(event?.Type == "builder")
+        #expect(event?.Action == "prune")
+        #expect(event?.Actor.ID == "")
+        #expect(event?.Actor.Attributes["reclaimed"] == "2048")
     }
 
     @Test("container prune emits a per-container 'destroy' before the aggregate prune")
@@ -476,4 +512,15 @@ private struct StubNetworkClient: ClientNetworkProtocol {
         RESTNetworkCreate(Id: "net-abc123", Warning: "")
     }
     func delete(id: String, logger: Logger) async throws {}
+}
+
+private struct StubBuilderClient: ClientBuilderProtocol {
+    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {}
+    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+        fatalError("not exercised by this test")
+    }
+    func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {
+        BuilderPruneResult(deletedCaches: ["cache-1"], spaceReclaimed: 2048)
+    }
+    func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord] { [] }
 }


### PR DESCRIPTION
## Summary

`POST /build/prune` removed cached build layers but never broadcast a Docker event for it — one of the gaps flagged in the events-parity audit on #90.

## Change

- `BuildPruneRoute.swift`: broadcasts `Type=builder Action=prune` after a successful prune, with an empty `Actor.ID` and a `reclaimed` attribute carrying the freed space.

## Verification against real Docker

Checked against moby `master` (`daemon/builder/backend/backend.go`'s `PruneCache`):

```go
b.eventsService.Log(events.ActionPrune, events.BuilderEventType, events.Actor{
    Attributes: map[string]string{
        "reclaimed": strconv.FormatInt(buildCacheSize, 10),
    },
})
```

Exact match: `BuilderEventType = "builder"`, a single aggregate event (no per-cache-entry events), empty actor, one `reclaimed` attribute. Same aggregate-only shape already used by `ContainerPruneRoute`/`VolumePruneRoute`/`NetworkPruneRoute` in this codebase.

## Testing

- `make fmt` — no drift.
- `make test` — 869 tests passed, including the new `builderPruneEventBroadcast` test in `NewEventsTests.swift`.