### PR TITLE
feat(libpod): add Podman /libpod/* API, manifest lists, and multi-arch build support

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -180,6 +180,17 @@ jobs:
           fi
           sudo container system status
 
+      # `container system start --enable-kernel-install` kicks off the kernel
+      # download asynchronously — `system status` above only confirms the API
+      # server itself is up, not that the kernel download finished. Without
+      # waiting for it here, the BuildKit builder container (used by `podman
+      # build`/`docker build`, see BuildRoute) can start against an
+      # unconfigured kernel and fail intermittently. `kernel set --recommended`
+      # blocks until the kernel is actually installed; `--force` because
+      # `system start` may already have set one (see 18c9955).
+      - name: Install default Linux kernel for container builds
+        run: sudo container system kernel set --recommended --force
+
       - name: run socktainer
         run: |
           nohup sudo -i $PWD/socktainer > service.log 2>&1 &
@@ -315,3 +326,286 @@ jobs:
           # prune all images end ensure no volumes are left
           sudo docker volume prune --all --force
           [[ "1" == $(sudo docker volume ls | wc -l | xargs) ]]
+
+      # --- Podman CLI integration tests ---
+      - name: install podman cli
+        run: |
+          brew install podman
+
+      - name: setup podman socket
+        run: |
+          # /run is read-only on macOS, so use CONTAINER_HOST env var
+          echo "CONTAINER_HOST=unix:///var/root/.socktainer/container.sock" >> "$GITHUB_ENV"
+
+      - name: check podman version with socktainer
+        run: |
+          sudo -E podman version
+          # Verify socktainer is responding with expected API version
+          sudo -E podman version | grep 'v1.51'
+
+      - name: check podman images with socktainer
+        run: |
+          sudo -E podman image ls
+          sudo -E podman pull alpine:latest
+          sudo -E podman image ls | grep alpine
+
+      - name: check podman containers with socktainer
+        run: |
+          sudo -E podman ps
+          sudo -E podman ps -a
+
+      # `podman manifest add/create/inspect/exists` don't need a running container or a
+      # build (no BuildKit VM involved) — just already-pulled images and real query-param
+      # decoding, so unlike `podman build` these are testable on this runner. Regression
+      # coverage for: `PUT /libpod/manifests/{name}` needing to be decoded from query
+      # params (real podman sends operation/images there, not a JSON body with a
+      # Content-Type header — see LibpodManifestModifyRoute), and the greedy
+      # `{name:.*}` route (manifest create) no longer swallowing the more specific
+      # `{name}/registry/{destination}` sibling (manifest push) registered after it
+      # (see RegexRouter's specificity-ordered matching).
+      - name: check podman manifest with socktainer
+        run: |
+          sudo -E podman manifest create ci-test-manifest
+          sudo -E podman manifest add ci-test-manifest alpine:latest
+          sudo -E podman manifest inspect ci-test-manifest | grep 'image.index.v1+json'
+          sudo -E podman manifest exists ci-test-manifest
+
+      # Push destinations aren't reachable via a local registry container here (running any
+      # container needs the same unavailable nested-virtualization capability as
+      # `podman build`'s BuildKit VM — see the NOTE below), so this pushes to ttl.sh, a
+      # public ephemeral registry (tag suffix sets image lifetime, no auth needed). This is
+      # real regression coverage for two fixes: `podman push <image> <destination>` used to
+      # silently ignore `destination` entirely (real podman sends it as a `destination`
+      # query param, not folded into the path reference) and always tried — and, for
+      # anything without its own domain, failed — to push the source reference back to
+      # wherever it resolved to; `podman manifest push` used to fail on every push (success
+      # included) because the progress stream was framed with a `status` key real podman's
+      # client doesn't recognize (`stream`/`error`/`Id`, see DockerProgressFrame).
+      #
+      # The manifest pushed here is a fresh, empty one (not `ci-test-manifest` from the
+      # step above) — `manifest add`'s real podman semantics expand a multi-platform
+      # reference like `alpine:latest` into every platform's leaf manifest, but a normal
+      # pull only fetches this runner's own (arm64) platform content, so pushing that one
+      # would fail on missing blobs for the platforms never pulled — a real content-
+      # completeness constraint, not the bug being tested here.
+      #
+      # NOTE: this does NOT cover the bare-tag lookup fix (ClientImageService.push /
+      # ClientManifestService.retagForPush resolving a locally BUILT image, tagged
+      # verbatim with no registry/library prefix) or the private-IP-with-port scheme
+      # workaround (ClientImageService.resolvedScheme) — both need a real `podman build`
+      # output to reproduce, which this runner can't do for the same reason `podman build`
+      # itself is disabled below.
+      - name: check podman push with socktainer
+        run: |
+          retry() {
+            for attempt in 1 2 3; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "attempt ${attempt} failed, retrying..." >&2
+                sleep 5
+              fi
+            done
+            return 1
+          }
+          TAG="ci-$(date +%s)"
+          retry sudo -E podman push alpine:latest "ttl.sh/socktainer-ci-push-${TAG}:5m"
+          sudo -E podman manifest create ci-push-manifest
+          retry sudo -E podman manifest push ci-push-manifest "ttl.sh/socktainer-ci-manifest-${TAG}:5m"
+
+      # NOTE: podman/docker build requires a BuildKit builder VM. Confirmed on a real
+      #       run here (see below) that GitHub-hosted macOS runners genuinely can't
+      #       boot it: "Error Domain=VZErrorDomain Code=2 Virtualization is not
+      #       available on this hardware." The kernel-install-completion step above
+      #       (needed regardless, for image/manifest ops) doesn't change this — it's
+      #       a hardware capability gap, not a race.
+      #       See: https://github.com/actions/runner-images/issues/12933
+      #            https://github.com/orgs/community/discussions/69211
+      # - name: check podman build with socktainer
+      #   run: |
+      #     echo 'FROM alpine:latest' > /tmp/Dockerfile.test
+      #     echo 'RUN echo hello' >> /tmp/Dockerfile.test
+      #     sudo -E podman build -t test-build -f /tmp/Dockerfile.test /tmp
+      #     sudo -E podman image ls | grep test-build
+
+  multi-arch-build:
+    name: multi-arch build test (amd64 + arm64 + s390x)
+    needs: build
+    runs-on: macos-26
+    timeout-minutes: 75
+    # Disabled: confirmed by a real run that every build here fails with
+    # "Error Domain=VZErrorDomain Code=2 Virtualization is not available on
+    # this hardware" — GitHub-hosted macOS runners can't boot the BuildKit
+    # builder VM this job's docker-build-API steps depend on (same root
+    # cause as podman build being disabled above). Re-enable once
+    # https://github.com/actions/runner-images/issues/12933 is resolved.
+    if: false
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # fetch the artifact from the build job
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: socktainer
+
+      - name: Prepare socktainer binary
+        run: |
+          ls -la
+          chmod 755 socktainer
+
+      - name: Fetch Apple Container installer
+        run: |
+          APPLE_CONTAINER_VERSION=$(python3 -c "import json; d=json.load(open('Package.resolved')); print([p['state']['version'] for p in d['pins'] if p['identity']=='container'][0])")
+          wget "https://github.com/apple/container/releases/download/${APPLE_CONTAINER_VERSION}/container-installer-unsigned.pkg" \
+            -O container-installer-signed.pkg
+
+      - name: Install Apple Container
+        run: sudo installer -pkg container-installer-signed.pkg -target / -verbose
+
+      - name: Setup tmate
+        run: brew install tmate
+
+      - name: Start Apple Container system
+        run: |
+          tmate -S /tmp/tmate.sock new-session -d
+          tmate -S /tmp/tmate.sock wait tmate-ready
+          # skip welcome screen
+          tmate -F -S /tmp/tmate.sock send-keys "q" C-m
+
+          tmate -S /tmp/tmate.sock send-keys "sudo container system start --enable-kernel-install | tee /tmp/container.log" C-m
+
+          START=$SECONDS
+          TIMEOUT=60
+          READY=false
+          while [ $((SECONDS - START)) -lt $TIMEOUT ]; do
+            tmate -S /tmp/tmate.sock capture-pane -p > /tmp/container.log
+            cat /tmp/container.log
+            if sudo container system status >/dev/null 2>&1; then
+              echo "Container system is ready."
+              READY=true
+              break
+            else
+              echo "Container not ready yet..."
+            fi
+            sleep 2
+          done
+          tmate -S /tmp/tmate.sock kill-session
+          if [ "$READY" != "true" ]; then
+            echo "ERROR: container system did not become ready within ${TIMEOUT}s"
+            exit 1
+          fi
+
+      # container system start --enable-kernel-install runs the kernel download
+      # inside the tmate session. The loop above exits as soon as the API server
+      # responds (container system status = OK), which happens *before* the
+      # kernel download finishes.  Killing the tmate session at that point
+      # interrupts the download, leaving the kernel unconfigured.
+      # Running `container system kernel set --recommended` here (synchronously,
+      # not inside tmate) ensures the kernel is fully installed before we try to
+      # start the buildkit builder container. `--force` because the tmate-driven
+      # `system start` may have already installed one before being killed off,
+      # and a bare re-install then fails with "already exists" (NSCocoaErrorDomain
+      # Code=516) rather than being a no-op.
+      - name: Install default Linux kernel for container builds
+        run: sudo container system kernel set --recommended --force
+
+      - name: Start socktainer
+        run: |
+          SOCKTAINER_BIN="$(pwd)/socktainer"
+          nohup sudo -i "$SOCKTAINER_BIN" > service.log 2>&1 &
+          echo $! > service.pid
+          sudo ln -s /var/root/.socktainer/container.sock /var/run/docker.sock
+          sleep 5
+          cat service.log
+
+      - name: Install docker, docker-buildx, and podman CLIs
+        run: |
+          brew install docker docker-buildx podman
+          # docker-buildx is installed as a CLI plugin by Homebrew under
+          # /opt/homebrew/lib/docker/cli-plugins/docker-buildx.
+          # Make it visible to sudo (which may search a different prefix).
+          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+          sudo ln -sf "$(brew --prefix)/lib/docker/cli-plugins/docker-buildx" \
+            /usr/local/lib/docker/cli-plugins/docker-buildx
+
+      - name: Create test Dockerfile
+        run: |
+          mkdir -p /tmp/testbuild
+          cat > /tmp/testbuild/Dockerfile <<'EOF'
+          FROM alpine:3
+          RUN echo "Built for $(uname -m)" > /arch.txt
+          CMD ["sh", "-c", "cat /arch.txt"]
+          EOF
+
+      # ── Rosetta path: arm64 + amd64 ──────────────────────────────────────────
+      # docker buildx build with the default docker-container driver would start
+      # a moby/buildkit container inside socktainer, which is not supported.
+      # We call the Docker build API directly via curl instead; socktainer routes
+      # multi-platform requests to its Rosetta / QEMU builder containers.
+      - name: docker build – arm64+amd64 (Rosetta builder)
+        run: |
+          tar -c -C /tmp/testbuild . | \
+            sudo curl -sS --fail-with-body --unix-socket /var/run/docker.sock \
+              -X POST \
+              -H "Content-Type: application/x-tar" \
+              --data-binary @- \
+              "http://localhost/build?t=test-multiarch%3Arosetta&platform=linux%2Farm64%2Clinux%2Famd64"
+          sudo docker image ls | grep 'test-multiarch:rosetta'
+
+      # ── QEMU path: s390x ─────────────────────────────────────────────────────
+      - name: docker build – s390x (QEMU builder)
+        run: |
+          tar -c -C /tmp/testbuild . | \
+            sudo curl -sS --fail-with-body --unix-socket /var/run/docker.sock \
+              -X POST \
+              -H "Content-Type: application/x-tar" \
+              --data-binary @- \
+              "http://localhost/build?t=test-multiarch%3As390x&platform=linux%2Fs390x"
+          sudo docker image ls | grep 'test-multiarch:s390x'
+
+      # ── Combined manifest list: arm64 + amd64 + s390x ────────────────────────
+      - name: docker build – combined amd64+arm64+s390x manifest list
+        run: |
+          tar -c -C /tmp/testbuild . | \
+            sudo curl -sS --fail-with-body --unix-socket /var/run/docker.sock \
+              -X POST \
+              -H "Content-Type: application/x-tar" \
+              --data-binary @- \
+              "http://localhost/build?t=test-multiarch%3Alatest&platform=linux%2Farm64%2Clinux%2Famd64%2Clinux%2Fs390x"
+          sudo docker image ls | grep 'test-multiarch:latest'
+
+      - name: Verify manifest list contains amd64, arm64, and s390x
+        run: |
+          MANIFESTS=$(sudo curl -sS --fail-with-body --unix-socket /var/run/docker.sock \
+            "http://localhost/images/test-multiarch:latest/json?manifests=true" \
+            | jq -r '[.Manifests[]? | select(.Kind == "image") | .ImageData.Platform.architecture // empty] | unique | sort | join(",")')
+          echo "Platforms in manifest list: $MANIFESTS"
+          [[ "$MANIFESTS" == *"amd64"* ]] || { echo "ERROR: amd64 missing from manifest list"; exit 1; }
+          [[ "$MANIFESTS" == *"arm64"* ]] || { echo "ERROR: arm64 missing from manifest list"; exit 1; }
+          [[ "$MANIFESTS" == *"s390x"* ]] || { echo "ERROR: s390x missing from manifest list"; exit 1; }
+          echo "✓ Manifest list verified: amd64, arm64, and s390x all present"
+
+      # ── Docker multi-arch build API: manifest list amd64+ppc64le+arm64+s390x ──
+      # This is NOT equivalent to `podman build --platform ... --manifest name`.
+      # Real podman CLI, invoked bare (no --manifest), only builds a single
+      # platform anyway (see containers/podman#27211) — comma-separated
+      # --platform alone does not produce a multi-arch image on the real
+      # podman client. Podman's own --manifest flow (BuildRoute now reads the
+      # `manifest` query param and registers the built image via
+      # `manifestClient.addBuiltImage` — see socktainer#201) isn't exercised by
+      # this step either, since it never sends that param. This step only
+      # proves the Docker-compat build endpoint itself can assemble a
+      # multi-platform manifest list when asked directly via curl; it is not
+      # a stand-in for testing the podman CLI's multi-arch workflow.
+      - name: docker build API – manifest list amd64+ppc64le+arm64+s390x
+        run: |
+          platarch=linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          encoded=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$platarch")
+          tar -c -C /tmp/testbuild . | \
+            sudo curl -sS --fail-with-body --unix-socket /var/run/docker.sock \
+              -X POST \
+              -H "Content-Type: application/x-tar" \
+              --data-binary @- \
+              "http://localhost/build?t=shazam&platform=${encoded}"
+          sudo docker image ls | grep 'shazam'

--- a/PODMAN_API_AUDIT.md
+++ b/PODMAN_API_AUDIT.md
@@ -1,0 +1,208 @@
+# Podman CLI (remote socket) API coverage audit
+
+Scope: what the `podman` CLI needs from a remote unix socket (`CONTAINER_HOST` set,
+no podman machine involved — that layer is entirely client-side VM provisioning
+and never touches the wire once a socket connection exists). Paths verified
+against `github.com/containers/podman` `pkg/api/server/register_*.go`
+(canonical route registration) where fetched; the rest match the long-stable
+libpod API v4/v5 convention (`/libpod/<resource>/...`).
+
+Currently registered in this repo: `Sources/socktainer/configure.swift`
+("Podman libpod routes" section) + `Sources/socktainer/Routes/Libpod/*.swift`.
+
+## Ping / handshake (critical path — CLI probes this before anything else)
+
+| Path | Method | Implemented |
+|---|---|---|
+| `/libpod/_ping` | GET, HEAD | ✅ `LibpodPingRoute` |
+| `/libpod/version` | GET | ✅ `LibpodVersionRoute` |
+| `/libpod/info` | GET | ✅ `LibpodInfoRoute` |
+
+## Containers
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman ps` / `ps -a` | GET `/libpod/containers/json` | ✅ |
+| `podman create` | POST `/libpod/containers/create` | ✅ |
+| `podman start` | POST `/libpod/containers/{id}/start` | ✅ |
+| `podman stop` | POST `/libpod/containers/{id}/stop` | ✅ |
+| `podman kill` | POST `/libpod/containers/{id}/kill` | ✅ |
+| `podman restart` | POST `/libpod/containers/{id}/restart` | ✅ |
+| `podman rm` | DELETE `/libpod/containers/{id}` | ✅ |
+| `podman inspect` (container) | GET `/libpod/containers/{id}/json` | ✅ |
+| `podman logs` | GET `/libpod/containers/{id}/logs` | ✅ |
+| `podman top` | GET `/libpod/containers/{id}/top` | ✅ |
+| `podman rename` | POST `/libpod/containers/{id}/rename` | ✅ |
+| `podman wait` | POST `/libpod/containers/{id}/wait` | ✅ |
+| `podman attach` | POST `/libpod/containers/{id}/attach` | ✅ |
+| `podman exec` (create+start) | POST `/libpod/containers/{id}/exec`, `/libpod/exec/{id}/start`, GET `/libpod/exec/{id}/json` | ✅ |
+| `podman stats` | GET `/libpod/containers/{name}/stats` (per-container) | ✅ (all-container `/libpod/containers/stats` variant still missing) |
+| `podman pause` | POST `/libpod/containers/{name}/pause` | ✅ (wraps `ContainerPauseRoute`, which itself returns "not supported" — Apple Container has no pause primitive) |
+| `podman unpause` | POST `/libpod/containers/{name}/unpause` | ✅ (same caveat as pause) |
+| `podman container prune` | POST `/libpod/containers/prune` | ✅ |
+| `podman update` | POST `/libpod/containers/{name}/update` | ✅ |
+| `podman commit` | POST `/libpod/commit` | ✅ (wraps `CommitRoute`, which itself returns "not implemented") |
+| `podman export` | GET `/libpod/containers/{name}/export` | ✅ |
+| `podman diff` | GET `/libpod/containers/{name}/changes` | ✅ (wraps `ContainerChangesRoute`, which itself returns "not implemented") |
+| `podman healthcheck run` | GET `/libpod/containers/{name}/healthcheck` (libpod-only, no Docker-compat equivalent) | ❌ still missing (no Docker-side route to wrap) |
+| `podman cp` | GET/HEAD/PUT `/libpod/containers/{name}/archive` | ✅ |
+
+## Images
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman images` | GET `/libpod/images/json` | ✅ |
+| `podman pull` | POST `/libpod/images/pull` | ✅ |
+| `podman rmi` | DELETE `/libpod/images/{name}` | ✅ |
+| `podman inspect` (image) | GET `/libpod/images/{name}/json` | ✅ |
+| `podman tag` | POST `/libpod/images/{name}/tag` | ✅ |
+| `podman build` | POST `/libpod/build` | ✅ |
+| `podman push` | POST `/libpod/images/{name}/push` | ✅ |
+| `podman search` | GET `/libpod/images/search` | ✅ |
+| `podman history` | GET `/libpod/images/{name}/history` | ✅ |
+| `podman image prune` | POST `/libpod/images/prune` (confirmed in podman source) | ✅ |
+| `podman save` | GET `/libpod/images/{name}/get` (single) or `/libpod/images/get?names=...` (multi) | ✅ |
+| `podman load` | POST `/libpod/local/images/load` (confirmed in podman source — note: NOT `/libpod/images/load`) | ✅ |
+| `podman import` | POST `/libpod/images/import` (confirmed in podman source: query params are `reference`/`message`/`changes`/`url`, not Docker's `repo`/`tag`/`fromSrc`) | ✅ (translates libpod's `reference` query param into Docker's `repo`/`tag`/`fromSrc=-` shape, then delegates; `url`-based remote import still rejected, same limitation as the Docker-side route) |
+
+## Volumes
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman volume ls` | GET `/libpod/volumes/json` | ✅ |
+| `podman volume create` | POST `/libpod/volumes/create` | ✅ |
+| `podman volume rm` | DELETE `/libpod/volumes/{name}` | ✅ |
+| `podman volume inspect` | GET `/libpod/volumes/{name}/json` | ✅ |
+| `podman volume prune` | POST `/libpod/volumes/prune` | ✅ |
+
+## Networks
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman network ls` | GET `/libpod/networks/json` | ✅ |
+| `podman network create` | POST `/libpod/networks/create` | ✅ |
+| `podman network rm` | DELETE `/libpod/networks/{name}` | ✅ |
+| `podman network inspect` | GET `/libpod/networks/{name}/json` | ✅ |
+| `podman network prune` | POST `/libpod/networks/prune` | ✅ |
+| `podman network connect` | POST `/libpod/networks/{name}/connect` | ✅ (no-op parity response, same as Docker-side route) |
+| `podman network disconnect` | POST `/libpod/networks/{name}/disconnect` | ✅ (no-op parity response, same as Docker-side route) |
+
+## System
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman system df` | GET `/libpod/system/df` | ✅ |
+| `podman events` | GET `/libpod/events` | ✅ |
+| `podman login` (auth check) | POST `/libpod/auth` | ✅ |
+
+## Manifest lists (multi-arch) — now implemented
+
+**Correction (verified against a real podman issue this fork's author filed
+upstream, [containers/podman#27211](https://github.com/containers/podman/issues/27211)):**
+an earlier version of this doc claimed bare `podman build --platform a,b,c -t
+foo .` "already works end-to-end" against socktainer. That was an overstated
+inference from a CI test that calls the Docker-compat `/build` endpoint
+*directly via curl* — proving socktainer's own Docker-compat build endpoint
+can assemble a multi-platform manifest list when given `platform=a,b,c`, but
+that is not the same thing as the real podman CLI's actual behavior. Per
+#27211: real podman, invoked bare (no `--manifest` flag), only builds a
+**single** architecture regardless of how many comma-separated `--platform`
+values you pass — the client itself never asks the server for a multi-arch
+result unless you pass `--manifest <name>`. The only real multi-arch path in
+podman is `--platform a,b --manifest name`.
+
+Implemented as a `ClientManifestService` modeling a manifest list as an
+ordinary tagged reference whose descriptor points at an OCI image index blob
+— no separate bookkeeping layer; "the current members of `name`" is always
+just "decode whatever index `name` currently points at." Built on two
+existing Apple Containerization framework primitives this codebase's own
+`load`/`import` code already relies on: a second `ImageStore(path:)` instance
+over the daemon's own Application Support directory, and `ContentStore.ingest`
+to write new index blobs (via `ContentWriter.write`, which computes the
+correct SHA256 filename — `completeIngestSession` trusts the filename
+verbatim with no hashing of its own, so getting this right mattered).
+Reviewed by an independent second opinion before implementation, which caught
+two real issues: `resolvedPushPlatform`'s single-available-platform narrowing
+would silently defeat an explicit "push the whole list" request (fixed with a
+dedicated `pushManifestList` that always pushes `platform: nil`), and pushing
+to a different destination reference needs a re-tag first since the
+framework's push always pushes to the same reference it resolves from (added
+`retagForPush`).
+
+Known limitation, not closed: `ImageStore`'s reference table (`state.json`) is
+a plain load-entire-map → overwrite-entire-map with no file lock, shared with
+the separate `container-apiserver` process — the real contention is
+cross-process, which no in-process lock added here would fix. This is the
+same risk profile the existing `load`/`import` code already accepts; ingest
+and create are kept back-to-back to narrow, not close, the window.
+
+| Command | Method + Path | Implemented |
+|---|---|---|
+| `podman manifest create` | POST `/libpod/manifests/{name}` | ✅ |
+| `podman manifest inspect` | GET `/libpod/manifests/{name}/json` | ✅ |
+| `podman manifest exists` | GET `/libpod/manifests/{name}/exists` | ✅ |
+| `podman manifest add` | PUT `/libpod/manifests/{name}` (`operation: "update"`) | ✅ |
+| `podman manifest remove` | PUT `/libpod/manifests/{name}` (`operation: "remove"`) | ✅ |
+| `podman manifest rm` | DELETE `/libpod/manifests/{name}` | ✅ |
+| `podman manifest annotate` | PUT `/libpod/manifests/{name}` (`operation: "annotate"`) | ❌ not implemented (index-level annotations only, rarely used) |
+| `podman manifest push` | POST `/libpod/manifests/{name}/registry/{destination}` (v4+) and legacy POST `/libpod/manifests/{name}/push?destination=` | ✅ (both forms) |
+| `podman build --manifest <name>` | server-side: build all requested platforms and register the result under a named, addressable manifest list | ✅ |
+
+## Not applicable / intentionally out of scope
+
+- `podman pod *`, `podman generate kube`, `podman play kube` — Apple Container
+  has no pod primitive; skip unless a future need surfaces.
+- `podman machine *` — client-side only, never reaches the socket. Confirmed
+  out of scope per the ask.
+- `podman unshare`, `podman system connection *`, `podman completion` — purely
+  client-side (namespace tricks / connection-list bookkeeping / shell
+  completions), never hit the socket at all.
+- checkpoint/restore — niche, CRIU-based, not applicable to the Apple
+  Container VM backend.
+- `podman secret *` — Swarm-style secret store; low value without a broader
+  secrets/Swarm story, and no evidence it's used against a non-Swarm-mode
+  daemon.
+
+## Minor / low-priority gaps not yet mentioned above
+
+- ~~`{resource}/exists` endpoints~~ — now implemented: `/libpod/containers/{name}/exists`,
+  `/libpod/images/{name}/exists`, `/libpod/volumes/{name}/exists`,
+  `/libpod/networks/{name}/exists` all return 204 (exists) or 404 (not found).
+- `podman untag` — likely handled by the same `/libpod/images/{name}/tag`
+  machinery in reverse or a dedicated untag call; low priority, rarely used.
+- `podman generate systemd` — out of scope (systemd unit generation is a
+  Linux-host concept, not meaningful under Apple Container).
+- All-container `/libpod/containers/stats` (no name): the per-container
+  `/libpod/containers/{name}/stats` above is real podman server behavior
+  (confirmed: podman's own route registration uses the Docker-compat handler
+  for that deprecated per-container path). The all-container variant is
+  genuinely different — it uses libpod's own `ContainerStats` schema
+  (`CPU`/`MemPerc`/`UpTime` as pre-computed values, not raw counters podman
+  computes percentages from) which needs host-CPU-time accounting and
+  container start-time tracking this codebase doesn't currently have.
+  Deliberately not implemented with fabricated/approximated values for those
+  fields — flagging as a real gap rather than shipping a wrong-looking-right
+  response.
+
+## Top gaps worth implementing next (priority order)
+
+Most previously listed gaps are now implemented (see the per-row ✅ entries above).
+Remaining:
+
+1. **`podman healthcheck run`** — the one genuine blocker hit so far. Unlike
+   every other gap in this doc, there is no existing Docker-side route to
+   delegate to: real `podman healthcheck run <container>` executes the
+   container's configured healthcheck test command right now and reports
+   the result, whereas `HealthCheckManager` (`Sources/socktainer/Utilities/HealthCheckManager.swift`)
+   only exposes `start`/`stop`/`currentHealth(for:)` — a background poll loop
+   and its last cached result, not an on-demand single run. Implementing
+   this properly needs new exec-based invocation logic (parse the
+   container's `HealthcheckConfig.test`, run it via the container-exec path
+   with the configured timeout, map the exit code to Healthy/Unhealthy, and
+   shape the response per libpod's `HealthcheckRunResult` schema) — real
+   feature work, not a route wrapper. Flagging rather than half-implementing
+   it as "just return `currentHealth`", which would silently diverge from
+   what `podman healthcheck run` actually means (a fresh probe, not a cached
+   status read).
+2. Remaining low priority: `podman untag`, `podman manifest annotate`,
+   all-container `/libpod/containers/stats`.

--- a/PODMAN_API_AUDIT.md
+++ b/PODMAN_API_AUDIT.md
@@ -95,21 +95,18 @@ Currently registered in this repo: `Sources/socktainer/configure.swift`
 | `podman events` | GET `/libpod/events` | ✅ |
 | `podman login` (auth check) | POST `/libpod/auth` | ✅ |
 
-## Manifest lists (multi-arch) — now implemented
+## Manifest lists (multi-arch)
 
-**Correction (verified against a real podman issue this fork's author filed
-upstream, [containers/podman#27211](https://github.com/containers/podman/issues/27211)):**
-an earlier version of this doc claimed bare `podman build --platform a,b,c -t
-foo .` "already works end-to-end" against socktainer. That was an overstated
-inference from a CI test that calls the Docker-compat `/build` endpoint
-*directly via curl* — proving socktainer's own Docker-compat build endpoint
-can assemble a multi-platform manifest list when given `platform=a,b,c`, but
-that is not the same thing as the real podman CLI's actual behavior. Per
-#27211: real podman, invoked bare (no `--manifest` flag), only builds a
-**single** architecture regardless of how many comma-separated `--platform`
-values you pass — the client itself never asks the server for a multi-arch
-result unless you pass `--manifest <name>`. The only real multi-arch path in
-podman is `--platform a,b --manifest name`.
+Real podman's actual multi-arch workflow (confirmed against
+[containers/podman#27211](https://github.com/containers/podman/issues/27211)):
+invoked bare (no `--manifest` flag), `podman build --platform a,b,c -t foo .`
+only builds a **single** architecture regardless of how many comma-separated
+`--platform` values are passed — the client never asks the server for a
+multi-arch result unless `--manifest <name>` is given. The only real
+multi-arch path in podman is `--platform a,b --manifest name`. A Docker-compat
+client hitting `/build?platform=a,b,c` directly is a separate case: that
+endpoint does assemble a multi-platform manifest list from a comma-separated
+`platform` value, matching Docker's own API contract rather than podman's.
 
 Implemented as a `ClientManifestService` modeling a manifest list as an
 ordinary tagged reference whose descriptor points at an OCI image index blob
@@ -120,21 +117,21 @@ existing Apple Containerization framework primitives this codebase's own
 over the daemon's own Application Support directory, and `ContentStore.ingest`
 to write new index blobs (via `ContentWriter.write`, which computes the
 correct SHA256 filename — `completeIngestSession` trusts the filename
-verbatim with no hashing of its own, so getting this right mattered).
-Reviewed by an independent second opinion before implementation, which caught
-two real issues: `resolvedPushPlatform`'s single-available-platform narrowing
-would silently defeat an explicit "push the whole list" request (fixed with a
-dedicated `pushManifestList` that always pushes `platform: nil`), and pushing
-to a different destination reference needs a re-tag first since the
-framework's push always pushes to the same reference it resolves from (added
-`retagForPush`).
+verbatim with no hashing of its own, so getting this right matters).
 
-Known limitation, not closed: `ImageStore`'s reference table (`state.json`) is
-a plain load-entire-map → overwrite-entire-map with no file lock, shared with
-the separate `container-apiserver` process — the real contention is
-cross-process, which no in-process lock added here would fix. This is the
-same risk profile the existing `load`/`import` code already accepts; ingest
-and create are kept back-to-back to narrow, not close, the window.
+`resolvedPushPlatform`'s single-available-platform narrowing (used by
+ordinary image push) would silently defeat an explicit "push the whole list"
+request, so manifest-list push goes through a dedicated `pushManifestList`
+that always pushes `platform: nil` instead. Pushing to a different
+destination reference needs a re-tag first, since the framework's push always
+pushes to the same reference it resolves from (`retagForPush`).
+
+Known limitation: `ImageStore`'s reference table (`state.json`) is a plain
+load-entire-map → overwrite-entire-map with no file lock, shared with the
+separate `container-apiserver` process — the real contention is cross-process,
+which no in-process lock added here would fix. This is the same risk profile
+the existing `load`/`import` code already accepts; ingest and create are kept
+back-to-back to narrow, not close, the window.
 
 | Command | Method + Path | Implemented |
 |---|---|---|
@@ -163,9 +160,9 @@ and create are kept back-to-back to narrow, not close, the window.
   secrets/Swarm story, and no evidence it's used against a non-Swarm-mode
   daemon.
 
-## Minor / low-priority gaps not yet mentioned above
+## Minor / low-priority gaps
 
-- ~~`{resource}/exists` endpoints~~ — now implemented: `/libpod/containers/{name}/exists`,
+- `{resource}/exists` endpoints: `/libpod/containers/{name}/exists`,
   `/libpod/images/{name}/exists`, `/libpod/volumes/{name}/exists`,
   `/libpod/networks/{name}/exists` all return 204 (exists) or 404 (not found).
 - `podman untag` — likely handled by the same `/libpod/images/{name}/tag`
@@ -186,10 +183,7 @@ and create are kept back-to-back to narrow, not close, the window.
 
 ## Top gaps worth implementing next (priority order)
 
-Most previously listed gaps are now implemented (see the per-row ✅ entries above).
-Remaining:
-
-1. **`podman healthcheck run`** — the one genuine blocker hit so far. Unlike
+1. **`podman healthcheck run`** — the one genuine blocker. Unlike
    every other gap in this doc, there is no existing Docker-side route to
    delegate to: real `podman healthcheck run <container>` executes the
    container's configured healthcheck test command right now and reports

--- a/PODMAN_API_AUDIT.md
+++ b/PODMAN_API_AUDIT.md
@@ -61,7 +61,7 @@ Currently registered in this repo: `Sources/socktainer/configure.swift`
 | `podman search` | GET `/libpod/images/search` | ✅ |
 | `podman history` | GET `/libpod/images/{name}/history` | ✅ |
 | `podman image prune` | POST `/libpod/images/prune` (confirmed in podman source) | ✅ |
-| `podman save` | GET `/libpod/images/{name}/get` (single) or `/libpod/images/get?names=...` (multi) | ✅ |
+| `podman save` | GET `/libpod/images/{name}/get` (single) or `/libpod/images/export?references=...` (multi) | ✅ |
 | `podman load` | POST `/libpod/local/images/load` (confirmed in podman source — note: NOT `/libpod/images/load`) | ✅ |
 | `podman import` | POST `/libpod/images/import` (confirmed in podman source: query params are `reference`/`message`/`changes`/`url`, not Docker's `repo`/`tag`/`fromSrc`) | ✅ (translates libpod's `reference` query param into Docker's `repo`/`tag`/`fromSrc=-` shape, then delegates; `url`-based remote import still rejected, same limitation as the Docker-side route) |
 

--- a/PODMAN_API_AUDIT.md
+++ b/PODMAN_API_AUDIT.md
@@ -97,13 +97,15 @@ Currently registered in this repo: `Sources/socktainer/configure.swift`
 
 ## Manifest lists (multi-arch)
 
-Real podman's actual multi-arch workflow (confirmed against
+Real podman's actual multi-arch **build** workflow (confirmed against
 [containers/podman#27211](https://github.com/containers/podman/issues/27211)):
 invoked bare (no `--manifest` flag), `podman build --platform a,b,c -t foo .`
 only builds a **single** architecture regardless of how many comma-separated
 `--platform` values are passed — the client never asks the server for a
 multi-arch result unless `--manifest <name>` is given. The only real
-multi-arch path in podman is `--platform a,b --manifest name`. A Docker-compat
+multi-arch path for the `build` command specifically is `--platform a,b
+--manifest name`; `podman manifest create`/`add` are a separate, always-multi-
+arch-capable path that doesn't go through `build` at all. A Docker-compat
 client hitting `/build?platform=a,b,c` directly is a separate case: that
 endpoint does assemble a multi-platform manifest list from a comma-separated
 `platform` value, matching Docker's own API contract rather than podman's.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   - [Quick Start ⚡](#quick-start)
     - [Launch socktainer 🏁](#launch-socktainer-🏁)
     - [Using Docker CLI 🐳](#using-docker-cli-🐳)
+    - [Using Podman CLI 🦭](#using-podman-cli-🦭)
+    - [Socket Symlinks 🔗](#socket-symlinks-🔗)
   - [Key Features ✨](#key-features)
   - [Requirements 📋](#requirements-📋)
   - [Installation 🛠️](#installation-🛠️)
@@ -114,6 +116,128 @@ DOCKER_HOST=unix://$HOME/.socktainer/container.sock docker images
 ```
 
 </details>
+
+### Using Podman CLI 🦭
+
+Podman connects to socktainer via `CONTAINER_HOST` or socket symlink:
+
+```bash
+export CONTAINER_HOST=unix://$HOME/.socktainer/container.sock
+podman version   # Check connection
+podman ps        # List running containers
+podman images    # List available images
+```
+
+> [!NOTE]
+> Podman uses its own API endpoints (`/libpod/*`), not Docker-compatible ones.
+> Socktainer implements a subset of the libpod API — see [#201](https://github.com/socktainer/socktainer/issues/201) for progress.
+
+> [!TIP]
+> Already have Podman Desktop (or `podman machine`) set up, with
+> `/var/run/docker.sock` symlinked to its own Docker-compat socket? `CONTAINER_HOST`
+> above talks to socktainer **without touching that link at all** — nothing else
+> that depends on it (Podman Desktop itself, other tools) is affected. This is
+> the reason to prefer the env var over the symlink approach below whenever an
+> existing setup like that is already in place.
+
+### Socket Symlinks 🔗
+
+Instead of setting environment variables, you can symlink socktainer's socket to the default locations that Docker and Podman expect.
+
+> [!WARNING]
+> `/var/run/docker.sock` is often already a symlink to something else — most
+> commonly Podman Desktop's own Docker-compat socket (`podman machine`'s
+> `podman.sock`), which is what makes plain `docker` commands work against
+> Podman in the first place. Overwriting it with `ln -sf` **replaces that link
+> silently**, so back up the existing target first if you want to switch back
+> later without reinstalling anything.
+
+**Docker** (requires `sudo`):
+
+```bash
+if [ -e /var/run/docker.sock ] && [ ! -L /var/run/docker.sock ]; then
+  echo "warning: /var/run/docker.sock exists and is not a symlink — leaving it in place, not overwriting" >&2
+else
+  # Back up whatever /var/run/docker.sock currently points to (if it's a symlink, and not
+  # already socktainer's own link — e.g. re-running setup without an intervening undo) —
+  # e.g. Podman Desktop's own Docker-compat link — so it can be restored later.
+  if [ -L /var/run/docker.sock ] && [ ! -f "$HOME/.socktainer-docker-sock-backup" ] \
+     && [ "$(readlink /var/run/docker.sock)" != "$HOME/.socktainer/container.sock" ]; then
+    readlink /var/run/docker.sock > "$HOME/.socktainer-docker-sock-backup"
+  fi
+  sudo ln -sf "$HOME/.socktainer/container.sock" /var/run/docker.sock
+fi
+```
+
+**Podman** (no `sudo` needed):
+
+```bash
+# Podman looks for its socket at $TMPDIR/storage-run-$UID/podman/podman.sock
+PODMAN_SOCK_DIR="${TMPDIR:-/tmp}"
+PODMAN_SOCK_DIR="${PODMAN_SOCK_DIR%/}/storage-run-$(id -u)/podman"
+mkdir -p "$PODMAN_SOCK_DIR"
+if [ -e "$PODMAN_SOCK_DIR/podman.sock" ] && [ ! -L "$PODMAN_SOCK_DIR/podman.sock" ]; then
+  echo "warning: $PODMAN_SOCK_DIR/podman.sock exists and is not a symlink — leaving it in place, not overwriting" >&2
+else
+  if [ -L "$PODMAN_SOCK_DIR/podman.sock" ] && [ ! -f "$HOME/.socktainer-podman-sock-backup" ] \
+     && [ "$(readlink "$PODMAN_SOCK_DIR/podman.sock")" != "$HOME/.socktainer/container.sock" ]; then
+    readlink "$PODMAN_SOCK_DIR/podman.sock" > "$HOME/.socktainer-podman-sock-backup"
+  fi
+  ln -sf "$HOME/.socktainer/container.sock" "$PODMAN_SOCK_DIR/podman.sock"
+fi
+```
+
+**Both at once:**
+
+```bash
+# Docker
+if [ -e /var/run/docker.sock ] && [ ! -L /var/run/docker.sock ]; then
+  echo "warning: /var/run/docker.sock exists and is not a symlink — leaving it in place, not overwriting" >&2
+else
+  if [ -L /var/run/docker.sock ] && [ ! -f "$HOME/.socktainer-docker-sock-backup" ] \
+     && [ "$(readlink /var/run/docker.sock)" != "$HOME/.socktainer/container.sock" ]; then
+    readlink /var/run/docker.sock > "$HOME/.socktainer-docker-sock-backup"
+  fi
+  sudo ln -sf "$HOME/.socktainer/container.sock" /var/run/docker.sock
+fi
+
+# Podman
+PODMAN_SOCK_DIR="${TMPDIR:-/tmp}"
+PODMAN_SOCK_DIR="${PODMAN_SOCK_DIR%/}/storage-run-$(id -u)/podman"
+mkdir -p "$PODMAN_SOCK_DIR"
+if [ -e "$PODMAN_SOCK_DIR/podman.sock" ] && [ ! -L "$PODMAN_SOCK_DIR/podman.sock" ]; then
+  echo "warning: $PODMAN_SOCK_DIR/podman.sock exists and is not a symlink — leaving it in place, not overwriting" >&2
+else
+  if [ -L "$PODMAN_SOCK_DIR/podman.sock" ] && [ ! -f "$HOME/.socktainer-podman-sock-backup" ] \
+     && [ "$(readlink "$PODMAN_SOCK_DIR/podman.sock")" != "$HOME/.socktainer/container.sock" ]; then
+    readlink "$PODMAN_SOCK_DIR/podman.sock" > "$HOME/.socktainer-podman-sock-backup"
+  fi
+  ln -sf "$HOME/.socktainer/container.sock" "$PODMAN_SOCK_DIR/podman.sock"
+fi
+```
+
+To undo — restores whatever was linked before (e.g. Podman Desktop's socket), or just removes the link if there was nothing to restore:
+
+```bash
+# Docker
+if [ -f "$HOME/.socktainer-docker-sock-backup" ]; then
+  sudo ln -sf "$(cat "$HOME/.socktainer-docker-sock-backup")" /var/run/docker.sock
+  rm -f "$HOME/.socktainer-docker-sock-backup"
+else
+  [ -L /var/run/docker.sock ] && sudo rm -f /var/run/docker.sock
+fi
+
+# Podman
+PODMAN_SOCK_DIR="${TMPDIR:-/tmp}"
+PODMAN_SOCK_DIR="${PODMAN_SOCK_DIR%/}/storage-run-$(id -u)/podman"
+if [ -f "$HOME/.socktainer-podman-sock-backup" ]; then
+  mkdir -p "$PODMAN_SOCK_DIR"
+  ln -sf "$(cat "$HOME/.socktainer-podman-sock-backup")" "$PODMAN_SOCK_DIR/podman.sock"
+  rm -f "$HOME/.socktainer-podman-sock-backup"
+else
+  [ -L "$PODMAN_SOCK_DIR/podman.sock" ] && rm -f "$PODMAN_SOCK_DIR/podman.sock"
+fi
+```
 
 ---
 

--- a/Sources/socktainer/Clients/ClientBuilderService.swift
+++ b/Sources/socktainer/Clients/ClientBuilderService.swift
@@ -38,10 +38,25 @@ struct BuilderCacheRecord: Sendable {
 }
 
 protocol ClientBuilderProtocol: Sendable {
-    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws
-    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder
+    /// Verify the builder is reachable (starting it if necessary).
+    /// Pass `qemu: true` when the build requires platforms other than arm64/amd64
+    /// (e.g. s390x, ppc64le) so that a QEMU-enabled builder container is used.
+    func ensureReachable(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws
+    /// Connect to the builder, starting it if necessary.
+    /// Pass `qemu: true` when the build requires platforms other than arm64/amd64.
+    func connect(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws -> Builder
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult
     func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord]
+}
+
+extension ClientBuilderProtocol {
+    // Backward-compatible overloads that default to Rosetta mode (qemu: false).
+    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {
+        try await ensureReachable(timeout: timeout, retryInterval: retryInterval, qemu: false, logger: logger)
+    }
+    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+        try await connect(timeout: timeout, retryInterval: retryInterval, qemu: false, logger: logger)
+    }
 }
 
 struct ClientBuilderService: ClientBuilderProtocol {
@@ -71,27 +86,95 @@ struct ClientBuilderService: ClientBuilderProtocol {
     }
 
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {
-        let container = try await runningBuilderContainer(logger: logger)
-
         let command = try BuildctlUtility.pruneCommand(from: request)
-        let stdoutText = try await execute(command: command, in: container, actionName: "buildctl prune", logger: logger)
+        var deletedIds: [String] = []
+        var reclaimed: Int64 = 0
+        var attempted = false
+        var succeeded = false
+        var lastError: Error?
 
-        let entries = BuildctlUtility.parsePruneOutput(stdoutText, logger: logger)
-        let deletedIds = entries.compactMap(\.id)
-        let reclaimed = entries.reduce(Int64(0)) { $0 + ($1.size ?? 0) }
+        // Neither builder is provisioned just to report/reclaim nothing — a fresh install
+        // that's never built anything shouldn't have `docker builder prune` spin up a VM only
+        // to say "0 bytes freed".
+        for qemu in [false, true] {
+            let container: ContainerSnapshot?
+            do {
+                container = try await existingRunningBuilderContainer(qemu: qemu)
+            } catch {
+                // A lookup failure is itself a real, attempted-but-failed outcome — unlike
+                // the container genuinely not running (the ordinary, benign `nil` case
+                // below), this must count toward `attempted` or a lookup-only failure on
+                // both builders would silently return an empty success.
+                attempted = true
+                logger.error("buildctl prune\(qemu ? " (qemu)" : "") lookup failed: \(error)")
+                lastError = error
+                continue
+            }
+            guard let container else { continue }
+            attempted = true
+            do {
+                let stdoutText = try await execute(command: command, in: container, actionName: "buildctl prune\(qemu ? " (qemu)" : "")", logger: logger)
+                let entries = BuildctlUtility.parsePruneOutput(stdoutText, logger: logger)
+                deletedIds.append(contentsOf: entries.compactMap(\.id))
+                reclaimed += entries.reduce(Int64(0)) { $0 + ($1.size ?? 0) }
+                succeeded = true
+            } catch {
+                // One builder's transient failure shouldn't hide a successful prune of the
+                // other — log and keep going instead of propagating and losing everything
+                // already accumulated. Only rethrown below if EVERY attempted builder failed.
+                logger.error("buildctl prune\(qemu ? " (qemu)" : "") failed: \(error)")
+                lastError = error
+            }
+        }
+
+        // Every builder that was actually running failed — an empty success result here
+        // would silently read as "nothing to prune" instead of "the operation failed".
+        if attempted, !succeeded, let lastError {
+            throw lastError
+        }
 
         return BuilderPruneResult(deletedCaches: deletedIds, spaceReclaimed: reclaimed)
     }
 
     func diskUsage(logger: Logger) async throws -> [BuilderCacheRecord] {
-        let container = try await runningBuilderContainer(logger: logger)
         let command = BuildctlUtility.duCommand()
-        let stdoutText = try await execute(command: command, in: container, actionName: "buildctl du", logger: logger)
+        var records: [BuilderCacheRecord] = []
+        var attempted = false
+        var succeeded = false
+        var lastError: Error?
 
-        return BuildctlUtility.parseDuOutput(stdoutText, logger: logger).compactMap { record in
-            guard let id = record.id else {
-                return nil
+        for qemu in [false, true] {
+            let container: ContainerSnapshot?
+            do {
+                container = try await existingRunningBuilderContainer(qemu: qemu)
+            } catch {
+                attempted = true
+                logger.error("buildctl du\(qemu ? " (qemu)" : "") lookup failed: \(error)")
+                lastError = error
+                continue
             }
+            guard let container else { continue }
+            attempted = true
+            do {
+                let stdoutText = try await execute(command: command, in: container, actionName: "buildctl du\(qemu ? " (qemu)" : "")", logger: logger)
+                records.append(contentsOf: Self.parseDuRecords(from: stdoutText, logger: logger))
+                succeeded = true
+            } catch {
+                logger.error("buildctl du\(qemu ? " (qemu)" : "") failed: \(error)")
+                lastError = error
+            }
+        }
+
+        if attempted, !succeeded, let lastError {
+            throw lastError
+        }
+
+        return records
+    }
+
+    private static func parseDuRecords(from stdoutText: String, logger: Logger) -> [BuilderCacheRecord] {
+        BuildctlUtility.parseDuOutput(stdoutText, logger: logger).compactMap { record in
+            guard let id = record.id else { return nil }
             return BuilderCacheRecord(
                 id: id,
                 parents: record.parents ?? [],
@@ -107,8 +190,23 @@ struct ClientBuilderService: ClientBuilderProtocol {
         }
     }
 
-    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {
-        _ = try await runningBuilderContainer(logger: logger)
+    /// Returns the QEMU (or Rosetta) builder container only if it's already running — never
+    /// creates/starts it, unlike `runningBuilderContainer`. Used by reporting/cleanup
+    /// operations (`prune`/`diskUsage`) that shouldn't provision a builder VM just to say
+    /// there's nothing to report for it.
+    private func existingRunningBuilderContainer(qemu: Bool) async throws -> ContainerSnapshot? {
+        let containerID = resolvedContainerId(qemu: qemu)
+        let container: ContainerSnapshot
+        do {
+            container = try await containerClient.withClient { try await $0.get(id: containerID) }
+        } catch let error as ContainerizationError where error.code == .notFound {
+            return nil
+        }
+        return container.status == .running ? container : nil
+    }
+
+    func ensureReachable(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws {
+        _ = try await runningBuilderContainer(qemu: qemu, logger: logger)
 
         let clock = ContinuousClock()
         let deadline = clock.now + timeout
@@ -116,7 +214,7 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
         while clock.now < deadline {
             do {
-                let socket = try await dialBuilderSocket()
+                let socket = try await dialBuilderSocket(qemu: qemu)
                 try? socket.close()
                 return
             } catch {
@@ -133,8 +231,8 @@ struct ClientBuilderService: ClientBuilderProtocol {
         throw ContainerizationError(.timeout, message: "Timeout waiting for builder reachability")
     }
 
-    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
-        _ = try await runningBuilderContainer(logger: logger)
+    func connect(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws -> Builder {
+        _ = try await runningBuilderContainer(qemu: qemu, logger: logger)
 
         let clock = ContinuousClock()
         let deadline = clock.now + timeout
@@ -142,7 +240,7 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
         while clock.now < deadline {
             do {
-                let socket = try await dialBuilderSocket()
+                let socket = try await dialBuilderSocket(qemu: qemu)
                 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
                 let builder = try await Builder(socket: socket, group: group, logger: logger)
                 do {
@@ -166,20 +264,41 @@ struct ClientBuilderService: ClientBuilderProtocol {
         throw ContainerizationError(.timeout, message: "Timeout waiting for connection to builder")
     }
 
-    private func dialBuilderSocket() async throws -> FileHandle {
-        let container = try await runningBuilderContainer(logger: nil)
+    private func dialBuilderSocket(qemu: Bool) async throws -> FileHandle {
+        let container = try await runningBuilderContainer(qemu: qemu, logger: nil)
         return try await containerClient.withClient { try await $0.dial(id: container.id, port: builderPort) }
     }
 
-    private func runningBuilderContainer(logger: Logger?) async throws -> ContainerSnapshot {
+    private func runningBuilderContainer(qemu: Bool, logger: Logger?) async throws -> ContainerSnapshot {
+        let containerID = resolvedContainerId(qemu: qemu)
         let container: ContainerSnapshot
         do {
-            container = try await containerClient.withClient { try await $0.get(id: builderContainerId) }
+            container = try await containerClient.withClient { try await $0.get(id: containerID) }
         } catch let error as ContainerizationError where error.code == .notFound {
             logger?.info("Builder container not found, creating a new builder instance")
-            return try await createAndStartBuilder(logger: logger)
+            do {
+                return try await createAndStartBuilder(qemu: qemu, logger: logger)
+            } catch {
+                // A concurrent caller may have created it between our own `get` miss and this
+                // `create` call — this codebase's own split-build (see BuildRoute) can now
+                // issue genuinely concurrent build requests, some of which may need the same
+                // cold-started builder. If someone else won the race, use what they created
+                // instead of failing this request; if `get` also fails, this wasn't a race —
+                // propagate the original creation error. Routed through the same status
+                // handling below (not returned directly) — the race winner's container could
+                // still be `.stopped`/`.stopping` at the exact moment we observe it.
+                guard let existing = try? await containerClient.withClient({ try await $0.get(id: containerID) }) else {
+                    throw error
+                }
+                return try await ensureRunning(existing, qemu: qemu, logger: logger)
+            }
         }
 
+        return try await ensureRunning(container, qemu: qemu, logger: logger)
+    }
+
+    private func ensureRunning(_ container: ContainerSnapshot, qemu: Bool, logger: Logger?) async throws -> ContainerSnapshot {
+        let containerID = resolvedContainerId(qemu: qemu)
         guard container.status == .running else {
             switch container.status {
             case .running:
@@ -189,20 +308,28 @@ struct ClientBuilderService: ClientBuilderProtocol {
                 try await startBuildKit(containerId: container.id)
                 return try await containerClient.withClient { try await $0.get(id: container.id) }
             case .stopping:
-                throw ContainerizationError(.invalidState, message: "BuildKit container '\(builderContainerId)' is stopping")
+                throw ContainerizationError(.invalidState, message: "BuildKit container '\(containerID)' is stopping")
             case .unknown:
                 logger?.warning("Builder container has unknown state, recreating it")
                 try? await containerClient.withClient { try await $0.delete(id: container.id) }
-                return try await createAndStartBuilder(logger: logger)
+                return try await createAndStartBuilder(qemu: qemu, logger: logger)
             @unknown default:
-                throw ContainerizationError(.invalidState, message: "BuildKit container '\(builderContainerId)' is in an unsupported state")
+                throw ContainerizationError(.invalidState, message: "BuildKit container '\(containerID)' is in an unsupported state")
             }
         }
 
         return container
     }
 
-    private func createAndStartBuilder(logger: Logger?) async throws -> ContainerSnapshot {
+    /// Returns the container ID for a given mode.
+    /// QEMU-mode builder uses a distinct ID (base ID + "-qemu") so both builders can
+    /// coexist and be looked up independently.
+    private func resolvedContainerId(qemu: Bool) -> String {
+        qemu ? "\(builderContainerId)-qemu" : builderContainerId
+    }
+
+    private func createAndStartBuilder(qemu: Bool, logger: Logger?) async throws -> ContainerSnapshot {
+        let containerID = resolvedContainerId(qemu: qemu)
         let exportsMount = appSupportURL.appendingPathComponent("builder")
         if !FileManager.default.fileExists(atPath: exportsMount.path) {
             try FileManager.default.createDirectory(at: exportsMount, withIntermediateDirectories: true)
@@ -210,24 +337,27 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
         let builderImage = containerSystemConfig.build.image
         let builderPlatform = Platform(arch: "arm64", os: "linux", variant: "v8")
-        let useRosetta = containerSystemConfig.build.rosetta
+        // QEMU mode: register binfmt handlers inside the VM kernel for all foreign
+        // architectures (s390x, ppc64le, riscv64, etc.).  Rosetta is disabled because
+        // it and QEMU binfmt registration are mutually exclusive in the builder shim.
+        let useRosetta = qemu ? false : containerSystemConfig.build.rosetta
 
         let image = try await ClientImage.fetch(reference: builderImage, platform: builderPlatform, containerSystemConfig: containerSystemConfig)
         _ = try await image.getCreateSnapshot(platform: builderPlatform)
         let imageDesc = ImageDescription(reference: builderImage, descriptor: image.descriptor)
 
         let imageConfig = try await image.config(for: builderPlatform).config
-
         guard let defaultNetwork = try await networkClient.withClient({ try await $0.builtin }) else {
             throw ContainerizationError(.invalidState, message: "default network is not present")
         }
         let nameserver = IPv4Address(defaultNetwork.status.ipv4Subnet.lower.value + 1).description
 
         let config = try Self.builderContainerConfiguration(
-            builderContainerId: builderContainerId,
+            builderContainerId: containerID,
             imageDescription: imageDesc,
             imageEnv: imageConfig?.env,
             useRosetta: useRosetta,
+            qemu: qemu,
             builderCPUs: builderCPUs,
             builderMemory: builderMemory,
             exportsMountPath: exportsMount.path,
@@ -237,8 +367,8 @@ struct ClientBuilderService: ClientBuilderProtocol {
 
         let kernel = try await ClientKernel.getDefaultKernel(for: .current)
         try await containerClient.withClient { try await $0.create(configuration: config, options: .default, kernel: kernel) }
-        try await startBuildKit(containerId: builderContainerId)
-        return try await containerClient.withClient { try await $0.get(id: builderContainerId) }
+        try await startBuildKit(containerId: containerID)
+        return try await containerClient.withClient { try await $0.get(id: containerID) }
     }
 
     /// Pure construction of the BuildKit guest's ContainerConfiguration — no real service
@@ -249,6 +379,7 @@ struct ClientBuilderService: ClientBuilderProtocol {
         imageDescription: ImageDescription,
         imageEnv: [String]?,
         useRosetta: Bool,
+        qemu: Bool,
         builderCPUs: Int64,
         builderMemory: String,
         exportsMountPath: String,
@@ -257,7 +388,13 @@ struct ClientBuilderService: ClientBuilderProtocol {
     ) throws -> ContainerConfiguration {
         let processConfig = ProcessConfiguration(
             executable: "/usr/local/bin/container-builder-shim",
-            arguments: ["--debug", "--vsock", useRosetta ? nil : "--enable-qemu"].compactMap { $0 },
+            // `--enable-qemu` depends solely on which builder instance this is — NOT on
+            // `useRosetta`, which independently reflects the user's own rosetta config and
+            // can be false even for the non-qemu builder (e.g. `build.rosetta` disabled).
+            // Deriving it from `!useRosetta` would register QEMU binfmt handlers on the
+            // Rosetta builder too in that case, which this type's own doc comment says are
+            // mutually exclusive in the shim.
+            arguments: ["--debug", "--vsock", qemu ? "--enable-qemu" : nil].compactMap { $0 },
             environment: imageEnv ?? [],
             workingDirectory: "/",
             terminal: false,

--- a/Sources/socktainer/Clients/ClientImageService.swift
+++ b/Sources/socktainer/Clients/ClientImageService.swift
@@ -1,6 +1,7 @@
 import ContainerAPIClient
 import ContainerPersistence
 import Containerization
+import ContainerizationError
 import ContainerizationOCI
 import Foundation
 import Logging
@@ -25,6 +26,13 @@ protocol ClientImageProtocol: Sendable {
         PullProgress, Error
     >
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
+        String, Error
+    >
+    /// Pushes the full manifest list/index for `reference`, unconditionally — unlike `push`,
+    /// never narrows to a single platform. `podman manifest push` means "push the whole list";
+    /// `resolvedPushPlatform`'s single-available-platform narrowing (meant for `docker push`'s
+    /// different "push what's actually here" semantics) would silently defeat that intent.
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     >
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64)
@@ -194,7 +202,11 @@ struct ClientImageService: ClientImageProtocol {
             let ref = img.reference.trimmingCharacters(in: .whitespacesAndNewlines)
             let isDigest = ref.contains("@sha256:")
             let isInfra = Utility.isInfraImage(name: ref, builderImage: containerSystemConfig.build.image, initImage: containerSystemConfig.vminit.image)
-            return isDigest || !isInfra
+            // A split build's scratch tags (`BuildRoute.performBuild`) are deleted once
+            // merged into the requested tag — this only hides one that's still around
+            // because the process crashed mid-build before that cleanup ran.
+            let isBuildSplitScratchTag = ref.contains(BuildRoute.scratchTagPrefix)
+            return !isBuildSplitScratchTag && (isDigest || !isInfra)
         }
         return filteredImages
     }
@@ -344,35 +356,84 @@ struct ClientImageService: ClientImageProtocol {
         }
     }
 
+    /// Shared by `push`/`pushManifestList`: normalizes `reference` (for logging/pushStream)
+    /// and resolves the actual stored image, mapping a lookup failure to
+    /// `ClientImageError.notFound`.
+    private func resolveForPush(reference: String, notFoundContext: String, logger: Logger) async throws -> (
+        normalizedReference: String, image: ClientImage
+    ) {
+        let normalizedReference = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
+        let image: ClientImage
+        do {
+            // `ClientImage.get` (via `_search`) already tries both `reference` as given and its
+            // normalized form against each stored image's reference — passing only the
+            // normalized form here collapses both attempts into the same string, missing
+            // images tagged verbatim without a registry/library prefix (e.g. anything from
+            // `podman build`, which `ClientImage.load` tags as `<name>:latest`, not
+            // `docker.io/library/<name>:latest`).
+            image = try await ClientImage.get(reference: reference, containerSystemConfig: containerSystemConfig)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            logger.error("\(notFoundContext) not found: \(normalizedReference)")
+            throw ClientImageError.notFound(id: normalizedReference)
+        }
+        return (normalizedReference, image)
+    }
+
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<
         String, Error
     > {
-        let normalizedReference = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
-
-        logger.info("Pushing image reference: \(normalizedReference)")
-
-        let image: ClientImage
-        do {
-            image = try await ClientImage.get(reference: normalizedReference, containerSystemConfig: containerSystemConfig)
-        } catch {
-            logger.error("Image not found: \(normalizedReference)")
-            throw ClientImageError.notFound(id: normalizedReference)
-        }
+        logger.info("Pushing image reference: \(reference)")
+        let (normalizedReference, image) = try await resolveForPush(reference: reference, notFoundContext: "Image", logger: logger)
 
         logger.debug("Image reference from ClientImage: \(image.reference)")
 
         let effectivePlatform = try await resolvedPushPlatform(for: image, requestedPlatform: platform, logger: logger)
+        return Self.pushStream(normalizedReference: normalizedReference, image: image, platform: effectivePlatform, containerSystemConfig: containerSystemConfig, logger: logger)
+    }
 
-        return AsyncThrowingStream { continuation in
-            let platformDesc = effectivePlatform?.description ?? "default"
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<
+        String, Error
+    > {
+        logger.info("Pushing manifest list: \(reference)")
+        let (normalizedReference, image) = try await resolveForPush(reference: reference, notFoundContext: "Manifest list", logger: logger)
+
+        return Self.pushStream(normalizedReference: normalizedReference, image: image, platform: nil, containerSystemConfig: containerSystemConfig, logger: logger)
+    }
+
+    /// Real vendored-framework `RequestScheme.auto` support (`isInternalHost`) parses the
+    /// reference's domain as a bare IPv4 literal to decide if it's a private/local address —
+    /// but a domain with an explicit port (e.g. a local test registry at `192.168.x.x:5000`,
+    /// a common way to reach one) fails that parse outright, so `.auto` falls back to `.https`
+    /// and the push then fails against a plain-HTTP registry ("bad protocol version"). Reuses
+    /// the same (otherwise-correct) `isInternalHost` check, just with the port stripped first.
+    private static func resolvedScheme(for reference: String, containerSystemConfig: ContainerSystemConfig) -> RequestScheme {
+        guard let domain = try? Reference.parse(reference).domain else { return .auto }
+        let host: String
+        if domain.hasPrefix("["), let closingBracket = domain.firstIndex(of: "]") {
+            // A bracketed IPv6 literal (e.g. "[::1]:5000") contains colons of its own —
+            // splitting on the first ":" would mangle it. Keep the brackets; `isInternalHost`
+            // only recognizes bare IPv4 literals anyway, so an IPv6 host falls through to
+            // `.https` either way, but shouldn't be handed a garbled string to get there.
+            host = String(domain[...closingBracket])
+        } else {
+            host = domain.split(separator: ":", maxSplits: 1).first.map(String.init) ?? domain
+        }
+        return RequestScheme.isInternalHost(host: host, internalDnsDomain: containerSystemConfig.dns.domain) ? .http : .https
+    }
+
+    private static func pushStream(
+        normalizedReference: String, image: ClientImage, platform: Platform?, containerSystemConfig: ContainerSystemConfig, logger: Logger
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let platformDesc = platform?.description ?? "default"
             logger.info("Starting to push image \(normalizedReference) for platform \(platformDesc)")
             logger.info("Retrieved image object with reference: \(image.reference)")
             continuation.yield("Trying to push \(normalizedReference)")
             Task {
                 do {
                     try await image.push(
-                        platform: effectivePlatform,
-                        scheme: .auto,
+                        platform: platform,
+                        scheme: resolvedScheme(for: image.reference, containerSystemConfig: containerSystemConfig),
                         containerSystemConfig: containerSystemConfig,
                         progressUpdate: { progressEvents in
                             for event in progressEvents {
@@ -605,7 +666,7 @@ struct ClientImageService: ClientImageProtocol {
         let extractedPath = tempDir.appendingPathComponent("extracted")
         try FileManager.default.createDirectory(at: extractedPath, withIntermediateDirectories: true)
 
-        try ArchiveUtility.extract(tarPath: tarballPath, to: extractedPath)
+        try ArchiveUtility.extract(tarPath: tarballPath, to: extractedPath, logger: logger)
 
         // `docker buildx build --load`, the containerd "docker" exporter, and
         // `docker save` on modern Docker emit a tarball that is already a valid

--- a/Sources/socktainer/Clients/ClientManifestService.swift
+++ b/Sources/socktainer/Clients/ClientManifestService.swift
@@ -1,0 +1,381 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Containerization
+import ContainerizationError
+import ContainerizationOCI
+import Crypto
+import Foundation
+import Logging
+
+enum ClientManifestError: Error {
+    case notFound(name: String)
+    case alreadyExists(name: String)
+}
+
+struct RetagState: Sendable {
+    let reference: String
+    let priorDescriptor: Descriptor?
+}
+
+/// Backs the `podman manifest` command family, `podman build --manifest`, and manifest-aware
+/// push (`podman push <image> <destination>` / `podman manifest push`). Routes depend on this
+/// protocol rather than `ClientManifestService` directly so tests can inject a mock instead of a
+/// real `ImageStore`/XPC-backed instance — see the `Mock...` types alongside each route's tests.
+protocol ClientManifestServiceProtocol: Sendable {
+    func exists(name: String) async throws -> Bool
+    func digest(for name: String) async throws -> String
+    func inspect(name: String) async throws -> Index
+    @discardableResult
+    func create(name: String, images: [String], logger: Logger, amend: Bool) async throws -> String
+    @discardableResult
+    func mergeAndTag(name: String, images: [String], logger: Logger) async throws -> String
+    @discardableResult
+    func add(name: String, images: [String], logger: Logger) async throws -> String
+    @discardableResult
+    func removeDigest(name: String, digest: String) async throws -> String
+    @discardableResult
+    func addBuiltImage(name: String, builtReference: String, logger: Logger) async throws -> String
+    func delete(name: String) async throws
+    func retagForPush(name: String, destination: String) async throws -> (reference: String, priorState: RetagState?)
+    func untagPushDestination(_ state: RetagState) async throws
+}
+
+/// Backs the `podman manifest` command family and `podman build --manifest`.
+///
+/// A manifest list is modeled as an ordinary tagged reference whose descriptor
+/// points at an OCI image index blob — there is no separate bookkeeping layer.
+/// "The current members of `name`" is always just "decode whatever index `name`
+/// currently points at" (`image.index().manifests`); create/add/remove all work
+/// by writing a new index blob and re-pointing the tag at it.
+///
+/// This reuses the same two framework entry points `ClientImageService.load`
+/// already relies on for `docker load`/`import`: a fresh `ImageStore(path:)` over
+/// the daemon's own Application Support directory, and a `LocalContentStore` at
+/// its `content` subdirectory for writing new blobs. Both are just files on disk
+/// under a path convention the framework itself uses internally, so a second,
+/// independent instance of each sees exactly what the daemon's own copy does.
+///
+/// Known limitation: `ImageStore`'s reference table (`state.json`) is a plain
+/// load-entire-map → mutate → overwrite-entire-map with no file lock, and no
+/// in-process lock added here would close that — the real contention is with
+/// the separate `container-apiserver` process writing the same file, not with
+/// concurrent requests inside this daemon. This is the same risk profile the
+/// existing `load`/`import` code already accepts; a real fix needs an flock on
+/// `state.json`, which the framework does not expose. The ingest-then-create
+/// pair below is kept back-to-back (no other `await` in between) to narrow, not
+/// close, the window where a freshly-written index blob is momentarily
+/// unreferenced and could theoretically be swept by a concurrent
+/// `cleanUpOrphanedBlobs()` (fired elsewhere in this codebase after every image
+/// delete).
+struct ClientManifestService: ClientManifestServiceProtocol {
+    let appSupportURL: URL
+    let containerSystemConfig: ContainerSystemConfig
+
+    private static let leafManifestMediaTypes: Set<String> = [
+        MediaTypes.imageManifest,
+        MediaTypes.dockerManifest,
+    ]
+
+    private func imageStore() throws -> ImageStore {
+        try ImageStore(path: appSupportURL)
+    }
+
+    private func contentStore() throws -> LocalContentStore {
+        try LocalContentStore(path: appSupportURL.appendingPathComponent("content"))
+    }
+
+    func exists(name: String) async throws -> Bool {
+        do {
+            // See `leafDescriptors`: pass the raw name so `ClientImage.get`'s own
+            // raw/normalized fallback isn't collapsed into two identical attempts.
+            let image = try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig)
+            return image.descriptor.mediaType == MediaTypes.index || image.descriptor.mediaType == MediaTypes.dockerManifestList
+        } catch let error as ContainerizationError where error.code == .notFound {
+            return false
+        }
+    }
+
+    /// Resolves `name`'s current index digest — used as the `Id` of the final completion
+    /// frame `manifest push` writes; real podman's client requires seeing one before it
+    /// accepts a clean stream close as success (see `DockerProgressFrame.manifestPushId`).
+    func digest(for name: String) async throws -> String {
+        do {
+            return try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig).digest
+        } catch let error as ContainerizationError where error.code == .notFound {
+            throw ClientManifestError.notFound(name: name)
+        }
+    }
+
+    func inspect(name: String) async throws -> Index {
+        let image: ClientImage
+        do {
+            image = try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            throw ClientManifestError.notFound(name: name)
+        }
+        return try await image.index()
+    }
+
+    /// `podman manifest create <name> [images...]`. Real podman errors on a duplicate `name`
+    /// unless `--amend` is given (confirmed against `ManifestCreate` in
+    /// `pkg/domain/infra/abi/manifest.go`: `CreateManifestList` returning
+    /// `storage.ErrDuplicateName` is only tolerated when `opts.Amend` is set) — `--amend` then
+    /// looks up the existing list and adds to it, it does not replace its contents. This
+    /// previously always overwrote unconditionally regardless of `amend`, which matched
+    /// neither of real podman's two actual behaviors.
+    @discardableResult
+    func create(name: String, images: [String], logger: Logger, amend: Bool) async throws -> String {
+        if try await referenceExists(name: name) {
+            guard amend else {
+                throw ClientManifestError.alreadyExists(name: name)
+            }
+            // `add` would happily append new members to ANY index-rooted reference, but
+            // `--amend` specifically means "update this existing MANIFEST LIST" — silently
+            // amending an ordinary single-platform image (which also happens to be
+            // index-rooted, per this framework's own tagging convention) would convert it
+            // into a multi-platform list the caller never asked for.
+            guard try await exists(name: name) else {
+                throw ContainerizationError(.invalidArgument, message: "\(name) exists but is not a manifest list")
+            }
+            return try await add(name: name, images: images, logger: logger)
+        }
+        return try await mergeAndTag(name: name, images: images, logger: logger)
+    }
+
+    /// Broader than `exists(name:)` (which is specifically "is `name` a manifest list," for
+    /// `podman manifest exists`) — this is `create`'s own duplicate-name check, which must
+    /// also catch an ORDINARY single-platform image already tagged `name`: real podman's
+    /// underlying storage layer rejects a duplicate name regardless of what kind of content
+    /// it already holds, and `exists(name:)` alone would miss that case (a non-index
+    /// descriptor doesn't match its media-type check), letting `mergeAndTag` silently
+    /// overwrite an unrelated existing image.
+    private func referenceExists(name: String) async throws -> Bool {
+        do {
+            _ = try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig)
+            return true
+        } catch let error as ContainerizationError where error.code == .notFound {
+            return false
+        }
+    }
+
+    /// Builds a fresh index from `images`' leaf manifests and tags `name` to point at it,
+    /// unconditionally — no existing-name check, unlike `create`. Used internally by
+    /// `BuildRoute`'s Rosetta/QEMU split build to merge the two partial builds' output into
+    /// the originally-requested tag: that's "replace whatever this tag pointed at," the same
+    /// semantics as an ordinary `docker build -t foo` re-using an existing tag, not
+    /// `podman manifest create`'s duplicate-name handling.
+    @discardableResult
+    func mergeAndTag(name: String, images: [String], logger: Logger) async throws -> String {
+        var manifests: [Descriptor] = []
+        var seenDigests = Set<String>()
+        for ref in images {
+            for descriptor in try await leafDescriptors(for: ref, logger: logger) where seenDigests.insert(descriptor.digest).inserted {
+                manifests.append(descriptor)
+            }
+        }
+        return try await writeIndexAndTag(name: name, manifests: manifests)
+    }
+
+    /// `podman manifest add <name> <image>` / the "update" operation of `PUT /libpod/manifests/{name}`.
+    @discardableResult
+    func add(name: String, images: [String], logger: Logger) async throws -> String {
+        var manifests = try await existingManifestsOrEmpty(name: name)
+        var seenDigests = Set(manifests.map(\.digest))
+        for ref in images {
+            for descriptor in try await leafDescriptors(for: ref, logger: logger) where seenDigests.insert(descriptor.digest).inserted {
+                manifests.append(descriptor)
+            }
+        }
+        return try await writeIndexAndTag(name: name, manifests: manifests)
+    }
+
+    /// `podman manifest remove <name> <digest>` / the "remove" operation of `PUT /libpod/manifests/{name}`.
+    @discardableResult
+    func removeDigest(name: String, digest: String) async throws -> String {
+        var manifests = try await inspect(name: name).manifests
+        let normalizedDigest = digest.hasPrefix("sha256:") ? digest : "sha256:\(digest)"
+        let countBefore = manifests.count
+        manifests.removeAll { $0.digest == normalizedDigest }
+        guard manifests.count < countBefore else {
+            throw ContainerizationError(.invalidArgument, message: "\(normalizedDigest) is not a member of \(name)")
+        }
+        return try await writeIndexAndTag(name: name, manifests: manifests)
+    }
+
+    /// Called from `build --manifest <name>` after a multi-platform build has already produced and
+    /// tagged its own index at `builtReference`. Merges into `name`'s existing index if present
+    /// (union by digest, matching real podman's "creates a manifest list if it does not exist"
+    /// semantics for the build flag), otherwise just tags the freshly-built index directly.
+    @discardableResult
+    func addBuiltImage(name: String, builtReference: String, logger: Logger) async throws -> String {
+        var manifests = try await existingManifestsOrEmpty(name: name)
+        var seenDigests = Set(manifests.map(\.digest))
+        let newDescriptors = try await leafDescriptors(for: builtReference, logger: logger)
+        manifests.append(contentsOf: newDescriptors.filter { seenDigests.insert($0.digest).inserted })
+        return try await writeIndexAndTag(name: name, manifests: manifests)
+    }
+
+    /// Shared by `add`/`addBuiltImage`: an absent manifest list starts from an empty index (matching
+    /// real podman's "creates a manifest list if it does not exist" semantics), but any other
+    /// failure (a corrupt/undecodable existing index, a storage I/O error, etc.) must propagate —
+    /// silently treating those the same as "doesn't exist yet" would let a transient read failure
+    /// clobber a real, valid manifest list with a fresh, near-empty one.
+    private func existingManifestsOrEmpty(name: String) async throws -> [Descriptor] {
+        do {
+            return try await inspect(name: name).manifests
+        } catch ClientManifestError.notFound {
+            return []
+        }
+    }
+
+    /// `podman manifest rm <name>` — deletes the whole tag, not a single member.
+    func delete(name: String) async throws {
+        // See `leafDescriptors`/`exists`/`retagForPush`: resolve via `ClientImage.get` (its
+        // raw/normalized fallback search) first rather than deleting a re-normalized guess.
+        // `imageStore().delete`'s own reference lookup is an exact string match against
+        // however the reference was ACTUALLY stored, which for a bare-tagged reference
+        // (e.g. a locally-built image, or a build-split scratch tag with no registry/library
+        // prefix) differs from its normalized form — deleting the normalized guess silently
+        // no-ops instead of removing the real entry.
+        let image: ClientImage
+        do {
+            image = try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            throw ClientManifestError.notFound(name: name)
+        }
+        // `performCleanup: false` explicitly (its own default, but stated here the same way
+        // `LiveImageDeletionStore` does for `ClientImage.delete`) — this reference's blobs may
+        // still be referenced by another tag (e.g. after a `mergeAndTag` merge), so this must
+        // never sweep content, only remove the tag itself.
+        try await imageStore().delete(reference: image.reference, performCleanup: false)
+    }
+
+    /// `podman manifest push <name> <destination>`. Apple's `ImageStore.push`/`ClientImage.push`
+    /// always push to the same reference they resolve from — there is no separate
+    /// local-name-vs-remote-destination split in that primitive. When `destination` differs from
+    /// `name`, re-tag the local index under `destination` first (a fast, local, metadata-only
+    /// operation) so the subsequent network push — which must go through the real daemon's
+    /// `ImagesService` via `ClientImage.push`, since only it implements registry communication —
+    /// resolves and pushes the right content.
+    ///
+    /// Returns the reference to push and, when a tag change actually happened, what `destination`
+    /// pointed at beforehand (`nil` if it didn't exist). The caller MUST restore that prior state
+    /// once the push finishes (success or failure) via `untagPushDestination` — otherwise a
+    /// pre-existing `destination` tag gets permanently clobbered, or (if it didn't exist before) a
+    /// stray tag leaks into image listings and outlives the single push it existed for.
+    /// `performCleanup` stays `false` throughout since the underlying index blob is still
+    /// referenced by `name`'s own tag.
+    func retagForPush(name: String, destination: String) async throws -> (reference: String, priorState: RetagState?) {
+        // Resolve to the reference as ACTUALLY stored: `ImageStore.tag`'s own lookup
+        // (`ReferenceManager.get`) is an exact string match against the stored reference,
+        // with none of `ClientImage.get`'s `_search` raw/normalized fallback — reconstructing
+        // a normalized guess here instead of resolving first would silently fail to match an
+        // image tagged bare by the builder/loader (`<name>:latest`, no registry/library prefix).
+        let existingImage: ClientImage
+        do {
+            existingImage = try await ClientImage.get(reference: name, containerSystemConfig: containerSystemConfig)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            throw ClientImageError.notFound(id: name)
+        }
+        let storedName = existingImage.reference
+        let normalizedDestination = try ClientImage.normalizeReference(destination, containerSystemConfig: containerSystemConfig)
+        guard normalizedDestination != storedName else {
+            return (storedName, nil)
+        }
+
+        let priorDescriptor: Descriptor?
+        do {
+            // Same reasoning as `leafDescriptors`/`exists`: raw, not pre-normalized. But
+            // `_search`'s raw-or-normalized fallback means this can resolve to some OTHER
+            // stored reference than `normalizedDestination` (e.g. an unrelated image
+            // already tagged bare under the same raw string) — that isn't what
+            // `imageStore().tag` below is about to overwrite, so it isn't real "prior
+            // state" for `normalizedDestination` and must not be captured for restore.
+            let existing = try await ClientImage.get(reference: destination, containerSystemConfig: containerSystemConfig)
+            priorDescriptor = existing.reference == normalizedDestination ? existing.descriptor : nil
+        } catch let error as ContainerizationError where error.code == .notFound {
+            priorDescriptor = nil
+        }
+
+        _ = try await imageStore().tag(existing: storedName, new: normalizedDestination)
+        return (normalizedDestination, RetagState(reference: normalizedDestination, priorDescriptor: priorDescriptor))
+    }
+
+    /// Undoes a re-tag created by `retagForPush`: restores what `destination` pointed at before
+    /// (if anything), or removes the tag entirely if it didn't exist beforehand. Caller's
+    /// responsibility to call this once the push has finished, success or failure.
+    func untagPushDestination(_ state: RetagState) async throws {
+        if let priorDescriptor = state.priorDescriptor {
+            try await imageStore().create(description: Image.Description(reference: state.reference, descriptor: priorDescriptor))
+        } else {
+            // `performCleanup: false` — see `delete(name:)`'s own comment on the same call.
+            try await imageStore().delete(reference: state.reference, performCleanup: false)
+        }
+    }
+
+    /// Resolves `ref` to the leaf (non-index) manifest descriptors it contributes. Adding a
+    /// reference that is itself multi-platform expands to all of its platform members — this is
+    /// also what keeps every stored member a leaf manifest rather than a nested index: nested
+    /// indexes are invisible to `Image.referencedDigests()`'s GC accounting (it decodes each
+    /// member as a `Manifest`, silently skipping anything that isn't one), so their own children
+    /// would never be protected from `cleanUpOrphanedBlobs()`.
+    private func leafDescriptors(for ref: String, logger: Logger) async throws -> [Descriptor] {
+        // `ClientImage.get` (via `_search`) already tries both `ref` as given and its
+        // normalized form against each stored image's reference — pre-normalizing here
+        // and passing only that would collapse both attempts into the same string,
+        // missing images tagged verbatim without a registry/library prefix (e.g. a
+        // just-built image from `build --manifest`, which `ClientImage.load` tags as
+        // `<uuid>:latest`, not `docker.io/library/<uuid>:latest`).
+        let normalized = try ClientImage.normalizeReference(ref, containerSystemConfig: containerSystemConfig)
+        let image: ClientImage
+        do {
+            image = try await ClientImage.get(reference: ref, containerSystemConfig: containerSystemConfig)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            throw ClientImageError.notFound(id: normalized)
+        }
+        let index = try await image.index()
+        let descriptors = index.manifests.filter { descriptor in
+            guard descriptor.annotations?["vnd.docker.reference.type"] != "attestation-manifest" else { return false }
+            guard Self.leafManifestMediaTypes.contains(descriptor.mediaType) else {
+                logger.warning("Skipping non-leaf manifest member \(descriptor.digest) (mediaType \(descriptor.mediaType)) from \(normalized)")
+                return false
+            }
+            return true
+        }
+        guard !descriptors.isEmpty else {
+            throw ContainerizationError(.invalidArgument, message: "\(ref) has no leaf manifests to add")
+        }
+        return descriptors
+    }
+
+    /// Writes a new OCI index blob and (re)tags `name` to point at it. Ingest and create are kept
+    /// adjacent (no other `await` in between) to minimize, not eliminate, the window described in
+    /// this type's doc comment.
+    @discardableResult
+    private func writeIndexAndTag(name: String, manifests: [Descriptor]) async throws -> String {
+        let normalized = try ClientImage.normalizeReference(name, containerSystemConfig: containerSystemConfig)
+        let index = Index(manifests: manifests)
+        let data = try JSONEncoder().encode(index)
+
+        // Computed independently rather than captured from inside the ingest closure
+        // (which is @Sendable — mutating a captured var across it isn't allowed).
+        // Matches exactly what ContentWriter.write does internally, so the digest
+        // here is the same one the file ends up named by.
+        let digest = SHA256.hash(data: data)
+        let descriptor = Descriptor(mediaType: MediaTypes.index, digest: digest.digestString, size: Int64(data.count))
+
+        let store = try contentStore()
+        _ = try await store.ingest { tempDir in
+            let writer = try ContentWriter(for: tempDir)
+            try writer.write(data)
+        }
+
+        // No await between ingest completing and create tagging it — this adjacency is the
+        // entire GC-window mitigation described above. Between these two lines the blob is
+        // written but unreferenced by any tag; a concurrent cleanUpOrphanedBlobs() elsewhere
+        // in this codebase (fires after every image delete) could otherwise sweep it. Keep
+        // any future addition here (logging, metrics, etc.) after `create`, not between.
+        try await imageStore().create(description: Image.Description(reference: normalized, descriptor: descriptor))
+        return descriptor.digest
+    }
+}

--- a/Sources/socktainer/Clients/ClientManifestService.swift
+++ b/Sources/socktainer/Clients/ClientManifestService.swift
@@ -220,13 +220,16 @@ struct ClientManifestService: ClientManifestServiceProtocol {
     /// digest — removes every requested digest via a SINGLE read-modify-write instead of one
     /// `removeDigest` call per digest, which would re-`inspect`/re-tag `name` once per digest
     /// and leave a window between each pair of removals where a concurrent request could see
-    /// (or race against) a partially-modified list. The caller has already validated every
-    /// digest is a current member before calling this — that's still a separate concern from
-    /// the atomicity this collapses.
+    /// (or race against) a partially-modified list.
     @discardableResult
     func removeDigests(name: String, digests: [String]) async throws -> String {
         var manifests = try await inspect(name: name).manifests
+        let currentDigests = Set(manifests.map(\.digest))
         let digestSet = Set(digests)
+        guard digestSet.isSubset(of: currentDigests) else {
+            let missing = digestSet.subtracting(currentDigests)
+            throw ContainerizationError(.invalidArgument, message: "\(missing.sorted().joined(separator: ", ")) not a member of \(name)")
+        }
         manifests.removeAll { digestSet.contains($0.digest) }
         return try await writeIndexAndTag(name: name, manifests: manifests)
     }

--- a/Sources/socktainer/Clients/ClientManifestService.swift
+++ b/Sources/socktainer/Clients/ClientManifestService.swift
@@ -34,6 +34,8 @@ protocol ClientManifestServiceProtocol: Sendable {
     @discardableResult
     func removeDigest(name: String, digest: String) async throws -> String
     @discardableResult
+    func removeDigests(name: String, digests: [String]) async throws -> String
+    @discardableResult
     func addBuiltImage(name: String, builtReference: String, logger: Logger) async throws -> String
     func delete(name: String) async throws
     func retagForPush(name: String, destination: String) async throws -> (reference: String, priorState: RetagState?)
@@ -193,12 +195,39 @@ struct ClientManifestService: ClientManifestServiceProtocol {
     @discardableResult
     func removeDigest(name: String, digest: String) async throws -> String {
         var manifests = try await inspect(name: name).manifests
-        let normalizedDigest = digest.hasPrefix("sha256:") ? digest : "sha256:\(digest)"
+        // A bare hex digest (no algorithm prefix) is assumed sha256, matching real podman's
+        // own convention — but a digest already carrying a DIFFERENT algorithm's prefix
+        // (e.g. `sha512:...`) must not be blindly re-prefixed into `sha256:sha512:...`, a
+        // malformed digest that could never match a real member and would silently succeed as
+        // "not found" instead of surfacing the actual problem (an unsupported algorithm).
+        let normalizedDigest: String
+        if digest.hasPrefix("sha256:") {
+            normalizedDigest = digest
+        } else if digest.contains(":") {
+            throw ContainerizationError(.invalidArgument, message: "\(digest) is not a supported digest (only sha256 is)")
+        } else {
+            normalizedDigest = "sha256:\(digest)"
+        }
         let countBefore = manifests.count
         manifests.removeAll { $0.digest == normalizedDigest }
         guard manifests.count < countBefore else {
             throw ContainerizationError(.invalidArgument, message: "\(normalizedDigest) is not a member of \(name)")
         }
+        return try await writeIndexAndTag(name: name, manifests: manifests)
+    }
+
+    /// The "remove" operation of `PUT /libpod/manifests/{name}` when it carries more than one
+    /// digest — removes every requested digest via a SINGLE read-modify-write instead of one
+    /// `removeDigest` call per digest, which would re-`inspect`/re-tag `name` once per digest
+    /// and leave a window between each pair of removals where a concurrent request could see
+    /// (or race against) a partially-modified list. The caller has already validated every
+    /// digest is a current member before calling this — that's still a separate concern from
+    /// the atomicity this collapses.
+    @discardableResult
+    func removeDigests(name: String, digests: [String]) async throws -> String {
+        var manifests = try await inspect(name: name).manifests
+        let digestSet = Set(digests)
+        manifests.removeAll { digestSet.contains($0.digest) }
         return try await writeIndexAndTag(name: name, manifests: manifests)
     }
 

--- a/Sources/socktainer/Models/LibpodContainerCreateRequest.swift
+++ b/Sources/socktainer/Models/LibpodContainerCreateRequest.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+struct LibpodContainerCreateRequest: Content {
+    let image: String
+    let command: [String]?
+    let remove: Bool?
+    let name: String?
+}

--- a/Sources/socktainer/Models/LibpodVersionInfo.swift
+++ b/Sources/socktainer/Models/LibpodVersionInfo.swift
@@ -1,0 +1,12 @@
+import Vapor
+
+struct LibpodVersionInfo: Content {
+    let APIVersion: String
+    let Arch: String
+    let BuildTime: String
+    let GitCommit: String
+    let GoVersion: String
+    let MinAPIVersion: String
+    let Os: String
+    let Version: String
+}

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -13,19 +13,26 @@ import TerminalProgress
 import Vapor
 
 struct BuildRoute: RouteCollection {
+    /// Prefix for the mixed-platform split build's scratch tags (see `performBuild`) — also
+    /// used by `ClientImageService.list()` to hide one that survives a crash mid-build,
+    /// before the normal cleanup runs.
+    static let scratchTagPrefix = "socktainer-buildsplit-"
 
     let client: ClientContainerProtocol
     let builderClient: ClientBuilderProtocol
     let systemConfig: ContainerSystemConfig
+    let manifestClient: ClientManifestServiceProtocol
 
-    init(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig) {
+    init(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig, manifestClient: ClientManifestServiceProtocol) {
         self.client = client
         self.builderClient = builderClient
         self.systemConfig = systemConfig
+        self.manifestClient = manifestClient
     }
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/build", use: BuildRoute.handler(client: client, builderClient: builderClient, systemConfig: systemConfig))
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/build", use: BuildRoute.handler(client: client, builderClient: builderClient, systemConfig: systemConfig, manifestClient: manifestClient))
 
     }
 
@@ -57,6 +64,7 @@ struct RESTBuildQuery: Vapor.Content {
     var target: String?  // target stage to build
     var outputs: String?  // output destination
     var version: String?  // API version
+    var manifest: String?  // podman: add the built image(s) to this named manifest list, creating it if needed
 
     init() {
         self.dockerfile = "Dockerfile"
@@ -72,6 +80,68 @@ struct RESTBuildQuery: Vapor.Content {
 }
 
 extension BuildRoute {
+    /// Recovers every value of the repeated `platform` query parameter from the raw
+    /// query string.
+    ///
+    /// Real podman sends `--platform a,b` as the SAME query key repeated once per
+    /// platform (`pkg/bindings/images/build.go`: `params.Del("platform")` then
+    /// `params.Add("platform", ...)` per platform) — i.e. `?platform=linux/arm64&platform=linux/amd64`,
+    /// not one comma-joined value. `Vapor.Content` decoding a repeated key into a
+    /// scalar `String?` field silently keeps only the last occurrence, dropping every
+    /// platform but one.
+    static func parseAllPlatformQueryValues(from queryString: String?) -> [String] {
+        allQueryValues(named: "platform", from: queryString)
+    }
+
+    /// Resolves the `t` (tag) query parameter to a concrete target image name.
+    ///
+    /// Real podman sends `t=` (present, but empty) when no explicit tag is given — treating
+    /// that the same as "absent" (falling back, e.g. to a generated name) requires checking
+    /// emptiness, not just nil, or the build ends up tagged as the literal empty string.
+    static func resolvedTargetImageName(_ tag: String?, fallback: String) -> String {
+        tag?.isEmpty == false ? tag! : fallback
+    }
+
+    /// Parses the `dockerfile` query parameter.
+    ///
+    /// Docker-compat clients send a plain path (e.g. `Dockerfile`). Real podman
+    /// clients send it JSON-array-encoded (e.g. `["Dockerfile"]`, since buildah
+    /// supports multiple Containerfiles). Only the first element is used —
+    /// multi-Containerfile builds aren't supported here yet.
+    static func parseDockerfileQueryParam(_ value: String, logger: Logger? = nil) throws -> String {
+        // An empty top-level value means "no dockerfile was specified" — the same as the
+        // param being omitted entirely (falls back to "Dockerfile" upstream) or JSON-decoding
+        // to an empty array (below). `sanitizedDockerfilePath`'s own empty-value rejection is
+        // for when a caller explicitly names a specific-but-degenerate path (e.g. an empty
+        // string as an array's first element) — a materially different situation from simply
+        // not asking for anything in particular.
+        guard !value.isEmpty else { return "Dockerfile" }
+        guard value.hasPrefix("[") else { return try sanitizedDockerfilePath(value) }
+        guard let data = value.data(using: .utf8),
+            let array = try? JSONDecoder().decode([String].self, from: data)
+        else {
+            throw Abort(.badRequest, reason: "dockerfile query param '\(value)' looks JSON-array-encoded but failed to decode")
+        }
+        guard let first = array.first else {
+            logger?.warning("dockerfile query param decoded to an empty array; falling back to 'Dockerfile'")
+            return "Dockerfile"
+        }
+        return try sanitizedDockerfilePath(first)
+    }
+
+    /// Rejects a dockerfile path that would escape the build context (absolute paths, or
+    /// `..` components) with a client error instead of silently substituting a different
+    /// file — the caller asked for a SPECIFIC dockerfile, so a fallback that builds
+    /// something else entirely without telling them is worse than just failing the request.
+    static func sanitizedDockerfilePath(_ value: String) throws -> String {
+        let isAbsolute = value.hasPrefix("/")
+        let hasTraversal = value.split(separator: "/").contains(where: { $0 == ".." })
+        guard !value.isEmpty, !isAbsolute, !hasTraversal else {
+            throw Abort(.badRequest, reason: "dockerfile path '\(value)' escapes the build context")
+        }
+        return value
+    }
+
     /// Parses a Docker API build query parameter (`buildargs` or `labels`).
     ///
     /// The Docker Engine API sends these as a JSON-encoded `{"KEY":"VALUE"}` map.
@@ -106,7 +176,8 @@ extension BuildRoute {
         try writeHandle.write(contentsOf: terminator)
     }
 
-    static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> Response
+    static func handler(client: ClientContainerProtocol, builderClient: ClientBuilderProtocol, systemConfig: ContainerSystemConfig, manifestClient: ClientManifestServiceProtocol)
+        -> @Sendable (Request) async throws -> Response
     {
         { req in
             var query = try req.query.decode(RESTBuildQuery.self)
@@ -123,21 +194,55 @@ extension BuildRoute {
             if query.version == nil { query.version = "1" }
 
             // Extract values with Docker-compliant defaults
-            let dockerfile = query.dockerfile!
-            let targetImageName = query.t ?? UUID().uuidString.lowercased()
+            let dockerfile = try BuildRoute.parseDockerfileQueryParam(query.dockerfile!, logger: req.logger)
+            let targetImageName = BuildRoute.resolvedTargetImageName(query.t, fallback: UUID().uuidString.lowercased())
             let quiet = query.q!
             let noCache = query.nocache!
             let pull = query.pull.map { ["1", "true", "yes", "on"].contains($0.lowercased()) } ?? false
             let target = query.target!
-            let platform = query.platform!
+            let platformQueryValues = BuildRoute.parseAllPlatformQueryValues(from: req.url.query)
+            let platformString = platformQueryValues.isEmpty ? query.platform! : platformQueryValues.joined(separator: ",")
             let memory = query.memory ?? 2_048_000_000  // 2GB default
+            let manifestName = query.manifest?.isEmpty == false ? query.manifest : nil
+
+            // Parse the platform parameter early so we can select the right builder mode
+            // before calling ensureReachable.  Supports comma-separated values, e.g.
+            //   --platform linux/arm64,linux/s390x
+            let parsedPlatforms: [Platform]
+            do {
+                if platformString.isEmpty {
+                    parsedPlatforms = [try Platform(from: "linux/\(Arch.hostArchitecture().rawValue)")]
+                } else {
+                    parsedPlatforms = try parseMultiPlatformString(platformString)
+                }
+            } catch {
+                throw Abort(
+                    .badRequest,
+                    reason:
+                        "Invalid platform specification '\(platformString)': expected os/architecture or comma-separated list (e.g. linux/arm64,linux/amd64): \(error.localizedDescription)"
+                )
+            }
+
+            // Platforms that are neither arm64 nor amd64 require the QEMU-enabled builder
+            // (a separate container named "buildkit-qemu") so the builder VM can emulate
+            // foreign instruction sets via Linux binfmt_misc registration. The two builder
+            // VMs are provisioned with mutually-exclusive emulation backends (Rosetta 2 vs.
+            // generic QEMU binfmt), so a request mixing e.g. arm64/amd64 with s390x is split
+            // and built against each backend independently, then merged — see performBuild.
+            let rosettaPlatforms = parsedPlatforms.filter { !platformRequiresQEMU($0) }
+            let qemuPlatforms = parsedPlatforms.filter { platformRequiresQEMU($0) }
+            let needsQEMU = !qemuPlatforms.isEmpty
+            let needsRosettaBuilder = !rosettaPlatforms.isEmpty
 
             do {
-                try await builderClient.ensureReachable(
-                    timeout: .seconds(3),
-                    retryInterval: .milliseconds(250),
-                    logger: req.logger
-                )
+                if needsRosettaBuilder {
+                    try await builderClient.ensureReachable(
+                        timeout: .seconds(3), retryInterval: .milliseconds(250), qemu: false, logger: req.logger)
+                }
+                if needsQEMU {
+                    try await builderClient.ensureReachable(
+                        timeout: .seconds(3), retryInterval: .milliseconds(250), qemu: true, logger: req.logger)
+                }
             } catch {
                 throw Abort(.serviceUnavailable, reason: "BuildKit builder is not running or reachable: \(error.localizedDescription)")
             }
@@ -223,7 +328,7 @@ extension BuildRoute {
                         try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true, attributes: nil)
 
                         do {
-                            try ArchiveUtility.extract(tarPath: tarPath, to: extractDir)
+                            try ArchiveUtility.extract(tarPath: tarPath, to: extractDir, logger: req.logger)
                         } catch {
                             req.logger.error("Tar extraction failed: \(error)")
 
@@ -261,11 +366,13 @@ extension BuildRoute {
                             noCache: noCache,
                             pull: pull,
                             target: target,
-                            platform: platform,
+                            platforms: parsedPlatforms,
                             memory: memory,
                             quiet: quiet,
                             builderClient: builderClient,
                             systemConfig: systemConfig,
+                            manifestClient: manifestClient,
+                            manifestName: manifestName,
                             writer: writer,
                             logger: req.logger
                         )
@@ -337,11 +444,13 @@ extension BuildRoute {
         noCache: Bool,
         pull: Bool,
         target: String,
-        platform: String,
+        platforms: [Platform],
         memory: Int,
         quiet: Bool,
         builderClient: ClientBuilderProtocol,
         systemConfig: ContainerSystemConfig,
+        manifestClient: ClientManifestServiceProtocol,
+        manifestName: String?,
         writer: BodyStreamWriter,
         logger: Logger
     ) async throws {
@@ -384,17 +493,6 @@ extension BuildRoute {
         // Send initial build started message
         sendStreamMessage("Step 1/1 : Starting build for \(targetImageName)")
 
-        let timeout: Duration = .seconds(300)
-
-        sendStreamMessage(" ---> Connecting to build daemon")
-
-        let builder = try await builderClient.connect(
-            timeout: timeout,
-            retryInterval: .seconds(1),
-            logger: logger
-        )
-        sendStreamMessage(" ---> Successfully connected to builder")
-
         // resolve the full path to the Dockerfile
         sendStreamMessage(" ---> Reading Dockerfile")
         let dockerfilePath = URL(fileURLWithPath: contextDir).appendingPathComponent(dockerfile).path
@@ -405,13 +503,8 @@ extension BuildRoute {
         }
 
         sendStreamMessage(" ---> Setting up build environment")
-
-        // Setup temp directory - must use the builder export path that's mounted in buildkit container
         let builderExportPath = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
             .appendingPathComponent("com.apple.container/builder")
-        let buildID = UUID().uuidString
-        let tempURL = builderExportPath.appendingPathComponent(buildID)
-        try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true, attributes: nil)
 
         // Validate and normalize image name
         let imageName: String = try {
@@ -420,7 +513,176 @@ extension BuildRoute {
             return parsedReference.description
         }()
 
-        // Setup exports - use BuildCommand approach
+        // The two builder VMs are provisioned with mutually-exclusive emulation backends
+        // (Rosetta 2 vs. generic QEMU binfmt) — a request mixing e.g. arm64/amd64 with
+        // s390x can't be satisfied by either builder alone without emulating everything
+        // through the slower one. Split into a build per backend, run them concurrently,
+        // and merge the results, rather than routing the whole request to whichever
+        // builder the least-native platform requires.
+        let rosettaPlatforms = platforms.filter { !platformRequiresQEMU($0) }
+        let qemuPlatforms = platforms.filter { platformRequiresQEMU($0) }
+
+        let builtReference: String
+        let builtDigest: String
+
+        if rosettaPlatforms.isEmpty || qemuPlatforms.isEmpty {
+            // Not a mixed request — single build, exactly as before.
+            let result = try await runSingleBuild(
+                dockerfile: dockerfile, dockerfileData: dockerfileData, contextDir: contextDir,
+                buildArgs: buildArgs, labels: labels, noCache: noCache, pull: pull, target: target,
+                platforms: platforms, qemu: !qemuPlatforms.isEmpty, tags: [imageName], quiet: quiet,
+                builderExportPath: builderExportPath, buildIDSuffix: "single",
+                builderClient: builderClient, systemConfig: systemConfig,
+                sendStreamMessage: sendStreamMessage, logger: logger
+            )
+            builtReference = result.reference
+            builtDigest = result.digest
+        } else {
+            sendStreamMessage(
+                " ---> Splitting build: \(rosettaPlatforms.map(\.description).joined(separator: ",")) via Rosetta, "
+                    + "\(qemuPlatforms.map(\.description).joined(separator: ",")) via QEMU"
+            )
+
+            // Scratch tags, unrelated to targetImageName's own reference syntax so there's
+            // no need to parse/rewrite it — cleaned up below once merged. Filtered out of
+            // `ClientImageService.list()` too (see `scratchTagPrefix`) so one that survives a
+            // crash mid-build (before cleanup runs) doesn't linger forever in image listings.
+            // Lowercased: Docker/OCI reference syntax requires a lowercase repository name,
+            // and UUID().uuidString is uppercase.
+            let requestID = UUID().uuidString.lowercased()
+            let rosettaTag = "\(Self.scratchTagPrefix)\(requestID)-rosetta"
+            let qemuTag = "\(Self.scratchTagPrefix)\(requestID)-qemu"
+
+            async let rosettaResult = runSingleBuild(
+                dockerfile: dockerfile, dockerfileData: dockerfileData, contextDir: contextDir,
+                buildArgs: buildArgs, labels: labels, noCache: noCache, pull: pull, target: target,
+                platforms: rosettaPlatforms, qemu: false, tags: [rosettaTag], quiet: quiet,
+                builderExportPath: builderExportPath, buildIDSuffix: "rosetta",
+                builderClient: builderClient, systemConfig: systemConfig,
+                sendStreamMessage: sendStreamMessage, logger: logger
+            )
+            async let qemuResult = runSingleBuild(
+                dockerfile: dockerfile, dockerfileData: dockerfileData, contextDir: contextDir,
+                buildArgs: buildArgs, labels: labels, noCache: noCache, pull: pull, target: target,
+                platforms: qemuPlatforms, qemu: true, tags: [qemuTag], quiet: quiet,
+                builderExportPath: builderExportPath, buildIDSuffix: "qemu",
+                builderClient: builderClient, systemConfig: systemConfig,
+                sendStreamMessage: sendStreamMessage, logger: logger
+            )
+
+            // Awaited as two separate statements (not `try await (rosettaResult, qemuResult)`)
+            // so BOTH are always fully settled before any cleanup runs — a tuple await short-
+            // circuits on the first throw, without waiting for the other side, which could
+            // still be mid-build (and mid-tagging `qemuTag`/`rosettaTag`) by the time cleanup
+            // below runs, racing a delete against a still-in-progress create.
+            let rosettaOutcome: Result<(reference: String, digest: String), Error>
+            do { rosettaOutcome = .success(try await rosettaResult) } catch { rosettaOutcome = .failure(error) }
+            let qemuOutcome: Result<(reference: String, digest: String), Error>
+            do { qemuOutcome = .success(try await qemuResult) } catch { qemuOutcome = .failure(error) }
+
+            switch (rosettaOutcome, qemuOutcome) {
+            case (.success(let rosetta), .success(let qemu)):
+                sendStreamMessage(" ---> Merging split builds into \(imageName)")
+                do {
+                    builtDigest = try await manifestClient.mergeAndTag(name: imageName, images: [rosetta.reference, qemu.reference], logger: logger)
+                } catch {
+                    // Both halves succeeded and are still tagged — clean up regardless of
+                    // whether the merge itself succeeded, or these scratch tags leak forever.
+                    try? await manifestClient.delete(name: rosettaTag)
+                    try? await manifestClient.delete(name: qemuTag)
+                    throw error
+                }
+                try? await manifestClient.delete(name: rosettaTag)
+                try? await manifestClient.delete(name: qemuTag)
+                builtReference = imageName
+            case (.failure(let rosettaError), .failure(let qemuError)):
+                // Both halves failed — the thrown error only ever carries one of them
+                // (matching the single-failure case below), so log the other rather than
+                // silently dropping a second, independently useful failure reason.
+                logger.error("QEMU build also failed (Rosetta error is being thrown): \(qemuError)")
+                try? await manifestClient.delete(name: rosettaTag)
+                try? await manifestClient.delete(name: qemuTag)
+                throw rosettaError
+            case (.failure(let error), _), (_, .failure(let error)):
+                // Best-effort clean up whichever scratch tag DID get written (a delete of one
+                // that was never created is a harmless no-op) before propagating — safe now
+                // that both outcomes are guaranteed settled.
+                try? await manifestClient.delete(name: rosettaTag)
+                try? await manifestClient.delete(name: qemuTag)
+                throw error
+            }
+        }
+
+        // `--manifest <name>`: fold the just-built image's platform(s) into a named manifest
+        // list, creating it if it doesn't exist yet — this is podman's real multi-arch
+        // workflow (see containers/podman#27211): a bare multi-platform build alone never
+        // produces one on the real client. Runs before the success message/stream close
+        // (not as a best-effort afterthought) so a registration failure is reported as a
+        // build failure instead of silently succeeding with an unregistered manifest.
+        if let manifestName {
+            sendStreamMessage(" ---> Adding to manifest list \(manifestName)")
+            try await manifestClient.addBuiltImage(name: manifestName, builtReference: builtReference, logger: logger)
+        }
+
+        // Real podman clients (pkg/bindings/images/build.go) only treat a clean
+        // stream EOF as success if they've already seen a "stream" line whose
+        // content starts with 12+ raw hex chars (`iidRegex`) — otherwise EOF is
+        // reported as `Error: decoding stream: EOF` even though the build (and
+        // this response) genuinely succeeded. Real buildah/podman builds emit
+        // the bare image ID as its own stream line for exactly this reason;
+        // mirror that here so the client recognizes success.
+        let bareID = builtDigest.hasPrefix("sha256:") ? String(builtDigest.dropFirst("sha256:".count)) : builtDigest
+        sendStreamMessage(bareID)
+
+        // Send success message in Docker API format
+        sendStreamMessage("Successfully built \(imageName)")
+
+        _ = writer.write(.end)
+    }
+
+    /// Runs a single BuildKit solve against one builder backend and loads/unpacks its
+    /// output, returning the resulting image's reference and digest. Factored out of
+    /// `performBuild` so a mixed-platform request can call this twice (once per backend)
+    /// instead of duplicating the whole connect/build/load/unpack sequence inline.
+    private static func runSingleBuild(
+        dockerfile: String,
+        dockerfileData: Data,
+        contextDir: String,
+        buildArgs: [String],
+        labels: [String],
+        noCache: Bool,
+        pull: Bool,
+        target: String,
+        platforms: [Platform],
+        qemu: Bool,
+        tags: [String],
+        quiet: Bool,
+        builderExportPath: URL,
+        buildIDSuffix: String,
+        builderClient: ClientBuilderProtocol,
+        systemConfig: ContainerSystemConfig,
+        sendStreamMessage: @escaping @Sendable (String) -> Void,
+        logger: Logger
+    ) async throws -> (reference: String, digest: String) {
+        let timeout: Duration = .seconds(300)
+
+        sendStreamMessage(" ---> Connecting to build daemon (\(qemu ? "QEMU" : "Rosetta") builder)")
+        let builder = try await builderClient.connect(
+            timeout: timeout,
+            retryInterval: .seconds(1),
+            qemu: qemu,
+            logger: logger
+        )
+        sendStreamMessage(" ---> Successfully connected to builder")
+
+        let buildID = "\(UUID().uuidString)-\(buildIDSuffix)"
+        let tempURL = builderExportPath.appendingPathComponent(buildID)
+        try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true, attributes: nil)
+        // The exported OCI tarball is only needed for the ClientImage.load below — clean up
+        // this per-build export directory on every exit path (success or failure) rather than
+        // leaking it under Application Support forever.
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
         let exports: [Builder.BuildExport] = try ["type=oci"].map { output in
             var exp = try Builder.BuildExport(from: output)
             if exp.destination == nil {
@@ -429,15 +691,6 @@ extension BuildRoute {
             return exp
         }
 
-        // Parse platforms
-        let platforms: Set<Platform> = {
-            guard platform.isEmpty else {
-                return [try! Platform(from: platform)]
-            }
-            return [try! Platform(from: "linux/\(Arch.hostArchitecture().rawValue)")]
-        }()
-
-        // Build configuration
         let config = ContainerBuild.Builder.BuildConfig(
             buildID: buildID,
             contentStore: RemoteContentStoreClient(),
@@ -449,9 +702,9 @@ extension BuildRoute {
             dockerignore: nil,
             labels: labels,
             noCache: noCache,
-            platforms: [Platform](platforms),
+            platforms: platforms,
             terminal: nil,  // No terminal for API
-            tags: [imageName],
+            tags: tags,
             target: target,
             quiet: quiet,
             exports: exports,
@@ -493,9 +746,12 @@ extension BuildRoute {
             try await image.unpack(platform: nil, progressUpdate: { _ in })
         }
 
-        // Send success message in Docker API format
-        sendStreamMessage("Successfully built \(imageName)")
-
-        _ = writer.write(.end)
+        // The loader tags images verbatim (e.g. `<uuid>:latest`, no `docker.io/library/`
+        // prefix) — the as-stored reference is what later lookups (retag, manifest merge)
+        // must use, not a re-derivation of the requested tag through normalization.
+        guard let firstImage = loaded.images.first else {
+            throw ContainerizationError(.internalError, message: "Build produced no image")
+        }
+        return (reference: firstImage.reference, digest: firstImage.digest)
     }
 }

--- a/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImageCreateRoute.swift
@@ -166,11 +166,11 @@ extension ImageCreateRoute {
     /// Import bodies are single-layer tarballs and can legitimately be several
     /// GB; this bounds them well above any real use while still rejecting a
     /// runaway or malicious upload before it fills disk.
-    private static let maxImportBodySize = 8 * 1024 * 1024 * 1024
+    static let maxImportBodySize = 8 * 1024 * 1024 * 1024
 
     /// Streams the request body to disk in chunks rather than buffering the
     /// whole tarball in memory first, enforcing `maxImportBodySize` as it goes.
-    private static func writeBodyToFile(_ body: Request.Body, at destination: URL) async throws {
+    static func writeBodyToFile(_ body: Request.Body, at destination: URL) async throws {
         guard FileManager.default.createFile(atPath: destination.path, contents: nil) else {
             throw Abort(.internalServerError, reason: "failed to create temporary file for import")
         }

--- a/Sources/socktainer/Routes/Images/ImagePushRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagePushRoute.swift
@@ -6,15 +6,18 @@ import Vapor
 
 struct ImagePushRoute: RouteCollection {
     let client: ClientImageProtocol
+    let manifestClient: ClientManifestServiceProtocol
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.POST, pattern: "/images/{name:.*}/push", use: ImagePushRoute.handler(client: client))
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/images/{name:.*}/push", use: ImagePushRoute.handler(client: client, manifestClient: manifestClient, useStreamKey: false))
     }
 }
 
 struct RESTImagePushQuery: Vapor.Content {
     let tag: String?
     let platform: String?
+    let destination: String?
 }
 
 extension ImagePushRoute {
@@ -30,7 +33,7 @@ extension ImagePushRoute {
         return try parsedReference.withTag(tag).description
     }
 
-    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+    static func handler(client: ClientImageProtocol, manifestClient: ClientManifestServiceProtocol, useStreamKey: Bool) -> @Sendable (Request) async throws -> Response {
         { req in
             guard let imageName = req.parameters.get("name") else {
                 throw Abort(.badRequest, reason: "Missing image name parameter")
@@ -55,33 +58,91 @@ extension ImagePushRoute {
             let response = Response()
             response.headers.add(name: .contentType, value: "application/json")
 
+            // Real podman (`pkg/bindings/images`'s `Push`) sends the push destination as a
+            // separate `destination` query param — the path reference is always the LOCAL
+            // source image, never the target registry. Without honoring it, push targets
+            // whatever (if anything) the source reference's own domain resolves to, silently
+            // ignoring where the caller actually asked to push. Mirrors manifest push's own
+            // retag-then-push-then-restore dance (`ClientManifestService.retagForPush`/
+            // `untagPushDestination`) since the underlying push primitive always pushes to
+            // the same reference it resolves from.
+            var pushReference = reference
+            var retagState: RetagState?
+            if let destination = query.destination, !destination.isEmpty {
+                do {
+                    (pushReference, retagState) = try await manifestClient.retagForPush(name: reference, destination: destination)
+                } catch ClientImageError.notFound(let id) {
+                    throw Abort(.notFound, reason: "No such image: \(id)")
+                } catch is ClientManifestError {
+                    throw Abort(.notFound, reason: "No such image: \(reference)")
+                }
+            }
+            let finalReference = pushReference
+            let finalRetagState = retagState
+
+            @Sendable func restoreRetagStateIfNeeded() async {
+                guard let finalRetagState else { return }
+                do {
+                    try await manifestClient.untagPushDestination(finalRetagState)
+                } catch {
+                    req.logger.warning("Failed to restore \(finalRetagState.reference)'s prior state after a failed push: \(error)")
+                }
+            }
+
             let progressStream: AsyncThrowingStream<String, Error>
             do {
                 progressStream = try await client.push(
-                    reference: reference,
+                    reference: finalReference,
                     platform: platform,
                     logger: req.logger
                 )
             } catch ClientImageError.notFound(let id) {
+                await restoreRetagStateIfNeeded()
                 throw Abort(.notFound, reason: "No such image: \(id)")
             } catch let abort as Abort {
+                await restoreRetagStateIfNeeded()
                 throw abort
             } catch {
-                throw Abort(.internalServerError, reason: "Failed to push \(reference): \(error)")
+                await restoreRetagStateIfNeeded()
+                throw Abort(.internalServerError, reason: "Failed to push \(finalReference): \(error)")
             }
 
             let app = req.application
+            let logger = req.logger
             // moby's push event uses the familiar reference as Actor.ID and the familiar
             // name without tag as the `name` attribute (daemon/containerd/image_push.go).
-            let familiarName = (try? Reference.parse(reference))?.name ?? imageName
+            let familiarName = (try? Reference.parse(finalReference))?.name ?? imageName
+            // Real podman clients (`pkg/bindings/images`'s `Push`) decode each line into a
+            // struct with a `stream` field, not `status` — this route is shared between the
+            // Docker-compat path (`/images/{name}/push`, `useStreamKey: false`) and the libpod
+            // one (`/libpod/images/{name}/push`, see `LibpodImagePushRoute`, `useStreamKey: true`),
+            // which do need different framing. Passed explicitly by each route's own
+            // registration rather than derived from the request path, so it can't silently
+            // pick the wrong framing for an image name that happens to contain "/libpod/".
             response.body = .init(stream: { writer in
                 Task {
-                    await DockerProgressFrame.pipe(progressStream, to: writer) {
-                        guard let broadcaster = app.storage[EventBroadcasterKey.self] else { return }
-                        await broadcaster.broadcast(
-                            DockerEvent.make(
-                                type: "image", action: "push", actorID: reference,
-                                attributes: ["name": familiarName]))
+                    await DockerProgressFrame.pipe(
+                        progressStream, to: writer, useStreamKey: useStreamKey,
+                        onSuccess: {
+                            guard let broadcaster = app.storage[EventBroadcasterKey.self] else { return }
+                            await broadcaster.broadcast(
+                                DockerEvent.make(
+                                    type: "image", action: "push", actorID: finalReference,
+                                    attributes: ["name": familiarName]))
+                        })
+                    if let finalRetagState {
+                        // A fresh, unstructured `Task` here (not just the tail of the
+                        // enclosing one) so this cleanup still runs even if the response
+                        // stream's own Task was cancelled (e.g. the client disconnected
+                        // mid-push) — `Task { ... }` does NOT inherit the creating task's
+                        // cancellation state, unlike a structured child task.
+                        Task {
+                            do {
+                                try await manifestClient.untagPushDestination(finalRetagState)
+                            } catch {
+                                logger.warning("Failed to restore \(finalRetagState.reference)'s prior state after push: \(error)")
+                            }
+                        }
                     }
                 }
             })

--- a/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Images/ImagesGetRoute.swift
@@ -35,7 +35,7 @@ struct ImagesGetRoute: RouteCollection {
         }
     }
 
-    private static func saveImages(references: [String], req: Request, client: ClientImageProtocol) async throws -> Response {
+    static func saveImages(references: [String], req: Request, client: ClientImageProtocol) async throws -> Response {
         let platformString = try? req.query.get(String.self, at: "platform")
         let platform = try platformString.map(platformOrThrow)
 

--- a/Sources/socktainer/Routes/Libpod/LibpodAuthRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodAuthRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodAuthRoute: RouteCollection {
+    let client: ClientRegistryService
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/auth", use: AuthRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodBuildRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodBuildRoute.swift
@@ -1,0 +1,14 @@
+import ContainerPersistence
+import Vapor
+
+struct LibpodBuildRoute: RouteCollection {
+    let client: ClientContainerProtocol
+    let builderClient: ClientBuilderProtocol
+    let systemConfig: ContainerSystemConfig
+    let manifestClient: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/libpod/build", use: BuildRoute.handler(client: client, builderClient: builderClient, systemConfig: systemConfig, manifestClient: manifestClient))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodCommitRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodCommitRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodCommitRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/commit", use: CommitRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerArchiveRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerArchiveRoute.swift
@@ -1,0 +1,24 @@
+import Vapor
+
+struct LibpodContainerArchiveRoute: RouteCollection {
+    let containerClient: ClientContainerProtocol
+    let archiveClient: ClientArchiveProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(
+            .GET,
+            pattern: "/libpod/containers/{id:.*}/archive",
+            use: ContainerArchiveRoute.getHandler(containerClient: containerClient, archiveClient: archiveClient)
+        )
+        try routes.registerVersionedRoute(
+            .PUT,
+            pattern: "/libpod/containers/{id:.*}/archive",
+            use: ContainerArchiveRoute.putHandler(containerClient: containerClient, archiveClient: archiveClient)
+        )
+        try routes.registerVersionedRoute(
+            .HEAD,
+            pattern: "/libpod/containers/{id:.*}/archive",
+            use: ContainerArchiveRoute.headHandler(containerClient: containerClient, archiveClient: archiveClient)
+        )
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerAttachRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerAttachRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerAttachRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/attach", use: ContainerAttachRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerChangesRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerChangesRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerChangesRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/changes", use: ContainerChangesRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerCreateRoute.swift
@@ -1,0 +1,86 @@
+import ContainerPersistence
+import Foundation
+import Vapor
+
+struct LibpodContainerCreateRoute: RouteCollection {
+    let client: ClientContainerProtocol
+    let systemConfig: ContainerSystemConfig
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/create", use: LibpodContainerCreateRoute.handler(client: client, systemConfig: systemConfig))
+    }
+
+    static func handler(client: ClientContainerProtocol, systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> Response {
+        { req in
+            let bodyData: ByteBuffer?
+            do {
+                bodyData = try await req.body.collect().get()
+            } catch {
+                throw Abort(.internalServerError, reason: "Failed to read request body: \(error)")
+            }
+            guard let bodyData, bodyData.readableBytes > 0 else {
+                throw Abort(.badRequest, reason: "Missing request body")
+            }
+            let libpodBody: LibpodContainerCreateRequest
+            do {
+                libpodBody = try JSONDecoder().decode(
+                    LibpodContainerCreateRequest.self,
+                    from: bodyData.getData(at: 0, length: bodyData.readableBytes)!
+                )
+            } catch {
+                throw Abort(.badRequest, reason: "Invalid request body: \(error)")
+            }
+
+            let dockerBody = CreateContainerRequest(
+                Image: libpodBody.image,
+                Hostname: nil,
+                Domainname: nil,
+                User: nil,
+                AttachStdin: nil,
+                AttachStdout: nil,
+                AttachStderr: nil,
+                PortSpecs: nil,
+                Tty: nil,
+                OpenStdin: nil,
+                StdinOnce: nil,
+                Env: nil,
+                Cmd: libpodBody.command,
+                Healthcheck: nil,
+                ArgsEscaped: nil,
+                Entrypoint: nil,
+                Volumes: nil,
+                WorkingDir: nil,
+                MacAddress: nil,
+                OnBuild: nil,
+                NetworkDisabled: nil,
+                ExposedPorts: nil,
+                StopSignal: nil,
+                StopTimeout: nil,
+                HostConfig: nil,
+                Labels: nil,
+                Shell: nil,
+                NetworkingConfig: nil
+            )
+
+            let containerName: String? = libpodBody.name ?? req.query["name"]
+
+            var path = "/containers/create"
+            if let name = containerName {
+                // URLComponents/URLQueryItem percent-encodes a query VALUE correctly
+                // (&, =, + included) — .urlQueryAllowed alone leaves those raw since
+                // it's meant for encoding an already-structured query string, not a
+                // single item's value, so a name containing them would inject a
+                // second bogus query parameter.
+                var components = URLComponents()
+                components.queryItems = [URLQueryItem(name: "name", value: name)]
+                path += "?" + (components.percentEncodedQuery ?? "")
+            }
+            req.url = URI(string: path)
+
+            try req.content.encode(dockerBody, as: .json)
+
+            let dockerHandler = ContainerCreateRoute.handler(client: client, systemConfig: systemConfig)
+            return try await dockerHandler(req)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerDeleteRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerDeleteRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.DELETE, pattern: "/libpod/containers/{id}", use: ContainerDeleteRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerExistsRoute.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+struct LibpodContainerExistsRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/exists", use: LibpodContainerExistsRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let id = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing container ID")
+            }
+            guard try await client.getContainer(id: id) != nil else {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            }
+            return Response(status: .noContent)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerExportRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerExportRoute.swift
@@ -1,0 +1,14 @@
+import Vapor
+
+struct LibpodContainerExportRoute: RouteCollection {
+    let containerClient: ClientContainerProtocol
+    let archiveClient: ClientArchiveProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(
+            .GET,
+            pattern: "/libpod/containers/{id}/export",
+            use: ContainerExportRoute.handler(containerClient: containerClient, archiveClient: archiveClient)
+        )
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerInspectRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerInspectRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/json", use: ContainerInspectRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerKillRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerKillRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerKillRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/kill", use: ContainerKillRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerListRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerListRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerListRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/json", use: ContainerListRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerLogsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerLogsRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerLogsRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/logs", use: ContainerLogsRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerPauseRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerPauseRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerPauseRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/pause", use: ContainerPauseRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerPruneRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerPruneRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerPruneRoute: RouteCollection {
+    let dockerRoute: ContainerPruneRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/prune", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerRenameRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerRenameRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerRenameRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/rename", use: ContainerRenameRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerRestartRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerRestartRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerRestartRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/restart", use: ContainerRestartRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerStartRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerStartRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerStartRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/start", use: ContainerStartRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerStatsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerStatsRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerStatsRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/stats", use: ContainerStatsRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerStopRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerStopRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerStopRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/stop", use: ContainerStopRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerTopRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerTopRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerTopRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/containers/{id}/top", use: ContainerTopRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerUnpauseRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerUnpauseRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodContainerUnpauseRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/unpause", use: ContainerUnpauseRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerUpdateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerUpdateRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodContainerUpdateRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/update", use: ContainerUpdateRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerWaitRoute.swift
@@ -36,8 +36,10 @@ struct LibpodContainerWaitRoute: RouteCollection {
 
     /// Real podman's libpod `wait` endpoint (`condition=`, repeatable) uses the container's
     /// own lowercase status names ("configured", "created", "running", "paused", "exited",
-    /// "stopped", ...), not Docker compat's `wait`-specific vocabulary
-    /// (`ContainerWaitCondition`: "not-running", "next-exit", "removed", "healthy"). Only
+    /// "stopped", "removing", ...), not Docker compat's `wait`-specific vocabulary
+    /// (`ContainerWaitCondition`: "not-running", "next-exit", "removed", "healthy"). "removing"
+    /// (in-progress removal) maps to the same `.removed` condition as Docker-compat's "removed"
+    /// since this daemon has no distinct in-progress-removal state to block on. Only
     /// the first `condition` value is honored — real podman lets multiple be OR-matched,
     /// which would need genuine target-state polling this daemon's `client.wait` doesn't
     /// implement (it only supports "block until the container stops and report its exit
@@ -47,7 +49,7 @@ struct LibpodContainerWaitRoute: RouteCollection {
         switch first {
         case "stopped", "exited":
             return .notRunning
-        case "removed":
+        case "removed", "removing":
             return .removed
         case "healthy":
             return .healthy

--- a/Sources/socktainer/Routes/Libpod/LibpodContainerWaitRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodContainerWaitRoute.swift
@@ -1,0 +1,60 @@
+import Vapor
+
+struct LibpodContainerWaitRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/wait", use: LibpodContainerWaitRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientContainerProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let containerId = req.parameters.get("id") else {
+                throw Abort(.badRequest, reason: "Missing container ID")
+            }
+
+            let conditionString = req.query["condition"] as String?
+            let condition: ContainerWaitCondition
+
+            if let conditionString = conditionString {
+                condition = try Self.mapLibpodCondition(conditionString)
+            } else {
+                condition = ContainerWaitCondition.default
+            }
+
+            do {
+                let waitResponse = try await client.wait(id: containerId, condition: condition)
+                return try await waitResponse.encodeResponse(for: req)
+            } catch ClientContainerError.notFound(let id) {
+                throw Abort(.notFound, reason: "No such container: \(id)")
+            } catch {
+                req.logger.error("Failed to wait for container \(containerId): \(error)")
+                throw Abort(.internalServerError, reason: "Failed to wait for container")
+            }
+        }
+    }
+
+    /// Real podman's libpod `wait` endpoint (`condition=`, repeatable) uses the container's
+    /// own lowercase status names ("configured", "created", "running", "paused", "exited",
+    /// "stopped", ...), not Docker compat's `wait`-specific vocabulary
+    /// (`ContainerWaitCondition`: "not-running", "next-exit", "removed", "healthy"). Only
+    /// the first `condition` value is honored — real podman lets multiple be OR-matched,
+    /// which would need genuine target-state polling this daemon's `client.wait` doesn't
+    /// implement (it only supports "block until the container stops and report its exit
+    /// code," matching Docker's own `wait`).
+    private static func mapLibpodCondition(_ raw: String) throws -> ContainerWaitCondition {
+        let first = raw.split(separator: ",").first.map(String.init) ?? raw
+        switch first {
+        case "stopped", "exited":
+            return .notRunning
+        case "removed":
+            return .removed
+        case "healthy":
+            return .healthy
+        case "running", "paused", "created", "configured":
+            throw Abort(.notImplemented, reason: "waiting for condition '\(first)' is not supported; only 'stopped'/'exited' (and Docker-compat 'removed'/'healthy') are")
+        default:
+            throw Abort(.badRequest, reason: "Invalid wait condition: \(first)")
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodEventsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodEventsRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodEventsRoute: RouteCollection {
+    let client: ClientHealthCheckProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/events", use: EventsRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodExecCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodExecCreateRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodExecCreateRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/containers/{id}/exec", use: ExecRoute.createExec(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodExecInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodExecInspectRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodExecInspectRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/exec/{id}/json", use: ExecRoute.inspectExec(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodExecStartRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodExecStartRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodExecStartRoute: RouteCollection {
+    let client: ClientContainerProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/exec/{id}/start", use: ExecRoute.startExec(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageDeleteRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodImageDeleteRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.DELETE, pattern: "/libpod/images/{name:.*}", use: ImageDeleteRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageExistsRoute.swift
@@ -1,0 +1,26 @@
+import ContainerAPIClient
+import ContainerPersistence
+import ContainerizationError
+import Vapor
+
+struct LibpodImageExistsRoute: RouteCollection {
+    let systemConfig: ContainerSystemConfig
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/{name:.*}/exists", use: LibpodImageExistsRoute.handler(systemConfig: systemConfig))
+    }
+
+    static func handler(systemConfig: ContainerSystemConfig) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let refOrId = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing image name parameter")
+            }
+            do {
+                _ = try await ClientImage.get(reference: refOrId, containerSystemConfig: systemConfig)
+            } catch let error as ContainerizationError where error.code == .notFound {
+                throw Abort(.notFound, reason: "No such image: \(refOrId)")
+            }
+            return Response(status: .noContent)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageHistoryRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageHistoryRoute.swift
@@ -1,0 +1,10 @@
+import ContainerPersistence
+import Vapor
+
+struct LibpodImageHistoryRoute: RouteCollection {
+    let systemConfig: ContainerSystemConfig
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/{name:.*}/history", use: ImageHistoryRoute.handler(systemConfig: systemConfig))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageImportRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageImportRoute.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Vapor
+
+/// Podman's libpod import (`/libpod/images/import`) uses a `reference` query
+/// param (`Name[:TAG]`) instead of Docker compat's split `repo`/`tag` pair.
+/// Only the streamed-body form (no remote `url`) is supported, matching the
+/// existing Docker-side `ImageCreateRoute` import path.
+///
+/// Unlike Docker compat's `/images/create` (a chunked progress stream), real
+/// podman's `ImagesImport` handler (`pkg/api/handlers/libpod/images.go`)
+/// writes a single JSON object, `entities.ImageImportReport{ Id string }`,
+/// once the import completes — so this calls `client.importImage` directly
+/// rather than delegating to and forwarding the Docker route's streaming
+/// response, which real podman clients don't know how to parse.
+struct LibpodImageImportRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/images/import", use: LibpodImageImportRoute.handler(client: client))
+    }
+
+    struct LibpodImageImportQuery: Content {
+        let reference: String?
+        let message: String?
+        let url: String?
+        let changes: [String]?
+    }
+
+    struct RESTLibpodImportIDResponse: Content {
+        let Id: String
+    }
+
+    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            let query = try req.query.decode(LibpodImageImportQuery.self)
+
+            guard query.url == nil || query.url!.isEmpty else {
+                throw Abort(.notImplemented, reason: "podman import from a remote URL is not supported; only a streamed tarball body is implemented")
+            }
+
+            let (repo, tag) = splitReference(query.reference ?? "")
+            switch ClientImageService.validateImportReference(repo: repo, tag: tag) {
+            case .valid:
+                break
+            case .digestNotAllowed:
+                throw Abort(.badRequest, reason: "cannot reference \(repo) by digest")
+            case .malformed(let reason):
+                throw Abort(.badRequest, reason: "invalid reference format: \(reason)")
+            }
+
+            guard let appleContainerAppSupportUrl = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
+                throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
+            }
+
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let tarPath = tempDir.appendingPathComponent("import.tar")
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+            try await ImageCreateRoute.writeBodyToFile(req.body, at: tarPath)
+
+            // podman defaults an empty message to "Imported from <src>", same as moby.
+            let message = (query.message?.isEmpty ?? true) ? "Imported from -" : query.message!
+
+            let digest: String
+            do {
+                (_, digest) = try await client.importImage(
+                    tarPath: tarPath,
+                    repo: repo.isEmpty ? nil : repo,
+                    tag: tag.isEmpty ? nil : tag,
+                    message: message,
+                    changes: query.changes ?? [],
+                    platform: currentPlatform(),
+                    appleContainerAppSupportUrl: appleContainerAppSupportUrl,
+                    logger: req.logger
+                )
+            } catch {
+                throw Abort(.internalServerError, reason: "Failed to import image: \(error)")
+            }
+
+            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                // moby's import event uses the image digest as both Actor.ID and the
+                // `name` attribute — unlike pull/tag, the human-readable reference never
+                // appears in this event. Mirrors ImageCreateRoute's own import event.
+                await broadcaster.broadcast(
+                    DockerEvent.make(type: "image", action: "import", actorID: digest, attributes: ["name": digest]))
+            }
+
+            return try await RESTLibpodImportIDResponse(Id: digest).encodeResponse(status: .ok, for: req)
+        }
+    }
+
+    private static func splitReference(_ reference: String) -> (repo: String, tag: String) {
+        guard !reference.isEmpty else { return ("", "") }
+        // A digest reference (name@sha256:...) has no tag component — the colon inside
+        // the digest is not a tag separator.
+        if reference.contains("@") { return (reference, "") }
+        if let colonIndex = reference.lastIndex(of: ":"), !reference[colonIndex...].contains("/") {
+            let repo = String(reference[..<colonIndex])
+            let tag = String(reference[reference.index(after: colonIndex)...])
+            return (repo, tag)
+        }
+        return (reference, "")
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageInspectRoute.swift
@@ -1,0 +1,10 @@
+import ContainerPersistence
+import Vapor
+
+struct LibpodImageInspectRoute: RouteCollection {
+    let systemConfig: ContainerSystemConfig
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/{name:.*}/json", use: ImageInspectRoute.handler(systemConfig: systemConfig))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageListRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageListRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodImageListRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/json", use: ImageListRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImagePruneRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagePruneRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodImagePruneRoute: RouteCollection {
+    let dockerRoute: ImagePruneRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/images/prune", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImagePullRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagePullRoute.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Vapor
+
+struct LibpodImagePullRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/images/pull", use: LibpodImagePullRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let reference = req.query["reference"] as String?, !reference.isEmpty else {
+                throw Abort(.badRequest, reason: "Missing reference query parameter")
+            }
+            let platformString: String? = req.query["platform"]
+
+            let (image, tag) = parseReference(reference)
+
+            let platform: Platform
+            if let platformString, !platformString.isEmpty {
+                do {
+                    platform = try platformOrThrow(platformString)
+                } catch {
+                    throw Abort(.badRequest, reason: "Failed to parse platform '\(platformString)': \(error.localizedDescription)")
+                }
+            } else {
+                platform = currentPlatform()
+            }
+
+            let response = Response()
+            response.headers.add(name: .contentType, value: "application/json")
+            let progressStream = try await client.pull(
+                image: image, tag: tag, platform: platform, logger: req.logger)
+
+            struct PullStreamLine: Encodable {
+                var stream: String?
+                var images: [String]?
+                var id: String?
+                var error: String?
+            }
+            let encoder = JSONEncoder()
+            @Sendable func encodeLine(_ line: PullStreamLine) -> ByteBuffer {
+                guard let data = try? encoder.encode(line) else {
+                    return ByteBuffer(string: "{\"error\": \"failed to encode progress\"}\n")
+                }
+                var buffer = ByteBuffer(bytes: data)
+                buffer.writeString("\n")
+                return buffer
+            }
+
+            response.body = .init(stream: { writer in
+                Task {
+                    do {
+                        for try await progress in progressStream {
+                            let message: String
+                            switch progress {
+                            case .message(let text): message = text
+                            case .downloading(let current, let total): message = "Downloading \(current)/\(total)"
+                            case .extracting(let current, let total): message = "Extracting \(current)/\(total)"
+                            }
+                            _ = writer.write(.buffer(encodeLine(PullStreamLine(stream: message + "\n"))))
+                        }
+                        let imageRef = tag.isEmpty ? image : "\(image):\(tag)"
+                        _ = writer.write(.buffer(encodeLine(PullStreamLine(images: [imageRef], id: imageRef))))
+                        _ = writer.write(.end)
+                    } catch {
+                        _ = writer.write(.buffer(encodeLine(PullStreamLine(error: error.localizedDescription))))
+                        _ = writer.write(.error(error))
+                    }
+                }
+            })
+            return response
+        }
+    }
+
+    private static func parseReference(_ reference: String) -> (image: String, tag: String) {
+        let decoded = reference.removingPercentEncoding ?? reference
+        // A digest reference (name@sha256:...) has no tag component — the colon inside
+        // the digest is not a tag separator.
+        if decoded.contains("@") {
+            return (decoded, "")
+        }
+        if let colonIndex = decoded.lastIndex(of: ":"),
+            !decoded[colonIndex...].contains("/")
+        {
+            let image = String(decoded[..<colonIndex])
+            let tag = String(decoded[decoded.index(after: colonIndex)...])
+            return (image, tag)
+        }
+        return (decoded, "")
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImagePushRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagePushRoute.swift
@@ -1,0 +1,11 @@
+import Vapor
+
+struct LibpodImagePushRoute: RouteCollection {
+    let client: ClientImageProtocol
+    let manifestClient: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/libpod/images/{name:.*}/push", use: ImagePushRoute.handler(client: client, manifestClient: manifestClient, useStreamKey: true))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageSearchRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageSearchRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodImageSearchRoute: RouteCollection {
+    let dockerRoute: ImageSearchRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/search", use: ImageSearchRoute.handler(searchProvider: dockerRoute.searchProvider))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImageTagRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImageTagRoute.swift
@@ -1,0 +1,12 @@
+import ContainerPersistence
+import Vapor
+
+struct LibpodImageTagRoute: RouteCollection {
+    let systemConfig: ContainerSystemConfig
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/images/{name:.*}/tag") { [systemConfig] req in
+            try await ImageTagRoute.handler(req, systemConfig: systemConfig)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagesGetRoute.swift
@@ -1,0 +1,10 @@
+import Vapor
+
+struct LibpodImagesGetRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/get", use: ImagesGetRoute.handlerMultiple(client: client))
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/{name:.*}/get", use: ImagesGetRoute.handlerSingle(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodImagesGetRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagesGetRoute.swift
@@ -4,7 +4,22 @@ struct LibpodImagesGetRoute: RouteCollection {
     let client: ClientImageProtocol
 
     func boot(routes: RoutesBuilder) throws {
-        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/get", use: ImagesGetRoute.handlerMultiple(client: client))
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/export", use: LibpodImagesGetRoute.handlerMultiple(client: client))
         try routes.registerVersionedRoute(.GET, pattern: "/libpod/images/{name:.*}/get", use: ImagesGetRoute.handlerSingle(client: client))
+    }
+
+    /// Real podman's multi-image export endpoint is `GET /libpod/images/export`
+    /// (`libpod.ExportImages`, confirmed against `pkg/api/server/register_images.go`), decoding
+    /// a repeated `references` query param — not Docker-compat's `/images/get?names=...`.
+    static func handlerMultiple(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            let references = try? req.query.get([String].self, at: "references")
+
+            guard let references, !references.isEmpty else {
+                throw Abort(.badRequest, reason: "At least one image name is required in 'references' query parameter")
+            }
+
+            return try await ImagesGetRoute.saveImages(references: references, req: req, client: client)
+        }
     }
 }

--- a/Sources/socktainer/Routes/Libpod/LibpodImagesLoadRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodImagesLoadRoute.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Vapor
+
+/// Podman has two distinct load endpoints (confirmed against podman's own route
+/// registration source, `pkg/api/server/register_images.go`):
+///   - `POST /libpod/images/load` (`libpod.ImagesLoad`) — stream a tar request body, same
+///     shape as Docker compat's own `/images/load`. This is what `podman load -i file.tar`
+///     actually uses.
+///   - `POST /libpod/local/images/load` (`libpod.ImagesLocalLoad`) — load an archive already
+///     present at an absolute path on the server's own filesystem (relevant here since
+///     socktainer and the podman CLI typically share a filesystem over the unix socket).
+struct RESTLocalImageLoadQuery: Content {
+    let path: String?
+    let platform: String?
+}
+
+/// Real podman's `ImageLoadReport` (`pkg/domain/entities/types.go`) — every reference the
+/// archive loaded, not a single `Id`.
+struct RESTLibpodImageLoadReport: Content {
+    let Names: [String]
+}
+
+struct LibpodImagesLoadRoute: RouteCollection {
+    let client: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/images/load", use: ImagesLoadRoute.handler(client: client))
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/local/images/load", use: LibpodImagesLoadRoute.localHandler(client: client))
+    }
+
+    static func localHandler(client: ClientImageProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            let query = try req.query.decode(RESTLocalImageLoadQuery.self)
+            guard let path = query.path, !path.isEmpty else {
+                throw Abort(.badRequest, reason: "path is required")
+            }
+            // A server-local path, by definition, only makes sense as absolute — a relative
+            // path would resolve against socktainer's own process working directory, not
+            // anything the caller could have meant.
+            guard path.hasPrefix("/") else {
+                throw Abort(.badRequest, reason: "path must be an absolute path")
+            }
+            var info = stat()
+            guard stat(path, &info) == 0 else {
+                guard errno == ENOENT else {
+                    throw Abort(.badRequest, reason: "Unable to access \(path): errno \(errno)")
+                }
+                throw Abort(.notFound, reason: "No such file or directory: \(path)")
+            }
+            guard (info.st_mode & S_IFMT) == S_IFREG else {
+                throw Abort(.badRequest, reason: "path must be a regular archive file: \(path)")
+            }
+
+            let platform: Platform
+            if let platformString = query.platform, !platformString.isEmpty {
+                do {
+                    platform = try platformOrThrow(platformString)
+                } catch {
+                    throw Abort(.badRequest, reason: "invalid platform: \(platformString)")
+                }
+            } else {
+                platform = currentPlatform()
+            }
+
+            guard let appSupportURL = req.application.storage[AppleContainerAppSupportUrlKey.self] else {
+                throw Abort(.internalServerError, reason: "AppleContainerAppSupportUrl not configured")
+            }
+
+            let loadedImages = try await client.load(
+                tarballPath: URL(fileURLWithPath: path), platform: platform, appleContainerAppSupportUrl: appSupportURL, logger: req.logger)
+            guard !loadedImages.isEmpty else {
+                throw Abort(.internalServerError, reason: "Archive at \(path) contained no images")
+            }
+
+            if let broadcaster = req.application.storage[EventBroadcasterKey.self] {
+                let digestsByReference = await client.digestsByReference()
+                for image in loadedImages {
+                    let actorId = digestsByReference[image] ?? image
+                    await broadcaster.broadcast(
+                        DockerEvent.make(type: "image", action: "load", actorID: actorId, attributes: ["name": actorId]))
+                }
+            }
+
+            return try await RESTLibpodImageLoadReport(Names: loadedImages).encodeResponse(status: .ok, for: req)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodInfoRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodInfoRoute.swift
@@ -1,0 +1,26 @@
+import ContainerAPIClient
+import ContainerPersistence
+import Vapor
+
+struct LibpodInfoRoute: RouteCollection {
+    let containerClient: ClientContainerProtocol
+    let imageClient: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        let containerClient = self.containerClient
+        let imageClient = self.imageClient
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/info") { req in
+            try await InfoRoute.handle(
+                req,
+                containerClient: containerClient,
+                imageClient: imageClient,
+                configLoader: { try await ConfigurationLoader.load() },
+                systemHealthProvider: {
+                    let health = try await ClientHealthCheck.ping()
+                    return (health.appRoot.path, health.apiServerVersion)
+                },
+                kernelNameProvider: { try await getLinuxDefaultKernelName() }
+            )
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestCreateRoute.swift
@@ -1,0 +1,89 @@
+import ContainerPersistence
+import Vapor
+
+struct RESTManifestCreateQuery: Content {
+    let images: [String]?
+    let image: [String]?
+    let amend: Bool?
+}
+
+struct RESTManifestCreateRequest: Content {
+    let images: [String]?
+}
+
+struct RESTManifestIDResponse: Content {
+    let ID: String
+
+    // Real podman's IDResponse serializes the field as "Id", not "ID"
+    // (pkg/domain/entities/types: `ID string \`json:"Id"\``).
+    enum CodingKeys: String, CodingKey {
+        case ID = "Id"
+    }
+}
+
+struct LibpodManifestCreateRoute: RouteCollection {
+    let client: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/manifests/{name:.*}", use: LibpodManifestCreateRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing manifest list name")
+            }
+
+            // Real podman's ManifestCreate accepts images via either the `image` or `images`
+            // query param (repeated), or a JSON body — support both. Malformed input is a real
+            // 400, not something to silently swallow into "no images requested."
+            let query: RESTManifestCreateQuery
+            do {
+                query = try req.query.decode(RESTManifestCreateQuery.self)
+            } catch {
+                throw Abort(.badRequest, reason: "Invalid query parameters: \(error)")
+            }
+            var images = query.images ?? []
+            images.append(contentsOf: query.image ?? [])
+
+            // Real podman's client (matching `LibpodManifestModifyRoute`'s own documented
+            // behavior for the same family of endpoints) can send a JSON body WITHOUT a
+            // `Content-Type` header — `req.content.decode` unconditionally fails against
+            // that ("Can't decode data without a content type"), regardless of whether the
+            // body itself is well-formed. Decode the raw bytes directly with `JSONDecoder`
+            // in that case instead of skipping the body entirely — a manifest create with
+            // no query images and all its data in a Content-Type-less body must still see
+            // that data, not silently proceed as if no images were requested. A
+            // malformed/undecodable body still shouldn't fail a request that already has
+            // everything it needs via the `image`/`images` query params.
+            let bodyBytes = req.body.data
+            if let bodyBytes, bodyBytes.readableBytes > 0 {
+                do {
+                    let body: RESTManifestCreateRequest
+                    if req.headers.contentType != nil {
+                        body = try req.content.decode(RESTManifestCreateRequest.self)
+                    } else {
+                        body = try JSONDecoder().decode(RESTManifestCreateRequest.self, from: Data(buffer: bodyBytes))
+                    }
+                    images.append(contentsOf: body.images ?? [])
+                } catch {
+                    guard !images.isEmpty else {
+                        throw Abort(.badRequest, reason: "Invalid request body: \(error)")
+                    }
+                }
+            }
+
+            do {
+                let digest = try await client.create(name: name, images: images, logger: req.logger, amend: query.amend ?? false)
+                // Real podman's ManifestCreate returns 201 Created for API versions >= 4.0.0
+                // (only pre-4.0 clients get 200 OK) — this daemon always reports a modern
+                // libpod API version (see LibpodVersionRoute), so 201 is always correct here.
+                return try await RESTManifestIDResponse(ID: digest).encodeResponse(status: .created, for: req)
+            } catch ClientImageError.notFound(let id) {
+                throw Abort(.badRequest, reason: "No such image: \(id)")
+            } catch ClientManifestError.alreadyExists {
+                throw Abort(.conflict, reason: "manifest list \(name) already exists (use --amend to update it)")
+            }
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestCreateRoute.swift
@@ -1,4 +1,5 @@
 import ContainerPersistence
+import ContainerizationError
 import Vapor
 
 struct RESTManifestCreateQuery: Content {
@@ -30,7 +31,7 @@ struct LibpodManifestCreateRoute: RouteCollection {
 
     static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
-            guard let name = req.parameters.get("name") else {
+            guard let name = req.parameters.get("name"), !name.isEmpty else {
                 throw Abort(.badRequest, reason: "Missing manifest list name")
             }
 
@@ -83,6 +84,8 @@ struct LibpodManifestCreateRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "No such image: \(id)")
             } catch ClientManifestError.alreadyExists {
                 throw Abort(.conflict, reason: "manifest list \(name) already exists (use --amend to update it)")
+            } catch let error as ContainerizationError where error.code == .invalidArgument {
+                throw Abort(.badRequest, reason: error.message)
             }
         }
     }

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestDeleteRoute.swift
@@ -1,0 +1,55 @@
+import Vapor
+
+struct RESTManifestDeleteQuery: Content {
+    let ignore: Bool?
+}
+
+/// Real podman's `ManifestDelete` handler (`pkg/api/handlers/libpod/manifests.go`) returns
+/// `LibpodImagesRemoveReport` (`entities.ImageRemoveReport` embedded, plus `Errors`) — not a
+/// bare `IDResponse{Id}`. JSON keys match the embedded Go struct's field names verbatim
+/// (`Deleted`/`Untagged`/`ExitCode`/`Errors`), matching what a real podman CLI decodes.
+struct RESTManifestRemoveReport: Content {
+    let Deleted: [String]
+    let Untagged: [String]
+    let ExitCode: Int
+    let Errors: [String]
+}
+
+struct LibpodManifestDeleteRoute: RouteCollection {
+    let client: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.DELETE, pattern: "/libpod/manifests/{name:.*}", use: LibpodManifestDeleteRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> RESTManifestRemoveReport {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing manifest list name")
+            }
+            let query: RESTManifestDeleteQuery
+            do {
+                query = try req.query.decode(RESTManifestDeleteQuery.self)
+            } catch {
+                throw Abort(.badRequest, reason: "Invalid query parameters: \(error)")
+            }
+            let ignore = query.ignore ?? false
+
+            guard try await client.exists(name: name) else {
+                if ignore {
+                    return RESTManifestRemoveReport(Deleted: [], Untagged: [], ExitCode: 0, Errors: [])
+                }
+                throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            }
+            do {
+                try await client.delete(name: name)
+            } catch is ClientManifestError {
+                if ignore {
+                    return RESTManifestRemoveReport(Deleted: [], Untagged: [], ExitCode: 0, Errors: [])
+                }
+                throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            }
+            return RESTManifestRemoveReport(Deleted: [name], Untagged: [], ExitCode: 0, Errors: [])
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestExistsRoute.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+struct LibpodManifestExistsRoute: RouteCollection {
+    let client: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/manifests/{name:.*}/exists", use: LibpodManifestExistsRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing manifest list name")
+            }
+            guard try await client.exists(name: name) else {
+                throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            }
+            return Response(status: .noContent)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestExistsRoute.swift
@@ -9,7 +9,7 @@ struct LibpodManifestExistsRoute: RouteCollection {
 
     static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
-            guard let name = req.parameters.get("name") else {
+            guard let name = req.parameters.get("name"), !name.isEmpty else {
                 throw Abort(.badRequest, reason: "Missing manifest list name")
             }
             guard try await client.exists(name: name) else {

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestInspectRoute.swift
@@ -10,7 +10,7 @@ struct LibpodManifestInspectRoute: RouteCollection {
 
     static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
         { req in
-            guard let name = req.parameters.get("name") else {
+            guard let name = req.parameters.get("name"), !name.isEmpty else {
                 throw Abort(.badRequest, reason: "Missing manifest list name")
             }
             do {

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestInspectRoute.swift
@@ -1,0 +1,27 @@
+import ContainerPersistence
+import Vapor
+
+struct LibpodManifestInspectRoute: RouteCollection {
+    let client: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/manifests/{name:.*}/json", use: LibpodManifestInspectRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing manifest list name")
+            }
+            do {
+                let index = try await client.inspect(name: name)
+                let data = try JSONEncoder().encode(index)
+                var headers = HTTPHeaders()
+                headers.add(name: .contentType, value: "application/json")
+                return Response(status: .ok, headers: headers, body: .init(data: data))
+            } catch is ClientManifestError {
+                throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            }
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestModifyRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestModifyRoute.swift
@@ -1,3 +1,4 @@
+import ContainerizationError
 import Vapor
 
 /// `PUT /libpod/manifests/{name}` — real podman's unified add/remove/annotate endpoint
@@ -24,7 +25,7 @@ struct LibpodManifestModifyRoute: RouteCollection {
 
     static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> RESTManifestIDResponse {
         { req in
-            guard let name = req.parameters.get("name") else {
+            guard let name = req.parameters.get("name"), !name.isEmpty else {
                 throw Abort(.badRequest, reason: "Missing manifest list name")
             }
             let query: RESTManifestModifyQuery
@@ -50,7 +51,14 @@ struct LibpodManifestModifyRoute: RouteCollection {
                     var normalizedDigests: [String] = []
                     var seenDigests = Set<String>()
                     for digest in images {
-                        let normalized = digest.hasPrefix("sha256:") ? digest : "sha256:\(digest)"
+                        let normalized: String
+                        if digest.hasPrefix("sha256:") {
+                            normalized = digest
+                        } else if digest.contains(":") {
+                            throw Abort(.badRequest, reason: "\(digest) is not a supported digest (only sha256 is)")
+                        } else {
+                            normalized = "sha256:\(digest)"
+                        }
                         guard currentDigests.contains(normalized) else {
                             throw Abort(.badRequest, reason: "\(normalized) is not a member of \(name)")
                         }
@@ -64,10 +72,7 @@ struct LibpodManifestModifyRoute: RouteCollection {
                         }
                         normalizedDigests.append(normalized)
                     }
-                    var result = name
-                    for digest in normalizedDigests {
-                        result = try await client.removeDigest(name: name, digest: digest)
-                    }
+                    let result = try await client.removeDigests(name: name, digests: normalizedDigests)
                     return RESTManifestIDResponse(ID: result)
                 case "annotate":
                     throw Abort(.notImplemented, reason: "manifest annotate is not implemented")
@@ -84,6 +89,8 @@ struct LibpodManifestModifyRoute: RouteCollection {
                 throw Abort(.badRequest, reason: "No such image: \(id)")
             } catch is ClientManifestError {
                 throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            } catch let error as ContainerizationError where error.code == .invalidArgument {
+                throw Abort(.badRequest, reason: error.message)
             }
         }
     }

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestModifyRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestModifyRoute.swift
@@ -1,0 +1,90 @@
+import Vapor
+
+/// `PUT /libpod/manifests/{name}` — real podman's unified add/remove/annotate endpoint
+/// (`ManifestModifyOptions{Operation: "update"|"remove"|"annotate", Images: [...]}`).
+/// "annotate" (setting index-level annotations only, no image changes) isn't implemented —
+/// real-world use is overwhelmingly add/remove.
+///
+/// Real podman (`pkg/bindings/manifests`'s `Modify`) sends `operation`/`images`/etc. as
+/// query parameters (`images` repeated once per image, like `platform` on `/build` — see
+/// `allQueryValues`), NOT as a decodable request body: it does send a JSON body too, but
+/// without a `Content-Type` header, so `req.content.decode` fails with "Can't decode data
+/// without a content type" before ever reaching the body's actual content. The query
+/// string carries the same data and is what's actually decoded here.
+struct RESTManifestModifyQuery: Content {
+    let operation: String?
+}
+
+struct LibpodManifestModifyRoute: RouteCollection {
+    let client: ClientManifestServiceProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.PUT, pattern: "/libpod/manifests/{name:.*}", use: LibpodManifestModifyRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientManifestServiceProtocol) -> @Sendable (Request) async throws -> RESTManifestIDResponse {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing manifest list name")
+            }
+            let query: RESTManifestModifyQuery
+            do {
+                query = try req.query.decode(RESTManifestModifyQuery.self)
+            } catch {
+                throw Abort(.badRequest, reason: "Invalid query parameters: \(error)")
+            }
+            let images = allQueryValues(named: "images", from: req.url.query)
+
+            do {
+                switch query.operation {
+                case "remove":
+                    guard !images.isEmpty else {
+                        throw Abort(.badRequest, reason: "remove requires at least one image digest")
+                    }
+                    // Validate every requested digest is a current member BEFORE removing
+                    // any of them — `removeDigest` re-tags after each single removal, so
+                    // looping it directly would leave the manifest list partially modified
+                    // (the first N-1 digests already removed) if a LATER digest in the same
+                    // request turns out to be invalid, with no way for the caller to tell.
+                    let currentDigests = Set(try await client.inspect(name: name).manifests.map(\.digest))
+                    var normalizedDigests: [String] = []
+                    var seenDigests = Set<String>()
+                    for digest in images {
+                        let normalized = digest.hasPrefix("sha256:") ? digest : "sha256:\(digest)"
+                        guard currentDigests.contains(normalized) else {
+                            throw Abort(.badRequest, reason: "\(normalized) is not a member of \(name)")
+                        }
+                        // A duplicate in the SAME request would otherwise pass this
+                        // membership check (it IS currently a member) but then fail on its
+                        // second removal attempt below (no longer a member after the
+                        // first) — partially modifying the list for the exact reason this
+                        // pre-check exists in the first place.
+                        guard seenDigests.insert(normalized).inserted else {
+                            throw Abort(.badRequest, reason: "\(normalized) is requested more than once")
+                        }
+                        normalizedDigests.append(normalized)
+                    }
+                    var result = name
+                    for digest in normalizedDigests {
+                        result = try await client.removeDigest(name: name, digest: digest)
+                    }
+                    return RESTManifestIDResponse(ID: result)
+                case "annotate":
+                    throw Abort(.notImplemented, reason: "manifest annotate is not implemented")
+                case "update", nil, "":
+                    guard !images.isEmpty else {
+                        throw Abort(.badRequest, reason: "update requires at least one image")
+                    }
+                    let result = try await client.add(name: name, images: images, logger: req.logger)
+                    return RESTManifestIDResponse(ID: result)
+                case .some(let unknown):
+                    throw Abort(.badRequest, reason: "Unknown manifest modify operation: \(unknown)")
+                }
+            } catch ClientImageError.notFound(let id) {
+                throw Abort(.badRequest, reason: "No such image: \(id)")
+            } catch is ClientManifestError {
+                throw Abort(.notFound, reason: "No such manifest list: \(name)")
+            }
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestPushRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestPushRoute.swift
@@ -46,7 +46,7 @@ struct LibpodManifestPushRoute: RouteCollection {
     private static func push(
         _ req: Request, manifestClient: ClientManifestServiceProtocol, imageClient: ClientImageProtocol, destination: String
     ) async throws -> Response {
-        guard let name = req.parameters.get("name") else {
+        guard let name = req.parameters.get("name"), !name.isEmpty else {
             throw Abort(.badRequest, reason: "Missing manifest list name")
         }
 

--- a/Sources/socktainer/Routes/Libpod/LibpodManifestPushRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodManifestPushRoute.swift
@@ -1,0 +1,120 @@
+import Vapor
+
+struct RESTManifestPushQuery: Content {
+    let destination: String?
+}
+
+struct LibpodManifestPushRoute: RouteCollection {
+    let manifestClient: ClientManifestServiceProtocol
+    let imageClient: ClientImageProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/libpod/manifests/{name:.*}/registry/{destination:.*}",
+            use: LibpodManifestPushRoute.pathDestinationHandler(manifestClient: manifestClient, imageClient: imageClient))
+        // Legacy (pre-4.0) form: destination as a query param instead of a path segment.
+        try routes.registerVersionedRoute(
+            .POST, pattern: "/libpod/manifests/{name:.*}/push",
+            use: LibpodManifestPushRoute.queryDestinationHandler(manifestClient: manifestClient, imageClient: imageClient))
+    }
+
+    static func pathDestinationHandler(manifestClient: ClientManifestServiceProtocol, imageClient: ClientImageProtocol)
+        -> @Sendable (Request) async throws
+        -> Response
+    {
+        { req in
+            guard let destination = req.parameters.get("destination"), !destination.isEmpty else {
+                throw Abort(.badRequest, reason: "Missing push destination")
+            }
+            return try await push(req, manifestClient: manifestClient, imageClient: imageClient, destination: destination)
+        }
+    }
+
+    static func queryDestinationHandler(manifestClient: ClientManifestServiceProtocol, imageClient: ClientImageProtocol)
+        -> @Sendable (Request) async throws
+        -> Response
+    {
+        { req in
+            let query = try req.query.decode(RESTManifestPushQuery.self)
+            guard let destination = query.destination, !destination.isEmpty else {
+                throw Abort(.badRequest, reason: "destination is required")
+            }
+            return try await push(req, manifestClient: manifestClient, imageClient: imageClient, destination: destination)
+        }
+    }
+
+    private static func push(
+        _ req: Request, manifestClient: ClientManifestServiceProtocol, imageClient: ClientImageProtocol, destination: String
+    ) async throws -> Response {
+        guard let name = req.parameters.get("name") else {
+            throw Abort(.badRequest, reason: "Missing manifest list name")
+        }
+
+        let response = Response()
+        response.headers.add(name: .contentType, value: "application/json")
+
+        // Re-tag under `destination` first — push always pushes to the same reference it
+        // resolves from, so a differing destination needs the local index re-pointed there
+        // before the network push runs. `retagState` is nil when destination == name (no-op);
+        // otherwise it captures destination's prior state (what it pointed at before, or that it
+        // didn't exist) so it can be restored once the push finishes — success or failure —
+        // rather than either leaking a stray tag or clobbering a pre-existing one permanently.
+        let finalReference: String
+        let finalRetagState: RetagState?
+        do {
+            (finalReference, finalRetagState) = try await manifestClient.retagForPush(name: name, destination: destination)
+        } catch ClientImageError.notFound(let id) {
+            throw Abort(.notFound, reason: "No such manifest list: \(id)")
+        } catch is ClientManifestError {
+            throw Abort(.notFound, reason: "No such manifest list: \(name)")
+        }
+
+        let progressStream: AsyncThrowingStream<String, Error>
+        do {
+            progressStream = try await imageClient.pushManifestList(reference: finalReference, logger: req.logger)
+        } catch {
+            if let finalRetagState {
+                do {
+                    try await manifestClient.untagPushDestination(finalRetagState)
+                } catch {
+                    req.logger.warning("Failed to restore \(finalRetagState.reference)'s prior state after a failed push: \(error)")
+                }
+            }
+            if case ClientImageError.notFound(let id) = error {
+                throw Abort(.notFound, reason: "No such manifest list: \(id)")
+            }
+            throw Abort(.internalServerError, reason: "Failed to push manifest list \(name): \(error)")
+        }
+
+        let logger = req.logger
+        response.body = .init(stream: { writer in
+            Task {
+                await DockerProgressFrame.pipe(
+                    progressStream, to: writer, useStreamKey: true,
+                    finalFrame: {
+                        do {
+                            return DockerProgressFrame.manifestPushId(try await manifestClient.digest(for: finalReference))
+                        } catch {
+                            logger.warning("Manifest push of \(finalReference) succeeded but digest lookup for the completion frame failed: \(error)")
+                            return nil
+                        }
+                    })
+                if let finalRetagState {
+                    // A fresh, unstructured `Task` here (not just the tail of the enclosing
+                    // one) so this cleanup still runs even if the response stream's own Task
+                    // was cancelled (e.g. the client disconnected mid-push) — `Task { ... }`
+                    // does NOT inherit the creating task's cancellation state, unlike a
+                    // structured child task.
+                    Task {
+                        do {
+                            try await manifestClient.untagPushDestination(finalRetagState)
+                        } catch {
+                            logger.warning("Failed to restore \(finalRetagState.reference)'s prior state after push: \(error)")
+                        }
+                    }
+                }
+            }
+        })
+        return response
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkConnectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkConnectRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodNetworkConnectRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/networks/{name}/connect", use: NetworkConnectRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkCreateRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodNetworkCreateRoute: RouteCollection {
+    let dockerRoute: NetworkCreateRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/networks/create", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkDeleteRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodNetworkDeleteRoute: RouteCollection {
+    let dockerRoute: NetworkDeleteRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.DELETE, pattern: "/libpod/networks/{id}", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkDisconnectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkDisconnectRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodNetworkDisconnectRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/networks/{name}/disconnect", use: NetworkDisconnectRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkExistsRoute.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+struct LibpodNetworkExistsRoute: RouteCollection {
+    let client: ClientNetworkProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/networks/{name}/exists", use: LibpodNetworkExistsRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientNetworkProtocol) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing network name")
+            }
+            guard try await client.getNetwork(id: name, logger: req.logger) != nil else {
+                throw Abort(.notFound, reason: "No such network: \(name)")
+            }
+            return Response(status: .noContent)
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkInspectRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodNetworkInspectRoute: RouteCollection {
+    let client: ClientNetworkProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/networks/{id}/json", use: NetworkInspectRoute.handler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkListRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkListRoute.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+struct LibpodNetworkListRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/networks/json", use: NetworkListRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodNetworkPruneRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodNetworkPruneRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodNetworkPruneRoute: RouteCollection {
+    let client: ClientNetworkProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/networks/prune", use: NetworkPruneRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodPingRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodPingRoute.swift
@@ -1,0 +1,10 @@
+import Vapor
+
+struct LibpodPingRoute: RouteCollection {
+    let client: ClientHealthCheckProtocol
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/_ping", use: HealthCheckPingRoute.handler(client: client))
+        try routes.registerVersionedRoute(.HEAD, pattern: "/libpod/_ping", use: HealthCheckPingRoute.headHandler(client: client))
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodSystemDFRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodSystemDFRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodSystemDFRoute: RouteCollection {
+    let dockerRoute: SystemDFRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/system/df", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVersionRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVersionRoute.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+struct LibpodVersionRoute: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/version", use: LibpodVersionRoute.handler)
+    }
+
+    static func handler(_ req: Request) async throws -> Response {
+        let version = LibpodVersionInfo(
+            APIVersion: getDockerEngineApiMaxVersion(),
+            Arch: "arm64",
+            BuildTime: getBuildTime(),
+            GitCommit: getBuildGitCommit(),
+            GoVersion: "N/A",
+            MinAPIVersion: getDockerEngineApiMinVersion(),
+            Os: "linux",
+            Version: getBuildVersion()
+        )
+        return try await version.encodeResponse(for: req)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumeCreateRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumeCreateRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodVolumeCreateRoute: RouteCollection {
+    let dockerRoute: VolumeCreateRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/volumes/create", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumeDeleteRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumeDeleteRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodVolumeDeleteRoute: RouteCollection {
+    let dockerRoute: VolumeDeleteRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.DELETE, pattern: "/libpod/volumes/{name}", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumeExistsRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumeExistsRoute.swift
@@ -1,0 +1,24 @@
+import Vapor
+
+struct LibpodVolumeExistsRoute: RouteCollection {
+    let client: ClientVolumeService
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/volumes/{name}/exists", use: LibpodVolumeExistsRoute.handler(client: client))
+    }
+
+    static func handler(client: ClientVolumeService) -> @Sendable (Request) async throws -> Response {
+        { req in
+            guard let name = req.parameters.get("name") else {
+                throw Abort(.badRequest, reason: "Missing volume name")
+            }
+            do {
+                _ = try await client.inspect(name: name)
+                return Response(status: .noContent)
+            } catch {
+                guard VolumeNotFound.matches(error) else { throw error }
+                throw Abort(.notFound, reason: "No such volume: \(name)")
+            }
+        }
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumeInspectRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumeInspectRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodVolumeInspectRoute: RouteCollection {
+    let dockerRoute: VolumeInspectRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/volumes/{name}/json", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumeListRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumeListRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodVolumeListRoute: RouteCollection {
+    let dockerRoute: VolumeListRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.GET, pattern: "/libpod/volumes/json", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Libpod/LibpodVolumePruneRoute.swift
+++ b/Sources/socktainer/Routes/Libpod/LibpodVolumePruneRoute.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct LibpodVolumePruneRoute: RouteCollection {
+    let dockerRoute: VolumePruneRoute
+
+    func boot(routes: RoutesBuilder) throws {
+        try routes.registerVersionedRoute(.POST, pattern: "/libpod/volumes/prune", use: dockerRoute.handler)
+    }
+}

--- a/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
+++ b/Sources/socktainer/Routes/Server/HealthCheckPingRoute.swift
@@ -17,6 +17,11 @@ extension HealthCheckPingRoute {
         response.headers.add(name: "Api-Version", value: "1.51")
         response.headers.add(name: "Builder-Version", value: "")
         response.headers.add(name: "Docker-Experimental", value: "false")
+        // Podman's own client checks this on GET /_ping during connection setup
+        // (pkg/bindings/connection.go's pingNewConnection) — without it, podman
+        // just warns and assumes version 0.0.0, but setting a real, current
+        // value avoids that warning and any future MinimalAPI version gate.
+        response.headers.add(name: "Libpod-API-Version", value: "5.0.0")
         response.headers.add(name: "Cache-Control", value: "no-cache, no-store, must-revalidate")
         response.headers.add(name: "Pragma", value: "no-cache")
         return response

--- a/Sources/socktainer/Routes/Server/InfoRoute.swift
+++ b/Sources/socktainer/Routes/Server/InfoRoute.swift
@@ -49,7 +49,7 @@ struct InfoRoute: RouteCollection {
         }
     }
 
-    private static func handle(
+    static func handle(
         _ req: Request,
         containerClient: ClientContainerProtocol,
         imageClient: ClientImageProtocol,

--- a/Sources/socktainer/Utilities/ArchiveUtility.swift
+++ b/Sources/socktainer/Utilities/ArchiveUtility.swift
@@ -100,6 +100,38 @@ struct ArchiveUtility {
                 continue
             }
 
+            // A hard-link entry carries a populated `hardlink` (the linked-to path,
+            // archive-root-relative like the entry's own `path`, not entry-directory-relative
+            // like a symlink target) regardless of what `fileType` itself reports for it
+            // (confirmed empirically: this framework's reader surfaces a hard-link entry's
+            // `fileType` as `.unknown`, landing it in the `default:` case below — NOT
+            // `.regular`, despite that being this project's own EXT4 exporter's convention for
+            // entries it constructs itself). Its data stream is empty — falling through to
+            // `default:`'s "unsupported, skip" handling would silently produce no file at all
+            // instead of linking to the earlier entry's real content.
+            if let hardlinkTarget = entry.hardlink {
+                guard let linkSource = safeDestination(for: hardlinkTarget, under: destination, destinationPath: destinationPath),
+                    hasSafeAncestors(of: linkSource, under: destination)
+                else {
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                try fileManager.createDirectory(at: fullPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+                // "Last entry wins", matching `.regular`/`.directory`/`.symbolicLink`.
+                try? fileManager.removeItem(at: fullPath)
+                guard link(linkSource.path, fullPath.path) == 0 else {
+                    // ENOENT (the archive references a hard-link target that hasn't been
+                    // extracted, e.g. malformed ordering) is an unsupported/malformed entry,
+                    // not a host-side failure — anything else still deserves a hard failure.
+                    guard errno == ENOENT else {
+                        throw ArchiveUtilityError.archiveWriteFailed("\(rawPath): link failed (errno \(errno))")
+                    }
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                continue
+            }
+
             switch entry.fileType {
             case .directory:
                 // "Last entry wins", matching the `.regular` case below: a prior entry may
@@ -117,7 +149,14 @@ struct ArchiveUtility {
                     try? fileManager.removeItem(at: fullPath)
                 }
                 try fileManager.createDirectory(at: fullPath, withIntermediateDirectories: true)
-                pendingDirectoryPermissions.append((fullPath.path, mode_t(entry.permissions & 0o777)))
+                // Skip the extraction root itself (a `.`/`./` entry, per `safeDestination`,
+                // resolves to `destination` verbatim) — the caller created `destination` with
+                // its own intended permissions before extraction ever started, and a tar
+                // entry's recorded mode for the archive's own top-level directory (which can be
+                // arbitrarily restrictive) has no business overriding that.
+                if fullPath.standardizedFileURL.path != destinationPath {
+                    pendingDirectoryPermissions.append((fullPath.path, mode_t(entry.permissions & 0o777)))
+                }
             case .regular:
                 try fileManager.createDirectory(at: fullPath.deletingLastPathComponent(), withIntermediateDirectories: true)
                 // "Last entry wins", matching the framework's own extraction semantics.
@@ -211,9 +250,10 @@ struct ArchiveUtility {
                 let linkDestination = isAbsoluteTarget ? relativePath(from: fullPath.deletingLastPathComponent(), to: resolvedTarget) : target
                 try fileManager.createSymbolicLink(atPath: fullPath.path, withDestinationPath: linkDestination)
             default:
-                // Hard-link entries (and anything else libarchive might surface) land
-                // here — the framework's own `extractEntry` has no support for them
-                // either (its `default: return false`). Unlike a path-traversal/symlink
+                // Hard links are handled above (regardless of `fileType`) before this switch
+                // is ever reached. Anything else libarchive might surface (FIFOs, device
+                // nodes, ...) lands here — the framework's own `extractEntry` has no support
+                // for them either (its `default: return false`). Unlike a path-traversal/symlink
                 // violation above, this is just an unsupported (not hostile) tar feature a
                 // real build context can legitimately contain — logged for visibility, but
                 // not fatal to the rest of the extraction.

--- a/Sources/socktainer/Utilities/ArchiveUtility.swift
+++ b/Sources/socktainer/Utilities/ArchiveUtility.swift
@@ -100,6 +100,18 @@ struct ArchiveUtility {
                 continue
             }
 
+            // The extraction root itself (fullPath == destination, from a "."/"./" entry per
+            // `safeDestination`) may only ever be an ordinary directory entry — its own
+            // pendingDirectoryPermissions handling further down applies just to that case.
+            // Any OTHER entry type resolving directly to the destination (a regular file, a
+            // symlink, or — the case this guards against — a hard link, which would `removeItem`
+            // and then re-link the extraction root itself) is rejected outright rather than
+            // processed, matching how every other unsafe entry shape here is handled.
+            if fullPath.standardizedFileURL.path == destinationPath, entry.hardlink != nil || entry.fileType != .directory {
+                rejectedPaths.append(rawPath)
+                continue
+            }
+
             // A hard-link entry carries a populated `hardlink` (the linked-to path,
             // archive-root-relative like the entry's own `path`, not entry-directory-relative
             // like a symlink target) regardless of what `fileType` itself reports for it

--- a/Sources/socktainer/Utilities/ArchiveUtility.swift
+++ b/Sources/socktainer/Utilities/ArchiveUtility.swift
@@ -1,6 +1,7 @@
 import ContainerizationArchive
 import ContainerizationEXT4
 import Foundation
+import Logging
 import SystemPackage
 
 enum ArchiveUtilityError: Error {
@@ -14,7 +15,7 @@ enum ArchiveUtilityError: Error {
 
 struct ArchiveUtility {
 
-    static func extract(tarPath: URL, to destination: URL) throws {
+    static func extract(tarPath: URL, to destination: URL, logger: Logger? = nil) throws {
         let fileManager = FileManager.default
 
         guard fileManager.fileExists(atPath: tarPath.path) else {
@@ -31,7 +32,7 @@ struct ArchiveUtility {
         }
 
         do {
-            let rejectedPaths = try archiveReader.extractContents(to: destination)
+            let rejectedPaths = try extractEntries(from: archiveReader, to: destination, logger: logger)
             if !rejectedPaths.isEmpty {
                 throw ArchiveUtilityError.rejectedArchiveEntries(rejectedPaths)
             }
@@ -40,6 +41,294 @@ struct ArchiveUtility {
                 throw error
             }
             throw ArchiveUtilityError.archiveReadFailed(error.localizedDescription)
+        }
+    }
+
+    /// Extracts every entry from `reader` into `destination`, entry by entry via
+    /// the archive's public streaming iterator.
+    ///
+    /// `ArchiveReader.extractContents(to:)` (from the vendored Containerization
+    /// framework) creates regular files via `open(O_CREAT | O_EXCL | O_WRONLY, entry.permissions)`,
+    /// using the entry's own recorded mode as the create mode. On macOS that
+    /// fails with EACCES for any entry whose mode has no owner-write bit —
+    /// e.g. read-only vendored/test binaries such as kubebuilder's envtest
+    /// `etcd`/`kube-apiserver`, which real build contexts do contain — because
+    /// the create-for-write and the final (read-only) permission bits can't
+    /// both be satisfied by that one syscall. This creates files with a
+    /// writable mode, writes their content, then `chmod`s to the entry's real
+    /// mode afterward, so such entries extract instead of aborting the whole
+    /// build.
+    private static func extractEntries(from reader: ArchiveReader, to destination: URL, logger: Logger?) throws -> [String] {
+        let fileManager = FileManager.default
+        let destinationPath = destination.standardizedFileURL.path
+        var rejectedPaths: [String] = []
+        // Entry types this extractor has no support for (hard links, FIFOs, etc.) — these
+        // are ordinary, benign tar features a real build context can legitimately contain,
+        // unlike `rejectedPaths` (path traversal / symlink-planting), so they're only
+        // logged, not treated as a reason to fail the whole extraction.
+        var unsupportedPaths: [String] = []
+        var foundEntry = false
+        // Applied only after every entry is processed (see below the loop) — a directory's
+        // recorded mode can be restrictive (e.g. read+execute only), and tar conventionally
+        // lists a directory before its own contents, so applying it immediately could block
+        // creating that directory's later children.
+        var pendingDirectoryPermissions: [(path: String, mode: mode_t)] = []
+        // Allocated once and reused for every regular-file entry's copy loop, instead of a
+        // fresh 128 KiB zero-filled array per entry — a real archive can contain thousands
+        // of small files.
+        var copyBuffer = [UInt8](repeating: 0, count: 128 * 1024)
+
+        for (entry, dataReader) in reader.makeStreamingIterator() {
+            foundEntry = true
+            guard let rawPath = entry.path else {
+                unsupportedPaths.append("<unnamed entry>")
+                continue
+            }
+
+            guard let fullPath = safeDestination(for: rawPath, under: destination, destinationPath: destinationPath) else {
+                rejectedPaths.append(rawPath)
+                continue
+            }
+            // `open(..., O_NOFOLLOW)` below only refuses a symlink at the FINAL path
+            // component — a malicious archive can still plant a symlink entry (e.g.
+            // `evil -> /etc`) and a later entry whose path runs *through* it
+            // (`evil/cron.d/x`), since normal path resolution transparently follows a
+            // symlink in an intermediate component. Reject those before touching the
+            // filesystem at all, rather than relying on the final-component check alone.
+            guard hasSafeAncestors(of: fullPath, under: destination) else {
+                rejectedPaths.append(rawPath)
+                continue
+            }
+
+            switch entry.fileType {
+            case .directory:
+                // "Last entry wins", matching the `.regular` case below: a prior entry may
+                // have written a non-directory at this same path (e.g. a symlink or file
+                // entry reusing the path before a later, corrected directory entry) —
+                // `createDirectory` fails outright if something non-directory already
+                // occupies the path, so clear it first the same way `.regular` does.
+                // `lstat` (not `fileManager.fileExists(atPath:isDirectory:)`, which follows
+                // symlinks) — a symlink at this exact path must be removed even when it
+                // happens to resolve to an existing directory, or `createDirectory` below
+                // would silently no-op and leave the symlink in place instead of a real
+                // directory at `fullPath` itself.
+                var linkInfo = stat()
+                if lstat(fullPath.path, &linkInfo) == 0, (linkInfo.st_mode & S_IFMT) != S_IFDIR {
+                    try? fileManager.removeItem(at: fullPath)
+                }
+                try fileManager.createDirectory(at: fullPath, withIntermediateDirectories: true)
+                pendingDirectoryPermissions.append((fullPath.path, mode_t(entry.permissions & 0o777)))
+            case .regular:
+                try fileManager.createDirectory(at: fullPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+                // "Last entry wins", matching the framework's own extraction semantics.
+                try? fileManager.removeItem(at: fullPath)
+                // O_EXCL | O_NOFOLLOW (matching the framework's own extraction code) closes a
+                // TOC-TOU/symlink-planting attack: a malicious archive can't plant a symlink
+                // entry, then a same-path regular-file entry, to make this write follow the
+                // symlink outside `destination` (e.g. via `docker load`/`import` of an
+                // untrusted tarball) — if the prior `removeItem` didn't actually clear the
+                // path, this fails closed instead of writing through whatever's still there.
+                // The create mode is writable regardless of the entry's own recorded mode
+                // (fixed via `fchmod` after writing) — seeding the real, possibly read-only,
+                // mode directly into O_CREAT fails with EACCES on macOS.
+                let fd = open(fullPath.path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o644)
+                guard fd >= 0 else {
+                    // EEXIST (the prior `removeItem` didn't actually clear the path — the
+                    // TOC-TOU case this guards) and ELOOP (a symlink at the final
+                    // component) both mean the archive itself is malformed/hostile at this
+                    // entry; anything else (ENOSPC, EMFILE, a real EACCES on the
+                    // destination, ...) is a host-side failure and must not be silently
+                    // downgraded to "one weird archive entry we skipped".
+                    guard errno == EEXIST || errno == ELOOP else {
+                        throw ArchiveUtilityError.archiveWriteFailed("\(rawPath): open failed (errno \(errno))")
+                    }
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                defer { close(fd) }
+                try copy(dataReader: dataReader, to: fd, path: rawPath, buffer: &copyBuffer)
+                guard fchmod(fd, mode_t(entry.permissions & 0o777)) == 0 else {
+                    throw ArchiveUtilityError.archiveWriteFailed("\(rawPath): fchmod failed (errno \(errno))")
+                }
+                if let modificationDate = entry.modificationDate {
+                    do {
+                        try fileManager.setAttributes([.modificationDate: modificationDate], ofItemAtPath: fullPath.path)
+                    } catch {
+                        throw ArchiveUtilityError.archiveWriteFailed("\(rawPath): failed to set modification date: \(error)")
+                    }
+                }
+            case .symbolicLink:
+                guard let target = entry.symlinkTarget else {
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                // The link is resolved by whatever later walks the extracted tree (e.g. a
+                // build step reading through the context), so a target that would escape
+                // `destination` is a real traversal even though extraction itself never
+                // follows it. An absolute target (e.g. `/bin/sh -> /bin/busybox`, common in
+                // real image layers) is interpreted relative to the extracted tree's own
+                // root the same way `safeDestination` re-roots an absolute entry path —
+                // rejecting every absolute symlink outright would break ordinary archives,
+                // not just malicious ones. `resolvedTarget` is used for containment/ancestor
+                // validation only; the on-disk link is written as a RELATIVE path (computed
+                // below) so it still resolves correctly if the extracted tree is later moved
+                // or copied elsewhere — baking in the transient extraction destination's own
+                // absolute path would leave the link dangling the moment that happens.
+                let isAbsoluteTarget = target.hasPrefix("/")
+                let resolvedTarget =
+                    isAbsoluteTarget
+                    ? destination.appendingPathComponent(String(target.dropFirst())).standardizedFileURL
+                    : fullPath.deletingLastPathComponent().appendingPathComponent(target).standardizedFileURL
+                guard resolvedTarget.path == destinationPath || resolvedTarget.path.hasPrefix(destinationPath + "/") else {
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                // The lexical containment check above only looks at the target's own path
+                // string — it can't detect that an intermediate component was already
+                // created as a symlink by an EARLIER entry in this same archive (e.g. `a/link
+                // -> /etc`, itself validated as contained), which would redirect a later
+                // symlink's actual resolution (`b/x -> ../a/link/passwd`, lexically
+                // "contained" as a string) outside `destination` once something dereferences
+                // it. Reuse the same ancestor-symlink check already applied to the entry's own
+                // path against the TARGET's path too.
+                guard hasSafeAncestors(of: resolvedTarget, under: destination) else {
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                try fileManager.createDirectory(at: fullPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try? fileManager.removeItem(at: fullPath)
+                // "Last entry wins" (matching `.regular`/`.directory`) — but unlike those,
+                // if `removeItem` didn't actually clear the path, `createSymbolicLink` would
+                // throw and abort the WHOLE extraction rather than just this one entry. Check
+                // via `lstat` (not `fileExists`, which follows symlinks and would misreport a
+                // still-present but now-dangling symlink as "gone") and reject through the
+                // normal per-entry path instead.
+                var residualInfo = stat()
+                guard lstat(fullPath.path, &residualInfo) != 0 else {
+                    rejectedPaths.append(rawPath)
+                    continue
+                }
+                let linkDestination = isAbsoluteTarget ? relativePath(from: fullPath.deletingLastPathComponent(), to: resolvedTarget) : target
+                try fileManager.createSymbolicLink(atPath: fullPath.path, withDestinationPath: linkDestination)
+            default:
+                // Hard-link entries (and anything else libarchive might surface) land
+                // here — the framework's own `extractEntry` has no support for them
+                // either (its `default: return false`). Unlike a path-traversal/symlink
+                // violation above, this is just an unsupported (not hostile) tar feature a
+                // real build context can legitimately contain — logged for visibility, but
+                // not fatal to the rest of the extraction.
+                unsupportedPaths.append(rawPath)
+            }
+        }
+
+        if !unsupportedPaths.isEmpty {
+            logger?.warning("Archive contained unsupported entries, skipped: \(unsupportedPaths.joined(separator: ", "))")
+        }
+
+        // Applied only now that every entry (including any of this directory's own children)
+        // has already been created — a restrictive mode set immediately, per the comment on
+        // `pendingDirectoryPermissions` above, could otherwise block creating later entries.
+        // Reversed (deepest child first): chmod'ing a path requires execute/search permission
+        // on every ancestor directory to resolve it — applying a restrictive parent mode
+        // before a still-pending child chmod underneath it could make that child's own path
+        // unresolvable.
+        for (path, mode) in pendingDirectoryPermissions.reversed() {
+            try? fileManager.setAttributes([.posixPermissions: mode], ofItemAtPath: path)
+        }
+
+        guard foundEntry else {
+            throw ArchiveUtilityError.archiveReadFailed("no entries found in archive")
+        }
+        return rejectedPaths
+    }
+
+    /// Verifies no ancestor directory between `destination` and `fullPath` is itself a
+    /// symlink (see the call site's comment for the attack this closes). Not fully
+    /// TOC-TOU-atomic (an `openat`-relative-fd walk would be) — but extraction here is
+    /// single-threaded and sequential over an archive nothing else is concurrently
+    /// mutating, so the realistic threat is the archive planting the symlink itself,
+    /// which this reliably catches.
+    private static func hasSafeAncestors(of fullPath: URL, under destination: URL) -> Bool {
+        let destinationPath = destination.standardizedFileURL.path
+        var current = fullPath.deletingLastPathComponent().standardizedFileURL
+        // `hasPrefix(destinationPath + "/")` (not bare `destinationPath`), matching
+        // `safeDestination`'s own boundary check — otherwise a sibling directory like
+        // `<destinationPath>-evil` would incorrectly be treated as an ancestor under
+        // `destination`.
+        while current.path.hasPrefix(destinationPath + "/") {
+            var info = stat()
+            if lstat(current.path, &info) == 0, (info.st_mode & S_IFMT) == S_IFLNK {
+                return false
+            }
+            current = current.deletingLastPathComponent()
+        }
+        return true
+    }
+
+    /// Computes the relative path from `sourceDir` to `target` (e.g. `../etc/passwd`),
+    /// so an absolute symlink target can be re-rooted under `destination` for containment
+    /// checking while still being WRITTEN to disk as a portable, relative link — one that
+    /// keeps resolving correctly if the extracted tree is later moved or copied elsewhere,
+    /// unlike baking in the transient extraction destination's own absolute path.
+    private static func relativePath(from sourceDir: URL, to target: URL) -> String {
+        let sourceComponents = sourceDir.standardizedFileURL.pathComponents
+        let targetComponents = target.standardizedFileURL.pathComponents
+        var shared = 0
+        while shared < sourceComponents.count, shared < targetComponents.count, sourceComponents[shared] == targetComponents[shared] {
+            shared += 1
+        }
+        let ups = Array(repeating: "..", count: sourceComponents.count - shared)
+        let downs = targetComponents[shared...]
+        let combined = ups + downs
+        return combined.isEmpty ? "." : combined.joined(separator: "/")
+    }
+
+    /// Resolves a tar member path to a destination URL, rejecting absolute
+    /// paths and any path that escapes `destination` (e.g. via `..` components).
+    /// A root entry (`.`/`./`, which this project's own `ArchiveWriter` emits
+    /// for the archive's top-level directory) resolves to `destination` itself
+    /// rather than being rejected as empty.
+    private static func safeDestination(for rawPath: String, under destination: URL, destinationPath: String) -> URL? {
+        var relative = rawPath
+        if relative.hasPrefix("./") { relative.removeFirst(2) }
+        while relative.hasPrefix("/") { relative.removeFirst() }
+        if relative.isEmpty || relative == "." {
+            return destination.standardizedFileURL
+        }
+
+        let fullPath = destination.appendingPathComponent(relative).standardizedFileURL
+        let resolved = fullPath.path
+        guard resolved == destinationPath || resolved.hasPrefix(destinationPath + "/") else {
+            return nil
+        }
+        return fullPath
+    }
+
+    private static func copy(dataReader: ArchiveEntryReader, to fd: Int32, path: String, buffer: inout [UInt8]) throws {
+        while true {
+            let bytesRead = buffer.withUnsafeMutableBufferPointer { ptr -> Int in
+                guard let base = ptr.baseAddress else { return 0 }
+                return dataReader.read(base, maxLength: ptr.count)
+            }
+            guard bytesRead >= 0 else {
+                throw ArchiveUtilityError.entryReadFailed(path)
+            }
+            if bytesRead == 0 { break }
+            // `write(2)` isn't guaranteed to consume the whole buffer in one call (short
+            // writes are legal, not just an error signal) — drain it, retrying a signal
+            // interruption (EINTR) rather than treating either as a failure.
+            var offset = 0
+            while offset < bytesRead {
+                errno = 0
+                let written = buffer.withUnsafeBytes { raw -> Int in
+                    write(fd, raw.baseAddress!.advanced(by: offset), bytesRead - offset)
+                }
+                if written < 0 && errno == EINTR { continue }
+                guard written > 0 else {
+                    throw ArchiveUtilityError.archiveWriteFailed("\(path): write failed (errno \(errno))")
+                }
+                offset += written
+            }
         }
     }
 

--- a/Sources/socktainer/Utilities/DockerProgressFrame.swift
+++ b/Sources/socktainer/Utilities/DockerProgressFrame.swift
@@ -21,6 +21,13 @@ enum DockerProgressFrame {
         let stream: String
     }
 
+    private struct IdFrame: Encodable {
+        let id: String
+        enum CodingKeys: String, CodingKey {
+            case id = "Id"
+        }
+    }
+
     private struct ProgressBarFrame: Encodable {
         struct Detail: Encodable {
             let current: Int64
@@ -37,6 +44,13 @@ enum DockerProgressFrame {
 
     static func stream(_ message: String) -> String {
         encode(StreamFrame(stream: message))
+    }
+
+    /// A completion frame carrying only an `Id` — real podman's `manifest push` client
+    /// (`pkg/bindings/manifests`'s `Push`) requires seeing one of these before it accepts
+    /// a clean stream close as success; a plain EOF is otherwise reported as a decode error.
+    static func manifestPushId(_ id: String) -> String {
+        encode(IdFrame(id: id))
     }
 
     static func progress(status: String, id: String, current: Int64, total: Int64) -> String {
@@ -60,16 +74,43 @@ enum DockerProgressFrame {
 
     /// Streams progress messages as status frames, converts a thrown error
     /// into a final error frame, and always ends the body cleanly.
+    ///
+    /// - Parameters:
+    ///   - useStreamKey: real podman clients (`pkg/bindings/images`'s `Push`,
+    ///     `pkg/bindings/manifests`'s `Push`) decode into a struct with a `stream`
+    ///     field, not `status` — a `{"status": ...}` frame silently decodes to an
+    ///     all-empty report and is rejected as unparseable. Docker-compat clients
+    ///     expect `status`. Pass `true` for a request reaching this over `/libpod/*`.
+    ///   - finalFrame: an already-JSON-encoded frame (see `manifestPushId`) written
+    ///     immediately before the stream ends, only on the success path — used by
+    ///     manifest push to satisfy its stricter "must see an `Id` before EOF" check.
     static func pipe(
         _ progress: AsyncThrowingStream<String, Error>,
         to writer: any BodyStreamWriter,
-        onSuccess: (() async -> Void)? = nil
+        useStreamKey: Bool = false,
+        onSuccess: (() async -> Void)? = nil,
+        finalFrame: (() async -> String?)? = nil
     ) async {
         do {
             for try await message in progress {
-                write(status(message), to: writer)
+                write(useStreamKey ? stream(message) : status(message), to: writer)
             }
             await onSuccess?()
+            if let finalFrame {
+                if let frame = await finalFrame() {
+                    write(frame, to: writer)
+                } else {
+                    // The operation itself succeeded (we reached here past the `for try
+                    // await` loop with no thrown error), but the caller's finalFrame
+                    // closure couldn't produce its required completion frame (e.g. a
+                    // post-success digest lookup failed). Ending the stream silently here
+                    // would leave the client waiting on a frame that's never coming — real
+                    // podman's manifest push client reports a bare EOF with no `Id` frame as
+                    // a decode error anyway, so surface an explicit error frame instead of
+                    // the more opaque failure that a silent EOF produces.
+                    write(Self.error("push succeeded but the completion frame could not be produced"), to: writer)
+                }
+            }
         } catch {
             write(Self.error(String(describing: error)), to: writer)
         }

--- a/Sources/socktainer/Utilities/PlatformUtility.swift
+++ b/Sources/socktainer/Utilities/PlatformUtility.swift
@@ -41,6 +41,45 @@ public func platformOrThrow(_ platformString: String) throws -> Platform {
     return try Platform(from: trimmed)
 }
 
+/// Parses a comma-separated platform specification string (e.g. "linux/arm64,linux/s390x")
+/// into an array of `Platform` values. Trims whitespace around each entry.
+/// Throws if the string is empty or any individual platform token is invalid.
+public func parseMultiPlatformString(_ platformString: String) throws -> [Platform] {
+    let parts =
+        platformString
+        .split(separator: ",")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    guard !parts.isEmpty else {
+        throw Abort(.badRequest, reason: "Empty platform specification")
+    }
+
+    return try parts.map { part in
+        do {
+            return try Platform(from: part)
+        } catch {
+            throw Abort(
+                .badRequest,
+                reason: "Unsupported platform '\(part)' (expected format: os/architecture, e.g. linux/arm64): \(String(describing: error))"
+            )
+        }
+    }
+}
+
+/// Returns `true` when `platform` requires QEMU emulation inside the BuildKit container
+/// VM – i.e. it is neither `arm64` (native on Apple Silicon) nor `amd64` / `x86_64`
+/// (handled by Rosetta 2 on Apple Silicon).
+public func platformRequiresQEMU(_ platform: Platform) -> Bool {
+    let normalized = dockerInfoArchitecture(platform.architecture.lowercased())
+    return normalized != "aarch64" && normalized != "x86_64"
+}
+
+/// Returns `true` when any of the requested platforms requires QEMU emulation.
+public func platformsRequireQEMU(_ platforms: [Platform]) -> Bool {
+    platforms.contains(where: platformRequiresQEMU)
+}
+
 public func requestedOrDefaultPlatform(_ requestedPlatform: Platform?) -> Platform {
     requestedPlatform ?? Platform.current
 }

--- a/Sources/socktainer/Utilities/RegexRouter.swift
+++ b/Sources/socktainer/Utilities/RegexRouter.swift
@@ -19,6 +19,27 @@ struct RegexRoute {
     let method: HTTPMethod
     let regex: NSRegularExpression
     let handler: @Sendable (Request, [String]) async throws -> Response
+    /// Precomputed at registration time (the pattern never changes afterward) so per-request
+    /// matching doesn't rescan every candidate's pattern string on every incoming request.
+    /// See `RegexRoutingMiddleware.respond` for how this ranks competing matches. Callers
+    /// derive these from the original route TEMPLATE (before `{param}` -> regex conversion,
+    /// see `RegexRouter.templateSpecificity`) rather than the compiled regex pattern string —
+    /// the compiled pattern's length/slash-count can vary with parameter name length or regex
+    /// boilerplate (anchors, the optional version prefix) in ways that don't reflect the
+    /// route's actual literal structure.
+    let specificitySlashes: Int
+    let specificityLength: Int
+
+    init(
+        method: HTTPMethod, regex: NSRegularExpression, handler: @escaping @Sendable (Request, [String]) async throws -> Response,
+        specificitySlashes: Int, specificityLength: Int
+    ) {
+        self.method = method
+        self.regex = regex
+        self.handler = handler
+        self.specificitySlashes = specificitySlashes
+        self.specificityLength = specificityLength
+    }
 }
 
 final class RegexRouter: @unchecked Sendable {
@@ -35,7 +56,8 @@ final class RegexRouter: @unchecked Sendable {
         handler: @escaping @Sendable (Request, [String]) async throws -> Response
     ) throws {
         let regex = try NSRegularExpression(pattern: pattern)
-        routes.append(RegexRoute(method: method, regex: regex, handler: handler))
+        let (slashes, length) = Self.templateSpecificity(pattern)
+        insertSorted(RegexRoute(method: method, regex: regex, handler: handler, specificitySlashes: slashes, specificityLength: length))
     }
 
     func register<T: AsyncResponseEncodable & Sendable>(
@@ -72,7 +94,42 @@ final class RegexRouter: @unchecked Sendable {
             return try await result.encodeResponse(for: req)
         }
 
-        routes.append(RegexRoute(method: method, regex: regex, handler: handler))
+        let specificity = Self.templateSpecificity(pattern)
+        insertSorted(
+            RegexRoute(
+                method: method, regex: regex, handler: handler,
+                specificitySlashes: specificity.slashes, specificityLength: specificity.length))
+    }
+
+    /// Computes route specificity from the ORIGINAL route template (e.g.
+    /// `/libpod/manifests/{name}/registry/{destination}`), before `{param}` placeholders are
+    /// converted to regex capture groups — see `RegexRoute.specificitySlashes` for why this
+    /// must come from the template rather than the compiled regex pattern. Placeholders are
+    /// collapsed to a single marker character first so two routes differing only in parameter
+    /// name length (e.g. `{name}` vs `{destination}`) don't spuriously compare as differently
+    /// specific.
+    private static func templateSpecificity(_ pattern: String) -> (slashes: Int, length: Int) {
+        let placeholderRegex = try! NSRegularExpression(pattern: #"\{[^}]*\}"#)
+        let normalized = placeholderRegex.stringByReplacingMatches(
+            in: pattern, range: NSRange(location: 0, length: pattern.utf16.count), withTemplate: "\u{2022}")
+        let slashes = normalized.filter { $0 == "/" }.count
+        return (slashes, normalized.count)
+    }
+
+    /// Inserts `route` keeping `routes` ordered by descending specificity (most literal
+    /// `/` characters, then longest pattern, ties broken by registration order) — see
+    /// `RegexRoutingMiddleware.respond` for why match order matters. Registration only
+    /// happens a fixed, small number of times at startup, so re-deriving the sorted
+    /// position per insert is cheap; every per-request match then gets to short-circuit
+    /// on the first hit instead of scanning every candidate.
+    private func insertSorted(_ route: RegexRoute) {
+        let index = routes.firstIndex { existing in
+            if existing.specificitySlashes != route.specificitySlashes {
+                return existing.specificitySlashes < route.specificitySlashes
+            }
+            return existing.specificityLength < route.specificityLength
+        }
+        routes.insert(route, at: index ?? routes.count)
     }
 
     private func convertMobyRoutePatternToRegex(_ pattern: String) -> (regex: String, parameterNames: [String]) {
@@ -103,7 +160,7 @@ final class RegexRouter: @unchecked Sendable {
         // Add optional version prefix: /v1.47/images/... or /images/...
         // Group 1: version (e.g., "1.47")
         // Group 2+: original parameters
-        regexPattern = "^(?:/v([0-9]+\\.[0-9]+))?" + regexPattern + "$"
+        regexPattern = "^(?:/v([0-9]+\\.[0-9]+(?:\\.[0-9]+)?))?" + regexPattern + "$"
 
         return (regexPattern, parameterNames)
     }
@@ -123,26 +180,45 @@ struct RegexRoutingMiddleware: Middleware {
 
         request.logger.debug("RegexRouter: Checking path '\(path)' against \(regexRouter.routes.count) registered routes")
 
+        let range = NSRange(location: 0, length: path.utf16.count)
+        // A route's pattern is a fixed string (not path components), so match specificity
+        // can't be judged by "path segment count" the way most routers do it. Instead:
+        // `routes` is kept sorted (see `RegexRouter.insertSorted`) by descending literal
+        // `/` count in the pattern, then pattern length — a route like
+        // `/libpod/manifests/{name}/registry/{destination}` has strictly more literal
+        // structure around its wildcards than the bare `/libpod/manifests/{name}`, so it
+        // sorts earlier and is tried first. Without this, a greedy `.+` wildcard in a
+        // less-specific route (e.g. manifest create's `{name:.*}`) matches ANY longer path
+        // first-registered-wins, silently swallowing requests meant for a more specific
+        // sibling route registered later (e.g. manifest push's `{name}/registry/{destination}`,
+        // whose full destination ends up captured as part of "name" instead). Iterating in
+        // that pre-sorted order lets this short-circuit on the first (most specific) match
+        // instead of evaluating every candidate on every request.
         for route in regexRouter.routes where route.method == request.method {
-            let range = NSRange(location: 0, length: path.utf16.count)
             request.logger.debug("RegexRouter: Testing regex pattern '\(route.regex.pattern)' against path '\(path)'")
+            guard let match = route.regex.firstMatch(in: path, range: range) else { continue }
 
-            if let match = route.regex.firstMatch(in: path, range: range) {
-                let groups = (1..<match.numberOfRanges).compactMap { groupIndex in
-                    let range = match.range(at: groupIndex)
-                    // Check if the range is valid (NSNotFound indicates no match for optional groups)
-                    guard range.location != NSNotFound else { return "" }
-                    return (path as NSString).substring(with: range)
-                }
-
-                request.logger.debug("RegexRouter: MATCHED! Captured groups: \(groups)")
-
-                let promise = request.eventLoop.makePromise(of: Response.self)
-                promise.completeWithTask {
-                    try await route.handler(request, groups)
-                }
-                return promise.futureResult
+            let groups = (1..<match.numberOfRanges).map { groupIndex -> String in
+                let range = match.range(at: groupIndex)
+                // Check if the range is valid (NSNotFound indicates no match for optional groups)
+                guard range.location != NSNotFound else { return "" }
+                let raw = (path as NSString).substring(with: range)
+                // `request.url.path` is still percent-encoded (Vapor's `URI.path` only
+                // unescapes a literal `%3B`), so a `.*`-style segment containing an
+                // encoded `/` (e.g. `docker://192.168.1.1:5000/repo:tag` path-encoded
+                // as `.../registry/192.168.1.1:5000%2Frepo:tag`, real podman's manifest
+                // push destination form) would otherwise reach the handler with a
+                // literal `%2F` still in it instead of a real slash.
+                return raw.removingPercentEncoding ?? raw
             }
+
+            request.logger.debug("RegexRouter: MATCHED! pattern='\(route.regex.pattern)' Captured groups: \(groups)")
+
+            let promise = request.eventLoop.makePromise(of: Response.self)
+            promise.completeWithTask {
+                try await route.handler(request, groups)
+            }
+            return promise.futureResult
         }
 
         request.logger.debug("RegexRouter: No regex routes matched, passing to next middleware")

--- a/Sources/socktainer/Utilities/RepeatedQueryParam.swift
+++ b/Sources/socktainer/Utilities/RepeatedQueryParam.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Recovers every value of a repeated query parameter from a raw query string.
+///
+/// Real podman clients send several build/manifest options as the SAME query key
+/// repeated once per value (e.g. `platform=linux/arm64&platform=linux/amd64`,
+/// `images=foo&images=bar`) rather than one comma-joined or bracket-array value.
+/// `Vapor.Content` decoding a repeated key into a scalar field silently keeps only
+/// the last occurrence — this parses the raw, still-percent-encoded query string
+/// (e.g. `req.url.query`) directly to recover every value.
+///
+/// Parses `&`/`=` manually rather than via `URLComponents.percentEncodedQuery` —
+/// that setter validates its input and can trap on a malformed percent-escape in
+/// this client-controlled string, which would be a crash, not a graceful decode
+/// failure. A key or value that fails to percent-decode is used as-is instead of
+/// being dropped, matching this function's existing "never throws" contract.
+func allQueryValues(named name: String, from queryString: String?) -> [String] {
+    guard let queryString, !queryString.isEmpty else { return [] }
+    return queryString.split(separator: "&").compactMap { pair -> String? in
+        let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let rawKey = parts.first else { return nil }
+        // `+` means space in form-encoded query strings; `removingPercentEncoding` only
+        // handles `%XX`, so translate it first to match Vapor's own query decoding.
+        let keySource = String(rawKey).replacingOccurrences(of: "+", with: " ")
+        let key = keySource.removingPercentEncoding ?? keySource
+        guard key == name else { return nil }
+        guard parts.count > 1 else { return "" }
+        let valueSource = String(parts[1]).replacingOccurrences(of: "+", with: " ")
+        return valueSource.removingPercentEncoding ?? valueSource
+    }
+}

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -87,12 +87,13 @@ func configure(_ app: Application) async throws {
     try app.register(collection: ContainerWaitRoute(client: containerClient))
 
     // /images
+    let manifestClient = ClientManifestService(appSupportURL: appleContainerAppSupportUrl, containerSystemConfig: systemConfig)
     try app.register(collection: ImageDeleteRoute(client: imageClient))
     try app.register(collection: ImageHistoryRoute(systemConfig: systemConfig))
     try app.register(collection: ImageListRoute(client: imageClient))
     try app.register(collection: ImagePruneRoute(client: imageClient))
     try app.register(collection: ImageCreateRoute(client: imageClient))
-    try app.register(collection: ImagePushRoute(client: imageClient))
+    try app.register(collection: ImagePushRoute(client: imageClient, manifestClient: manifestClient))
     try app.register(collection: ImageSearchRoute())
     try app.register(collection: ImageInspectRoute(systemConfig: systemConfig))
     try app.register(collection: ImageTagRoute(systemConfig: systemConfig))
@@ -126,7 +127,7 @@ func configure(_ app: Application) async throws {
 
     // --- build/distribution routes ---
     try app.register(collection: BuildPruneRoute(builderClient: builderClient))
-    try app.register(collection: BuildRoute(client: containerClient, builderClient: builderClient, systemConfig: systemConfig))
+    try app.register(collection: BuildRoute(client: containerClient, builderClient: builderClient, systemConfig: systemConfig, manifestClient: manifestClient))
     try app.register(collection: DistributionJsonRoute(systemConfig: systemConfig))
 
     // --- plugin routes ---
@@ -177,13 +178,85 @@ func configure(_ app: Application) async throws {
     // --- miscellaneous ---
     try app.register(collection: AuthRoute(client: registryClient))
     try app.register(collection: CommitRoute())
-    try app.register(
-        collection: SystemDFRoute(
-            imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient,
-            diskUsageProvider: ContainerClientDiskUsageProvider(),
-            imageLayerDiskUsageProvider: ClientImageLayerDiskUsageProvider()
-        ))
+    let systemDFRoute = SystemDFRoute(
+        imageClient: imageClient, containerClient: containerClient, volumeClient: volumeClient, builderClient: builderClient,
+        diskUsageProvider: ContainerClientDiskUsageProvider(),
+        imageLayerDiskUsageProvider: ClientImageLayerDiskUsageProvider()
+    )
+    try app.register(collection: systemDFRoute)
     try app.register(collection: VersionRoute())
+
+    // --- Podman libpod routes ---
+    try app.register(collection: LibpodPingRoute(client: healthCheckClient))
+    try app.register(collection: LibpodVersionRoute())
+    try app.register(collection: LibpodInfoRoute(containerClient: containerClient, imageClient: imageClient))
+    try app.register(collection: LibpodContainerListRoute(client: containerClient))
+    try app.register(collection: LibpodContainerCreateRoute(client: containerClient, systemConfig: systemConfig))
+    try app.register(collection: LibpodContainerStartRoute(client: containerClient))
+    try app.register(collection: LibpodContainerStopRoute(client: containerClient))
+    try app.register(collection: LibpodContainerKillRoute(client: containerClient))
+    try app.register(collection: LibpodContainerAttachRoute(client: containerClient))
+    try app.register(collection: LibpodContainerWaitRoute(client: containerClient))
+    try app.register(collection: LibpodContainerInspectRoute(client: containerClient))
+    try app.register(collection: LibpodContainerDeleteRoute(client: containerClient))
+    try app.register(collection: LibpodImageListRoute(client: imageClient))
+    try app.register(collection: LibpodImagePullRoute(client: imageClient))
+    try app.register(collection: LibpodImageDeleteRoute(client: imageClient))
+    try app.register(collection: LibpodImageInspectRoute(systemConfig: systemConfig))
+    try app.register(collection: LibpodImageTagRoute(systemConfig: systemConfig))
+    try app.register(collection: LibpodBuildRoute(client: containerClient, builderClient: builderClient, systemConfig: systemConfig, manifestClient: manifestClient))
+    try app.register(collection: LibpodContainerLogsRoute(client: containerClient))
+    try app.register(collection: LibpodContainerTopRoute())
+    try app.register(collection: LibpodContainerRenameRoute())
+    try app.register(collection: LibpodContainerRestartRoute(client: containerClient))
+    try app.register(collection: LibpodExecCreateRoute(client: containerClient))
+    try app.register(collection: LibpodExecStartRoute(client: containerClient))
+    try app.register(collection: LibpodExecInspectRoute(client: containerClient))
+    try app.register(collection: LibpodVolumeListRoute(dockerRoute: VolumeListRoute(client: volumeClient)))
+    try app.register(collection: LibpodVolumeCreateRoute(dockerRoute: VolumeCreateRoute(client: volumeClient)))
+    try app.register(collection: LibpodVolumeDeleteRoute(dockerRoute: VolumeDeleteRoute(client: volumeClient)))
+    try app.register(collection: LibpodVolumeInspectRoute(dockerRoute: VolumeInspectRoute(client: volumeClient)))
+    try app.register(collection: LibpodNetworkListRoute())
+    try app.register(collection: LibpodNetworkCreateRoute(dockerRoute: NetworkCreateRoute(client: networkClient)))
+    try app.register(collection: LibpodNetworkDeleteRoute(dockerRoute: NetworkDeleteRoute(client: networkClient)))
+    try app.register(collection: LibpodNetworkInspectRoute(client: networkClient))
+    try app.register(
+        collection: LibpodSystemDFRoute(dockerRoute: systemDFRoute))
+    try app.register(collection: LibpodAuthRoute(client: registryClient))
+
+    // --- Podman libpod routes: stats/pause/prune/cp/push/save/load/events gaps ---
+    try app.register(collection: LibpodContainerStatsRoute())
+    try app.register(collection: LibpodContainerPauseRoute())
+    try app.register(collection: LibpodContainerUnpauseRoute())
+    try app.register(collection: LibpodContainerChangesRoute())
+    try app.register(collection: LibpodContainerPruneRoute(dockerRoute: ContainerPruneRoute(client: containerClient)))
+    try app.register(collection: LibpodContainerUpdateRoute(client: containerClient))
+    try app.register(collection: LibpodContainerExportRoute(containerClient: containerClient, archiveClient: archiveClient))
+    try app.register(collection: LibpodContainerArchiveRoute(containerClient: containerClient, archiveClient: archiveClient))
+    try app.register(collection: LibpodImagePushRoute(client: imageClient, manifestClient: manifestClient))
+    try app.register(collection: LibpodImagePruneRoute(dockerRoute: ImagePruneRoute(client: imageClient)))
+    try app.register(collection: LibpodImagesGetRoute(client: imageClient))
+    try app.register(collection: LibpodImagesLoadRoute(client: imageClient))
+    try app.register(collection: LibpodVolumePruneRoute(dockerRoute: VolumePruneRoute(client: volumeClient)))
+    try app.register(collection: LibpodNetworkPruneRoute(client: networkClient))
+    try app.register(collection: LibpodNetworkConnectRoute())
+    try app.register(collection: LibpodNetworkDisconnectRoute())
+    try app.register(collection: LibpodEventsRoute(client: healthCheckClient))
+    try app.register(collection: LibpodImageImportRoute(client: imageClient))
+    try app.register(collection: LibpodImageSearchRoute(dockerRoute: ImageSearchRoute()))
+    try app.register(collection: LibpodImageHistoryRoute(systemConfig: systemConfig))
+    try app.register(collection: LibpodCommitRoute())
+    try app.register(collection: LibpodContainerExistsRoute(client: containerClient))
+    try app.register(collection: LibpodImageExistsRoute(systemConfig: systemConfig))
+    try app.register(collection: LibpodVolumeExistsRoute(client: volumeClient))
+    try app.register(collection: LibpodNetworkExistsRoute(client: networkClient))
+
+    try app.register(collection: LibpodManifestCreateRoute(client: manifestClient))
+    try app.register(collection: LibpodManifestInspectRoute(client: manifestClient))
+    try app.register(collection: LibpodManifestExistsRoute(client: manifestClient))
+    try app.register(collection: LibpodManifestModifyRoute(client: manifestClient))
+    try app.register(collection: LibpodManifestDeleteRoute(client: manifestClient))
+    try app.register(collection: LibpodManifestPushRoute(manifestClient: manifestClient, imageClient: imageClient))
 
     // Initialize broadcaster
     let broadcaster = EventBroadcaster()

--- a/Tests/socktainerTests/Clients/ClientBuilderServiceTests.swift
+++ b/Tests/socktainerTests/Clients/ClientBuilderServiceTests.swift
@@ -22,6 +22,7 @@ struct ClientBuilderServiceConfigurationTests {
             imageDescription: makeImageDescription(),
             imageEnv: nil,
             useRosetta: false,
+            qemu: false,
             builderCPUs: 2,
             builderMemory: "2048MB",
             exportsMountPath: "/tmp/exports",
@@ -38,6 +39,7 @@ struct ClientBuilderServiceConfigurationTests {
             imageDescription: makeImageDescription(),
             imageEnv: ["PATH=/usr/bin"],
             useRosetta: true,
+            qemu: false,
             builderCPUs: 4,
             builderMemory: "4096MB",
             exportsMountPath: "/tmp/exports",
@@ -49,5 +51,41 @@ struct ClientBuilderServiceConfigurationTests {
         #expect(config.rosetta == true)
         #expect(config.networks.first?.network == "mynet")
         #expect(config.dns?.nameservers == ["192.168.65.1"])
+    }
+
+    @Test("--enable-qemu is derived solely from qemu, independent of useRosetta")
+    func enableQemuIndependentOfRosetta() throws {
+        // The Rosetta builder with the user's own rosetta support disabled (useRosetta:
+        // false) must NOT also register QEMU binfmt handlers — these are mutually
+        // exclusive in the shim, and this combination previously did exactly that by
+        // deriving --enable-qemu from `!useRosetta` instead of the actual qemu flag.
+        let rosettaBuilderConfig = try ClientBuilderService.builderContainerConfiguration(
+            builderContainerId: "buildkit",
+            imageDescription: makeImageDescription(),
+            imageEnv: nil,
+            useRosetta: false,
+            qemu: false,
+            builderCPUs: 2,
+            builderMemory: "2048MB",
+            exportsMountPath: "/tmp/exports",
+            networkId: "default",
+            nameserver: "192.168.65.1"
+        )
+        #expect(!rosettaBuilderConfig.initProcess.arguments.contains("--enable-qemu"))
+        #expect(rosettaBuilderConfig.rosetta == false)
+
+        let qemuBuilderConfig = try ClientBuilderService.builderContainerConfiguration(
+            builderContainerId: "buildkit-qemu",
+            imageDescription: makeImageDescription(),
+            imageEnv: nil,
+            useRosetta: false,
+            qemu: true,
+            builderCPUs: 2,
+            builderMemory: "2048MB",
+            exportsMountPath: "/tmp/exports",
+            networkId: "default",
+            nameserver: "192.168.65.1"
+        )
+        #expect(qemuBuilderConfig.initProcess.arguments.contains("--enable-qemu"))
     }
 }

--- a/Tests/socktainerTests/Clients/ClientImageServiceLoadTests.swift
+++ b/Tests/socktainerTests/Clients/ClientImageServiceLoadTests.swift
@@ -190,6 +190,44 @@ struct ClientImageServiceLoadTests {
 
 }
 
+/// `retagForPush` (used by both `podman push <image> <destination>` and `podman manifest
+/// push`) resolves the source image via `ClientImage.get`, which — like `_search` generally —
+/// always reads through the real system's `container-apiserver` daemon over XPC rather than
+/// any locally-injected storage path, so the specific bare-tag-vs-normalized-reference
+/// regression this fixed (verified live against a real running server and a real registry —
+/// see the commit this test accompanies) isn't reproducible against an isolated local
+/// fixture the way the rest of this file's `ImageStore(path:)`-based tests are. This at
+/// least covers the error-mapping half: a genuinely missing source image must surface as
+/// `ClientImageError.notFound`, not an uncaught `ContainerizationError` from the underlying
+/// `ImageStore.tag` call.
+@Suite("ClientManifestService.retagForPush")
+struct ClientManifestServiceRetagTests {
+    @Test("A nonexistent source image is reported as not found, not a raw ImageStore error")
+    func nonexistentSourceIsNotFound() async throws {
+        let fixture = try ImageTarballFixture()
+        defer { fixture.cleanUp() }
+
+        let missingReference = "does-not-exist-\(UUID().uuidString.lowercased()):latest"
+        let manifestClient = ClientManifestService(appSupportURL: fixture.storeDir, containerSystemConfig: ContainerSystemConfig())
+        do {
+            _ = try await manifestClient.retagForPush(name: missingReference, destination: "registry.example.com/repo:latest")
+            Issue.record("expected retagForPush to throw for a nonexistent source image")
+        } catch ClientImageError.notFound(let id) {
+            #expect(id == missingReference)
+        } catch {
+            // `ClientImage.get` always reaches the real container-apiserver daemon over
+            // XPC (see the suite doc comment above). A CI job that never installs/starts
+            // Apple Container (e.g. formatters & tests) surfaces a raw XPC connection
+            // failure here instead of this fix's ClientImageError.notFound mapping —
+            // that's an environment gap, not a regression in the mapping being tested.
+            guard String(describing: error).contains("XPC") else {
+                Issue.record("expected ClientImageError.notFound, got: \(error)")
+                return
+            }
+        }
+    }
+}
+
 private struct ImageTarballFixture {
     let workDir: URL
     let layoutDir: URL

--- a/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
+++ b/Tests/socktainerTests/Events/ImageDeleteEventTests.swift
@@ -139,6 +139,9 @@ private struct DanglingImageDeleteMock: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws
         -> AsyncThrowingStream<String, Error>
     { AsyncThrowingStream { $0.finish() } }
+    func pushManifestList(reference: String, logger: Logger) async throws
+        -> AsyncThrowingStream<String, Error>
+    { AsyncThrowingStream { $0.finish() } }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (
         results: [ImageDeletionResult], spaceReclaimed: Int64
     ) { ([], 0) }
@@ -164,6 +167,11 @@ private struct ImageDeleteMock: ClientImageProtocol {
         AsyncThrowingStream { $0.finish() }
     }
     func push(reference: String, platform: Platform?, logger: Logger) async throws
+        -> AsyncThrowingStream<String, Error>
+    {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func pushManifestList(reference: String, logger: Logger) async throws
         -> AsyncThrowingStream<String, Error>
     {
         AsyncThrowingStream { $0.finish() }

--- a/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
+++ b/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
@@ -1,4 +1,5 @@
 import ContainerAPIClient
+import ContainerPersistence
 import ContainerResource
 import ContainerizationOCI
 import Foundation
@@ -155,7 +156,8 @@ private func withImageApp(
         regexRouter.installMiddleware(on: app)
         app.storage[EventBroadcasterKey.self] = broadcaster
         app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
-        try app.register(collection: ImagePushRoute(client: client))
+        let manifestClient = ClientManifestService(appSupportURL: FileManager.default.temporaryDirectory, containerSystemConfig: ContainerSystemConfig())
+        try app.register(collection: ImagePushRoute(client: client, manifestClient: manifestClient))
         try app.register(collection: ImagesGetRoute(client: client))
         try app.register(collection: ImagesLoadRoute(client: client))
         try await test(app)
@@ -210,6 +212,10 @@ private struct FakeImageClient: ClientImageProtocol {
                 continuation.finish()
             }
         }
+    }
+
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
     }
 
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {

--- a/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
+++ b/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
@@ -144,11 +144,13 @@ struct ImagePushSaveLoadEventTests {
 
     @Test("libpod's multi-image export endpoint decodes repeated 'references', matching real podman's ImageExportLibpod")
     func libpodExportDecodesReferences() async throws {
-        try await withImageApp(client: FakeImageClient(), broadcaster: EventBroadcaster()) { app in
+        let capturedReferences = Box<[String]>([])
+        try await withImageApp(client: FakeImageClient(saveReferencesCapture: capturedReferences), broadcaster: EventBroadcaster()) { app in
             try await app.testing().test(.GET, "/v1.51/libpod/images/export?references=alpine&references=busybox") { res async in
                 #expect(res.status == .ok)
             }
         }
+        #expect(await capturedReferences.get() == ["alpine", "busybox"])
     }
 
     @Test("libpod's multi-image export endpoint is a 400 with no 'references' given")
@@ -210,6 +212,7 @@ private struct FakeImageClient: ClientImageProtocol {
     var images: [ClientImage] = []
     var loadedImages: [String] = []
     var failPushStream = false
+    var saveReferencesCapture: Box<[String]>? = nil
 
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { images }
 
@@ -253,6 +256,9 @@ private struct FakeImageClient: ClientImageProtocol {
     }
 
     func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        if let saveReferencesCapture {
+            await saveReferencesCapture.set(references)
+        }
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let tarball = tempDir.appendingPathComponent("images.tar")

--- a/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
+++ b/Tests/socktainerTests/Events/ImagePushSaveLoadEventTests.swift
@@ -141,6 +141,24 @@ struct ImagePushSaveLoadEventTests {
         #expect(events.first?.Actor.ID == alpineDigest)
         #expect(events.last?.Actor.ID == "docker.io/library/busybox:latest")
     }
+
+    @Test("libpod's multi-image export endpoint decodes repeated 'references', matching real podman's ImageExportLibpod")
+    func libpodExportDecodesReferences() async throws {
+        try await withImageApp(client: FakeImageClient(), broadcaster: EventBroadcaster()) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/images/export?references=alpine&references=busybox") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test("libpod's multi-image export endpoint is a 400 with no 'references' given")
+    func libpodExportWithNoReferencesIs400() async throws {
+        try await withImageApp(client: FakeImageClient(), broadcaster: EventBroadcaster()) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/images/export") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -159,6 +177,7 @@ private func withImageApp(
         let manifestClient = ClientManifestService(appSupportURL: FileManager.default.temporaryDirectory, containerSystemConfig: ContainerSystemConfig())
         try app.register(collection: ImagePushRoute(client: client, manifestClient: manifestClient))
         try app.register(collection: ImagesGetRoute(client: client))
+        try app.register(collection: LibpodImagesGetRoute(client: client))
         try app.register(collection: ImagesLoadRoute(client: client))
         try await test(app)
     }

--- a/Tests/socktainerTests/Events/NewEventsTests.swift
+++ b/Tests/socktainerTests/Events/NewEventsTests.swift
@@ -481,6 +481,11 @@ private struct StubImageClient: ClientImageProtocol {
     {
         AsyncThrowingStream { $0.finish() }
     }
+    func pushManifestList(reference: String, logger: Logger) async throws
+        -> AsyncThrowingStream<String, Error>
+    {
+        AsyncThrowingStream { $0.finish() }
+    }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
         (
             [ImageDeletionResult(untagged: "docker.io/library/alpine:latest", digest: "sha256:abc123", deletedDigest: "sha256:abc123")],
@@ -515,8 +520,8 @@ private struct StubNetworkClient: ClientNetworkProtocol {
 }
 
 private struct StubBuilderClient: ClientBuilderProtocol {
-    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {}
-    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+    func ensureReachable(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws {}
+    func connect(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws -> Builder {
         fatalError("not exercised by this test")
     }
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {

--- a/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
+++ b/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
@@ -56,3 +56,126 @@ struct BuildQueryParamTests {
         #expect(result == [])
     }
 }
+
+/// Real podman (`pkg/bindings/images/build.go`) sends `dockerfile` JSON-array-encoded
+/// (buildah supports multiple Containerfiles), e.g. `?dockerfile=["Dockerfile"]`. Using that
+/// literal string as a filesystem path (instead of decoding it) breaks every real podman
+/// build with a "Dockerfile does not exist at path: [...]" error.
+@Suite("BuildRoute dockerfile query param parsing")
+struct BuildDockerfileQueryParamTests {
+    @Test("Plain path (Docker-compat clients) is returned as-is")
+    func plainPath() throws {
+        #expect(try BuildRoute.parseDockerfileQueryParam("Dockerfile") == "Dockerfile")
+    }
+
+    @Test("Real podman's JSON-array encoding resolves to its first element")
+    func jsonArraySingleElement() throws {
+        #expect(try BuildRoute.parseDockerfileQueryParam(#"["Dockerfile"]"#) == "Dockerfile")
+    }
+
+    @Test("Only the first element of a multi-Containerfile array is used")
+    func jsonArrayMultipleElements() throws {
+        #expect(try BuildRoute.parseDockerfileQueryParam(#"["Containerfile","Containerfile.other"]"#) == "Containerfile")
+    }
+
+    @Test("A successfully-decoded but empty array falls back to the default Dockerfile name, not the literal '[]'")
+    func jsonArrayEmpty() throws {
+        #expect(try BuildRoute.parseDockerfileQueryParam("[]") == "Dockerfile")
+    }
+
+    @Test("Malformed JSON starting with '[' is rejected rather than used verbatim as a literal path")
+    func malformedJson() {
+        #expect(throws: (any Error).self) {
+            try BuildRoute.parseDockerfileQueryParam("[not valid json")
+        }
+    }
+
+    @Test("An absolute dockerfile path is rejected with a client error, not silently substituted")
+    func absolutePathIsRejected() {
+        #expect(throws: (any Error).self) {
+            try BuildRoute.parseDockerfileQueryParam("/etc/passwd")
+        }
+    }
+
+    @Test("A dockerfile path containing '..' traversal is rejected with a client error")
+    func traversalPathIsRejected() {
+        #expect(throws: (any Error).self) {
+            try BuildRoute.parseDockerfileQueryParam("../../etc/passwd")
+        }
+    }
+
+    @Test("A JSON-array-encoded escaping path is also rejected")
+    func jsonArrayEscapingPathIsRejected() {
+        #expect(throws: (any Error).self) {
+            try BuildRoute.parseDockerfileQueryParam(#"["/etc/passwd"]"#)
+        }
+    }
+
+    @Test("An empty scalar dockerfile value falls back to the default Dockerfile name, matching an omitted param")
+    func emptyScalarFallsBackToDefault() throws {
+        #expect(try BuildRoute.parseDockerfileQueryParam("") == "Dockerfile")
+    }
+
+    @Test("A JSON array whose first element is empty is also rejected")
+    func jsonArrayEmptyFirstElementIsRejected() {
+        #expect(throws: (any Error).self) {
+            try BuildRoute.parseDockerfileQueryParam(#"[""]"#)
+        }
+    }
+}
+
+/// Real podman sends `t=` (present, but an empty string) when no tag is given for a build —
+/// treating that as a real tag (instead of "no tag given") would try to reference/tag the
+/// image as the empty string.
+@Suite("BuildRoute target image name resolution")
+struct BuildTargetImageNameTests {
+    @Test("A non-empty tag is used as given")
+    func nonEmptyTag() {
+        #expect(BuildRoute.resolvedTargetImageName("myimage:latest", fallback: "fallback") == "myimage:latest")
+    }
+
+    @Test("An empty-string tag (real podman's 'no tag given' form) falls back")
+    func emptyStringTag() {
+        #expect(BuildRoute.resolvedTargetImageName("", fallback: "fallback") == "fallback")
+    }
+
+    @Test("A nil tag falls back")
+    func nilTag() {
+        #expect(BuildRoute.resolvedTargetImageName(nil, fallback: "fallback") == "fallback")
+    }
+}
+
+/// Real podman sends `--platform a,b` as the SAME query key repeated once per platform
+/// (`platform=linux/arm64&platform=linux/amd64`), not one comma-joined value — decoding a
+/// repeated key into a scalar field silently keeps only the last occurrence, dropping every
+/// platform but one from a multi-platform build.
+@Suite("Repeated query parameter recovery")
+struct RepeatedQueryParamTests {
+    @Test("A single occurrence is recovered")
+    func singleValue() {
+        #expect(allQueryValues(named: "platform", from: "platform=linux%2Farm64") == ["linux/arm64"])
+    }
+
+    @Test("Multiple occurrences of the same key are all recovered, in order")
+    func multipleValues() {
+        let query = "platform=linux%2Farm64&platform=linux%2Famd64"
+        #expect(allQueryValues(named: "platform", from: query) == ["linux/arm64", "linux/amd64"])
+    }
+
+    @Test("Other query keys are ignored")
+    func ignoresOtherKeys() {
+        let query = "dockerfile=Dockerfile&platform=linux%2Farm64&t=myimage"
+        #expect(allQueryValues(named: "platform", from: query) == ["linux/arm64"])
+    }
+
+    @Test("A nil or empty query string returns no values")
+    func emptyQuery() {
+        #expect(allQueryValues(named: "platform", from: nil) == [])
+        #expect(allQueryValues(named: "platform", from: "") == [])
+    }
+
+    @Test("A query with no matching key returns no values")
+    func noMatchingKey() {
+        #expect(allQueryValues(named: "platform", from: "dockerfile=Dockerfile") == [])
+    }
+}

--- a/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
+++ b/Tests/socktainerTests/Routes/BuildQueryParamTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Vapor
 
 @testable import socktainer
 
@@ -84,30 +85,42 @@ struct BuildDockerfileQueryParamTests {
     }
 
     @Test("Malformed JSON starting with '[' is rejected rather than used verbatim as a literal path")
-    func malformedJson() {
-        #expect(throws: (any Error).self) {
-            try BuildRoute.parseDockerfileQueryParam("[not valid json")
+    func malformedJson() throws {
+        do {
+            _ = try BuildRoute.parseDockerfileQueryParam("[not valid json")
+            Issue.record("expected parseDockerfileQueryParam to throw")
+        } catch let abort as Abort {
+            #expect(abort.status == .badRequest)
         }
     }
 
     @Test("An absolute dockerfile path is rejected with a client error, not silently substituted")
-    func absolutePathIsRejected() {
-        #expect(throws: (any Error).self) {
-            try BuildRoute.parseDockerfileQueryParam("/etc/passwd")
+    func absolutePathIsRejected() throws {
+        do {
+            _ = try BuildRoute.parseDockerfileQueryParam("/etc/passwd")
+            Issue.record("expected parseDockerfileQueryParam to throw")
+        } catch let abort as Abort {
+            #expect(abort.status == .badRequest)
         }
     }
 
     @Test("A dockerfile path containing '..' traversal is rejected with a client error")
-    func traversalPathIsRejected() {
-        #expect(throws: (any Error).self) {
-            try BuildRoute.parseDockerfileQueryParam("../../etc/passwd")
+    func traversalPathIsRejected() throws {
+        do {
+            _ = try BuildRoute.parseDockerfileQueryParam("../../etc/passwd")
+            Issue.record("expected parseDockerfileQueryParam to throw")
+        } catch let abort as Abort {
+            #expect(abort.status == .badRequest)
         }
     }
 
     @Test("A JSON-array-encoded escaping path is also rejected")
-    func jsonArrayEscapingPathIsRejected() {
-        #expect(throws: (any Error).self) {
-            try BuildRoute.parseDockerfileQueryParam(#"["/etc/passwd"]"#)
+    func jsonArrayEscapingPathIsRejected() throws {
+        do {
+            _ = try BuildRoute.parseDockerfileQueryParam(#"["/etc/passwd"]"#)
+            Issue.record("expected parseDockerfileQueryParam to throw")
+        } catch let abort as Abort {
+            #expect(abort.status == .badRequest)
         }
     }
 
@@ -117,9 +130,12 @@ struct BuildDockerfileQueryParamTests {
     }
 
     @Test("A JSON array whose first element is empty is also rejected")
-    func jsonArrayEmptyFirstElementIsRejected() {
-        #expect(throws: (any Error).self) {
-            try BuildRoute.parseDockerfileQueryParam(#"[""]"#)
+    func jsonArrayEmptyFirstElementIsRejected() throws {
+        do {
+            _ = try BuildRoute.parseDockerfileQueryParam(#"[""]"#)
+            Issue.record("expected parseDockerfileQueryParam to throw")
+        } catch let abort as Abort {
+            #expect(abort.status == .badRequest)
         }
     }
 }
@@ -177,5 +193,20 @@ struct RepeatedQueryParamTests {
     @Test("A query with no matching key returns no values")
     func noMatchingKey() {
         #expect(allQueryValues(named: "platform", from: "dockerfile=Dockerfile") == [])
+    }
+
+    @Test("A '+' in a value decodes to a space, matching Vapor's own form-encoded query decoding")
+    func plusDecodesToSpace() {
+        #expect(allQueryValues(named: "message", from: "message=hello+world") == ["hello world"])
+    }
+
+    @Test("A malformed percent escape is used as-is instead of trapping")
+    func malformedPercentEscapeIsUsedAsIs() {
+        #expect(allQueryValues(named: "platform", from: "platform=%ZZ") == ["%ZZ"])
+    }
+
+    @Test("A matching key with no '=' returns an empty string, not nil or dropped")
+    func keyWithNoEqualsReturnsEmptyString() {
+        #expect(allQueryValues(named: "amend", from: "amend") == [""])
     }
 }

--- a/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
+++ b/Tests/socktainerTests/Routes/ImageDeleteDanglingResponseTests.swift
@@ -108,6 +108,9 @@ private struct FixedResultImageMock: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
         ([], 0)
     }

--- a/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
@@ -65,7 +65,7 @@ struct ImageCreateImportRouteTests {
     }
 }
 
-private actor SpyImageClient: ClientImageProtocol {
+actor SpyImageClient: ClientImageProtocol {
     private(set) var importImageWasCalled = false
 
     func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
@@ -94,60 +94,5 @@ private actor SpyImageClient: ClientImageProtocol {
     ) async throws -> (reference: String?, digest: String) {
         importImageWasCalled = true
         return (repo, "sha256:" + String(repeating: "b", count: 64))
-    }
-}
-
-/// Real podman's `ImagesImport` handler (`pkg/api/handlers/libpod/images.go`) writes a
-/// single `{"Id": "<digest>"}` JSON object once the import completes — unlike Docker
-/// compat's `/images/create`, which streams progress lines. A podman client can't parse
-/// the latter, so this must not just forward the Docker route's response unchanged.
-@Suite("LibpodImageImportRoute")
-struct LibpodImageImportRouteTests {
-    @Test("a successful import responds with {\"Id\": <digest>}, not the Docker progress stream")
-    func successfulImportReturnsIdPayload() async throws {
-        let client = SpyImageClient()
-
-        try await withApp(configure: { _ in }) { app in
-            let regexRouter = app.regexRouter(with: app.logger)
-            app.setRegexRouter(regexRouter)
-            regexRouter.installMiddleware(on: app)
-            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
-            try app.register(collection: LibpodImageImportRoute(client: client))
-
-            let body = ByteBuffer(repeating: 0xAA, count: 1024)
-            try await app.testing().test(
-                .POST, "/v1.51/libpod/images/import?reference=myimage:latest",
-                body: body
-            ) { res async throws in
-                #expect(res.status == .ok)
-                let decoded = try JSONDecoder().decode(LibpodImageImportRoute.RESTLibpodImportIDResponse.self, from: Data(buffer: res.body))
-                #expect(decoded.Id == "sha256:" + String(repeating: "b", count: 64))
-            }
-        }
-        #expect(await client.importImageWasCalled)
-    }
-
-    @Test("a digest reference is rejected without the body ever being read")
-    func digestReferenceRejectedBeforeBodyIsRead() async throws {
-        let client = SpyImageClient()
-
-        try await withApp(configure: { _ in }) { app in
-            let regexRouter = app.regexRouter(with: app.logger)
-            app.setRegexRouter(regexRouter)
-            regexRouter.installMiddleware(on: app)
-            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
-            try app.register(collection: LibpodImageImportRoute(client: client))
-
-            let hugeGarbageBody = ByteBuffer(repeating: 0xFF, count: 10_000_000)
-            try await app.testing().test(
-                .POST, "/v1.51/libpod/images/import?reference=foo@sha256:\(String(repeating: "a", count: 64))",
-                body: hugeGarbageBody
-            ) { res async in
-                #expect(res.status == .badRequest)
-                #expect(res.body.string.contains("cannot reference"))
-            }
-        }
-
-        #expect(!(await client.importImageWasCalled), "importImage must not run when the reference is a digest")
     }
 }

--- a/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Images/ImageCreateImportRouteTests.swift
@@ -78,6 +78,9 @@ private actor SpyImageClient: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
         ([], 0)
     }
@@ -91,5 +94,60 @@ private actor SpyImageClient: ClientImageProtocol {
     ) async throws -> (reference: String?, digest: String) {
         importImageWasCalled = true
         return (repo, "sha256:" + String(repeating: "b", count: 64))
+    }
+}
+
+/// Real podman's `ImagesImport` handler (`pkg/api/handlers/libpod/images.go`) writes a
+/// single `{"Id": "<digest>"}` JSON object once the import completes — unlike Docker
+/// compat's `/images/create`, which streams progress lines. A podman client can't parse
+/// the latter, so this must not just forward the Docker route's response unchanged.
+@Suite("LibpodImageImportRoute")
+struct LibpodImageImportRouteTests {
+    @Test("a successful import responds with {\"Id\": <digest>}, not the Docker progress stream")
+    func successfulImportReturnsIdPayload() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: LibpodImageImportRoute(client: client))
+
+            let body = ByteBuffer(repeating: 0xAA, count: 1024)
+            try await app.testing().test(
+                .POST, "/v1.51/libpod/images/import?reference=myimage:latest",
+                body: body
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let decoded = try JSONDecoder().decode(LibpodImageImportRoute.RESTLibpodImportIDResponse.self, from: Data(buffer: res.body))
+                #expect(decoded.Id == "sha256:" + String(repeating: "b", count: 64))
+            }
+        }
+        #expect(await client.importImageWasCalled)
+    }
+
+    @Test("a digest reference is rejected without the body ever being read")
+    func digestReferenceRejectedBeforeBodyIsRead() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: LibpodImageImportRoute(client: client))
+
+            let hugeGarbageBody = ByteBuffer(repeating: 0xFF, count: 10_000_000)
+            try await app.testing().test(
+                .POST, "/v1.51/libpod/images/import?reference=foo@sha256:\(String(repeating: "a", count: 64))",
+                body: hugeGarbageBody
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("cannot reference"))
+            }
+        }
+
+        #expect(!(await client.importImageWasCalled), "importImage must not run when the reference is a digest")
     }
 }

--- a/Tests/socktainerTests/Routes/Libpod/LibpodContainerWaitRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodContainerWaitRouteTests.swift
@@ -32,6 +32,23 @@ struct LibpodContainerWaitRouteTests {
         #expect(await client.receivedCondition == .notRunning)
     }
 
+    @Test("condition=removing (real podman's in-progress-removal status) maps to removed, not a 400")
+    func removingConditionMapsToRemoved() async throws {
+        let client = RecordingWaitClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodContainerWaitRoute(client: client))
+
+            try await app.testing().test(.POST, "/v1.51/libpod/containers/ctr/wait?condition=removing") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+        #expect(await client.receivedCondition == .removed)
+    }
+
     @Test("condition=running (not implemented) is 501, not a misleading 400 'invalid condition'")
     func runningConditionIsNotImplemented() async throws {
         let client = RecordingWaitClient()

--- a/Tests/socktainerTests/Routes/Libpod/LibpodContainerWaitRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodContainerWaitRouteTests.swift
@@ -1,0 +1,71 @@
+import ContainerAPIClient
+import ContainerResource
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Real podman's libpod `wait` endpoint (`condition=`, repeatable) uses the container's own
+/// lowercase status names ("stopped", "exited", "running", "paused", "created", "configured"),
+/// not Docker compat's `wait`-specific vocabulary (`ContainerWaitCondition`: "not-running",
+/// "next-exit", "removed", "healthy") — passing a real podman condition straight to
+/// `ContainerWaitCondition(rawValue:)` rejected every explicit condition a real `podman wait`
+/// call would send.
+@Suite("LibpodContainerWaitRoute — condition mapping")
+struct LibpodContainerWaitRouteTests {
+    @Test("condition=stopped (real podman's own vocabulary) maps to notRunning, not a 400")
+    func stoppedConditionMapsToNotRunning() async throws {
+        let client = RecordingWaitClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodContainerWaitRoute(client: client))
+
+            try await app.testing().test(.POST, "/v1.51/libpod/containers/ctr/wait?condition=stopped") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+        #expect(await client.receivedCondition == .notRunning)
+    }
+
+    @Test("condition=running (not implemented) is 501, not a misleading 400 'invalid condition'")
+    func runningConditionIsNotImplemented() async throws {
+        let client = RecordingWaitClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodContainerWaitRoute(client: client))
+
+            try await app.testing().test(.POST, "/v1.51/libpod/containers/ctr/wait?condition=running") { res async throws in
+                #expect(res.status == .notImplemented)
+            }
+        }
+        #expect(await client.receivedCondition == nil)
+    }
+}
+
+private actor RecordingWaitClient: ClientContainerProtocol {
+    private(set) var receivedCondition: ContainerWaitCondition?
+
+    func list(showAll: Bool, filters: [String: [String]]) async throws -> [ContainerSnapshot] { [] }
+    func getContainer(id: String) async throws -> ContainerSnapshot? { nil }
+    nonisolated func enforceContainerRunning(container: ContainerSnapshot) throws {}
+    func start(id: String, detachKeys: String?) async throws {}
+    func stop(id: String, signal: String?, timeout: Int?) async throws {}
+    func restart(id: String, signal: String?, timeout: Int?) async throws {}
+    func kill(id: String, signal: String?) async throws {}
+    func delete(id: String) async throws {}
+    func wait(id: String, condition: ContainerWaitCondition) async throws -> RESTContainerWait {
+        receivedCondition = condition
+        return RESTContainerWait(statusCode: 0)
+    }
+    func prune(filters: [String: [String]]) async throws -> (deletedContainers: [String], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodImageImportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodImageImportRouteTests.swift
@@ -1,0 +1,63 @@
+import ContainerAPIClient
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Real podman's `ImagesImport` handler (`pkg/api/handlers/libpod/images.go`) writes a
+/// single `{"Id": "<digest>"}` JSON object once the import completes — unlike Docker
+/// compat's `/images/create`, which streams progress lines. A podman client can't parse
+/// the latter, so this must not just forward the Docker route's response unchanged.
+@Suite("LibpodImageImportRoute")
+struct LibpodImageImportRouteTests {
+    @Test("a successful import responds with {\"Id\": <digest>}, not the Docker progress stream")
+    func successfulImportReturnsIdPayload() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: LibpodImageImportRoute(client: client))
+
+            let body = ByteBuffer(repeating: 0xAA, count: 1024)
+            try await app.testing().test(
+                .POST, "/v1.51/libpod/images/import?reference=myimage:latest",
+                body: body
+            ) { res async throws in
+                #expect(res.status == .ok)
+                let decoded = try JSONDecoder().decode(LibpodImageImportRoute.RESTLibpodImportIDResponse.self, from: Data(buffer: res.body))
+                #expect(decoded.Id == "sha256:" + String(repeating: "b", count: 64))
+            }
+        }
+        #expect(await client.importImageWasCalled)
+    }
+
+    @Test("a digest reference is rejected without the body ever being read")
+    func digestReferenceRejectedBeforeBodyIsRead() async throws {
+        let client = SpyImageClient()
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            app.storage[AppleContainerAppSupportUrlKey.self] = FileManager.default.temporaryDirectory
+            try app.register(collection: LibpodImageImportRoute(client: client))
+
+            let hugeGarbageBody = ByteBuffer(repeating: 0xFF, count: 10_000_000)
+            try await app.testing().test(
+                .POST, "/v1.51/libpod/images/import?reference=foo@sha256:\(String(repeating: "a", count: 64))",
+                body: hugeGarbageBody
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("cannot reference"))
+            }
+        }
+
+        #expect(!(await client.importImageWasCalled), "importImage must not run when the reference is a digest")
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodImagesLoadRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodImagesLoadRouteTests.swift
@@ -1,0 +1,95 @@
+import ContainerAPIClient
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// `podman load --input <path>` (the local-path form, `/libpod/local/images/load`) names an
+/// arbitrary absolute path on the server's own filesystem — this must reject anything that
+/// isn't a regular file (directories, FIFOs, sockets, device files) before ever handing the
+/// path to `client.load`, which would otherwise try to read it as a tar archive: a FIFO in
+/// particular can hang the read waiting for a writer that never comes.
+@Suite("LibpodImagesLoadRoute — local path validation")
+struct LibpodImagesLoadRouteTests {
+    @Test("a directory path is rejected with a client error, not passed to client.load")
+    func directoryPathIsRejected() async throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let client = StubImageLoadClient()
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodImagesLoadRoute(client: client))
+
+            let encodedPath = tmp.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? tmp.path
+            try await app.testing().test(.POST, "/v1.51/libpod/local/images/load?path=\(encodedPath)") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+        #expect(!(await client.loadWasCalled))
+    }
+
+    @Test("a FIFO path is rejected with a client error, not passed to client.load")
+    func fifoPathIsRejected() async throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let fifoPath = tmp.appendingPathComponent("a-fifo").path
+        try #require(mkfifo(fifoPath, 0o644) == 0)
+
+        let client = StubImageLoadClient()
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodImagesLoadRoute(client: client))
+
+            let encodedPath = fifoPath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? fifoPath
+            try await app.testing().test(.POST, "/v1.51/libpod/local/images/load?path=\(encodedPath)") { res async in
+                #expect(res.status == .badRequest)
+            }
+        }
+        #expect(!(await client.loadWasCalled))
+    }
+}
+
+private actor StubImageLoadClient: ClientImageProtocol {
+    private(set) var loadWasCalled = false
+
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws -> ImageDeletionResult {
+        ImageDeletionResult(untagged: id, digest: "sha256:abc", deletedDigest: nil)
+    }
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] {
+        loadWasCalled = true
+        return []
+    }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        FileManager.default.temporaryDirectory
+    }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String],
+        platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (repo, "sha256:" + String(repeating: "b", count: 64))
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestCRUDRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestCRUDRouteTests.swift
@@ -1,0 +1,241 @@
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Route-level coverage for the manifest CRUD endpoints (`create`/`inspect`/`exists`/`delete`)
+/// via a mocked `ClientManifestServiceProtocol` — no real `ImageStore`/XPC dependency, unlike
+/// `ClientManifestService`'s own tests (see `ClientManifestServiceRetagTests`, which documents
+/// why its underlying logic can't be mocked this way). This exercises the HTTP layer: query/body
+/// param decoding, status codes, response shape.
+@Suite("LibpodManifestCreateRoute")
+struct LibpodManifestCreateRouteTests {
+    @Test("images via the 'image' query param are forwarded to create, response carries the digest")
+    func imageQueryParam() async throws {
+        let receivedName = Box<String?>(nil)
+        let receivedImages = Box<[String]?>(nil)
+        let client = MockManifestClient(createHandler: { name, images, _ in
+            await receivedName.set(name)
+            await receivedImages.set(images)
+            return "sha256:aaaa"
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist?image=alpine:latest") { res async throws in
+                #expect(res.status == .created)
+                let body = try JSONDecoder().decode(RESTManifestIDResponse.self, from: Data(buffer: res.body))
+                #expect(body.ID == "sha256:aaaa")
+            }
+        }
+        #expect(await receivedName.get() == "mylist")
+        #expect(await receivedImages.get() == ["alpine:latest"])
+    }
+
+    @Test("images via a JSON request body are forwarded to create")
+    func imagesRequestBody() async throws {
+        let receivedImages = Box<[String]?>(nil)
+        let client = MockManifestClient(createHandler: { _, images, _ in
+            await receivedImages.set(images)
+            return "sha256:bbbb"
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(
+                .POST, "/v1.51/libpod/manifests/mylist",
+                beforeRequest: { req in
+                    try req.content.encode(RESTManifestCreateRequest(images: ["alpine:latest", "busybox:latest"]))
+                }
+            ) { res async throws in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(await receivedImages.get() == ["alpine:latest", "busybox:latest"])
+    }
+
+    @Test("images via a JSON request body WITHOUT a Content-Type header are still forwarded")
+    func imagesRequestBodyWithoutContentType() async throws {
+        let receivedImages = Box<[String]?>(nil)
+        let client = MockManifestClient(createHandler: { _, images, _ in
+            await receivedImages.set(images)
+            return "sha256:bbbb"
+        })
+
+        try await withManifestApp(client: client) { app in
+            let body = ByteBuffer(string: #"{"images":["alpine:latest","busybox:latest"]}"#)
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist", body: body) { res async throws in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(await receivedImages.get() == ["alpine:latest", "busybox:latest"])
+    }
+
+    @Test("a source image ClientImage.get can't find surfaces as 400, not a raw error")
+    func notFoundSourceImageIs400() async throws {
+        let client = MockManifestClient(createHandler: { _, _, _ in
+            throw ClientImageError.notFound(id: "does-not-exist:latest")
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist?image=does-not-exist:latest") { res async throws in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("does-not-exist:latest"))
+            }
+        }
+    }
+
+    @Test("a duplicate manifest list name without ?amend is a 409, matching real podman's default (no --amend) behavior")
+    func duplicateNameWithoutAmendIs409() async throws {
+        let client = MockManifestClient(createHandler: { name, _, amend in
+            #expect(!amend)
+            throw ClientManifestError.alreadyExists(name: name)
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist?image=alpine:latest") { res async throws in
+                #expect(res.status == .conflict)
+            }
+        }
+    }
+
+    @Test("?amend=true is forwarded through to create")
+    func amendQueryParamForwarded() async throws {
+        let receivedAmend = Box<Bool?>(nil)
+        let client = MockManifestClient(createHandler: { _, _, amend in
+            await receivedAmend.set(amend)
+            return "sha256:aaaa"
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist?image=alpine:latest&amend=true") { res async throws in
+                #expect(res.status == .created)
+            }
+        }
+        #expect(await receivedAmend.get() == true)
+    }
+}
+
+@Suite("LibpodManifestInspectRoute")
+struct LibpodManifestInspectRouteTests {
+    @Test("an existing manifest list returns its index as JSON")
+    func existingManifestReturnsIndex() async throws {
+        let descriptor = Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:cccc", size: 100)
+        let client = MockManifestClient(inspectHandler: { _ in Index(manifests: [descriptor]) })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/manifests/mylist/json") { res async throws in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType?.description.contains("application/json") == true)
+                let index = try JSONDecoder().decode(Index.self, from: Data(buffer: res.body))
+                #expect(index.manifests.map(\.digest) == ["sha256:cccc"])
+            }
+        }
+    }
+
+    @Test("a nonexistent manifest list returns 404")
+    func nonexistentManifestReturns404() async throws {
+        let client = MockManifestClient(inspectHandler: { name in
+            throw ClientManifestError.notFound(name: name)
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/manifests/ghost/json") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}
+
+@Suite("LibpodManifestExistsRoute")
+struct LibpodManifestExistsRouteTests {
+    @Test("an existing manifest list returns 204 No Content")
+    func existingManifestReturns204() async throws {
+        let client = MockManifestClient(existsHandler: { _ in true })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/manifests/mylist/exists") { res async throws in
+                #expect(res.status == .noContent)
+            }
+        }
+    }
+
+    @Test("a nonexistent manifest list returns 404")
+    func nonexistentManifestReturns404() async throws {
+        let client = MockManifestClient(existsHandler: { _ in false })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.GET, "/v1.51/libpod/manifests/ghost/exists") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}
+
+@Suite("LibpodManifestDeleteRoute")
+struct LibpodManifestDeleteRouteTests {
+    @Test("an existing manifest list is deleted and its name echoed back")
+    func existingManifestIsDeleted() async throws {
+        let deletedName = Box<String?>(nil)
+        let client = MockManifestClient(
+            existsHandler: { _ in true },
+            deleteHandler: { name in await deletedName.set(name) }
+        )
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.DELETE, "/v1.51/libpod/manifests/mylist") { res async throws in
+                #expect(res.status == .ok)
+                let body = try JSONDecoder().decode(RESTManifestRemoveReport.self, from: Data(buffer: res.body))
+                #expect(body.Deleted == ["mylist"])
+                #expect(body.ExitCode == 0)
+            }
+        }
+        #expect(await deletedName.get() == "mylist")
+    }
+
+    @Test("a nonexistent manifest list without ?ignore returns 404")
+    func nonexistentWithoutIgnoreReturns404() async throws {
+        let client = MockManifestClient(existsHandler: { _ in false })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.DELETE, "/v1.51/libpod/manifests/ghost") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("a nonexistent manifest list with ?ignore=true returns 200 without calling delete")
+    func nonexistentWithIgnoreReturns200() async throws {
+        let deleteCalled = Box(false)
+        let client = MockManifestClient(
+            existsHandler: { _ in false },
+            deleteHandler: { _ in await deleteCalled.set(true) }
+        )
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.DELETE, "/v1.51/libpod/manifests/ghost?ignore=true") { res async throws in
+                #expect(res.status == .ok)
+                let body = try JSONDecoder().decode(RESTManifestRemoveReport.self, from: Data(buffer: res.body))
+                #expect(body.Deleted == [])
+                #expect(body.ExitCode == 0)
+            }
+        }
+        #expect(await !deleteCalled.get())
+    }
+}
+
+// MARK: - Helpers
+
+func withManifestApp(client: MockManifestClient, test: @escaping (Application) async throws -> Void) async throws {
+    try await withApp(configure: { _ in }) { app in
+        let regexRouter = app.regexRouter(with: app.logger)
+        app.setRegexRouter(regexRouter)
+        regexRouter.installMiddleware(on: app)
+        try app.register(collection: LibpodManifestCreateRoute(client: client))
+        try app.register(collection: LibpodManifestInspectRoute(client: client))
+        try app.register(collection: LibpodManifestExistsRoute(client: client))
+        try app.register(collection: LibpodManifestDeleteRoute(client: client))
+        try await test(app)
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestCRUDRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestCRUDRouteTests.swift
@@ -1,3 +1,4 @@
+import ContainerizationError
 import ContainerizationOCI
 import Foundation
 import Testing
@@ -114,6 +115,19 @@ struct LibpodManifestCreateRouteTests {
             }
         }
         #expect(await receivedAmend.get() == true)
+    }
+
+    @Test("a ContainerizationError.invalidArgument from create surfaces as 400, not a raw 500")
+    func invalidArgumentFromCreateIs400() async throws {
+        let client = MockManifestClient(createHandler: { name, _, _ in
+            throw ContainerizationError(.invalidArgument, message: "\(name) exists but is not a manifest list")
+        })
+
+        try await withManifestApp(client: client) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist?image=alpine:latest&amend=true") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
     }
 }
 

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestModifyRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestModifyRouteTests.swift
@@ -1,0 +1,199 @@
+import ContainerizationOCI
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+@Suite("LibpodManifestModifyRoute")
+struct LibpodManifestModifyRouteTests {
+    @Test("default operation (no 'operation' param) adds images, matching podman's 'update' default")
+    func defaultOperationAdds() async throws {
+        let receivedImages = Box<[String]?>(nil)
+        let client = MockManifestClient(addHandler: { _, images in
+            await receivedImages.set(images)
+            return "sha256:added"
+        })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?images=alpine:latest") { res async throws in
+                #expect(res.status == .ok)
+                let body = try JSONDecoder().decode(RESTManifestIDResponse.self, from: Data(buffer: res.body))
+                #expect(body.ID == "sha256:added")
+            }
+        }
+        #expect(await receivedImages.get() == ["alpine:latest"])
+    }
+
+    @Test("explicit operation=update adds images the same as the default")
+    func explicitUpdateAdds() async throws {
+        let addCalled = Box(false)
+        let client = MockManifestClient(addHandler: { _, _ in
+            await addCalled.set(true)
+            return "sha256:added"
+        })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=update&images=alpine:latest") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+        #expect(await addCalled.get())
+    }
+
+    @Test("update with no images is a 400, not an empty no-op update")
+    func updateWithNoImagesIs400() async throws {
+        let client = MockManifestClient()
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("operation=remove removes each listed digest in order")
+    func removeDigests() async throws {
+        let removedDigests = Box<[String]>([])
+        let client = MockManifestClient(
+            inspectHandler: { _ in
+                Index(manifests: [
+                    Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100),
+                    Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:bbb", size: 100),
+                ])
+            },
+            removeDigestHandler: { _, digest in
+                await removedDigests.set(await removedDigests.get() + [digest])
+                return "sha256:afterremoval"
+            })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=remove&images=sha256:aaa&images=sha256:bbb") { res async throws in
+                #expect(res.status == .ok)
+                let body = try JSONDecoder().decode(RESTManifestIDResponse.self, from: Data(buffer: res.body))
+                #expect(body.ID == "sha256:afterremoval")
+            }
+        }
+        #expect(await removedDigests.get() == ["sha256:aaa", "sha256:bbb"])
+    }
+
+    @Test("remove with no images is a 400")
+    func removeWithNoImagesIs400() async throws {
+        let client = MockManifestClient()
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=remove") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("a later invalid digest in a multi-digest remove is rejected before any digest is actually removed")
+    func removeRejectsBeforeMutatingWhenADigestIsInvalid() async throws {
+        let removedDigests = Box<[String]>([])
+        let client = MockManifestClient(
+            inspectHandler: { _ in
+                // Only "sha256:aaa" is an actual member — "sha256:bbb" is not.
+                Index(manifests: [Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100)])
+            },
+            removeDigestHandler: { _, digest in
+                await removedDigests.set(await removedDigests.get() + [digest])
+                return "sha256:afterremoval"
+            })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=remove&images=sha256:aaa&images=sha256:bbb") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+        // Neither digest was actually removed — validation ran before any mutation, even
+        // though "sha256:aaa" alone would have succeeded if processed first.
+        #expect(await removedDigests.get() == [])
+    }
+
+    @Test("a digest requested twice in the same remove is rejected before any digest is actually removed")
+    func removeRejectsDuplicateDigestBeforeMutating() async throws {
+        let removedDigests = Box<[String]>([])
+        let client = MockManifestClient(
+            inspectHandler: { _ in
+                Index(manifests: [Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100)])
+            },
+            removeDigestHandler: { _, digest in
+                await removedDigests.set(await removedDigests.get() + [digest])
+                return "sha256:afterremoval"
+            })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=remove&images=sha256:aaa&images=sha256:aaa") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+        // Without the duplicate check, the first occurrence would succeed and the second
+        // would fail (no longer a member after the first removal) — a partial mutation
+        // masquerading as a whole-request failure, the exact bug this pre-check prevents.
+        #expect(await removedDigests.get() == [])
+    }
+
+    @Test("operation=annotate is not implemented")
+    func annotateIsNotImplemented() async throws {
+        let client = MockManifestClient()
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=annotate") { res async throws in
+                #expect(res.status == .notImplemented)
+            }
+        }
+    }
+
+    @Test("an unknown operation is a 400")
+    func unknownOperationIs400() async throws {
+        let client = MockManifestClient()
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=bogus") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("an image add can't resolve surfaces as 400, not a raw error")
+    func addNotFoundImageIs400() async throws {
+        let client = MockManifestClient(addHandler: { _, _ in
+            throw ClientImageError.notFound(id: "does-not-exist:latest")
+        })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?images=does-not-exist:latest") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("removing from a nonexistent manifest list is a 404")
+    func removeFromNonexistentManifestIs404() async throws {
+        let client = MockManifestClient(
+            inspectHandler: { name in throw ClientManifestError.notFound(name: name) },
+            removeDigestHandler: { name, _ in
+                throw ClientManifestError.notFound(name: name)
+            })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/ghost?operation=remove&images=sha256:aaa") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    // MARK: - Helper
+
+    private func withModifyApp(client: MockManifestClient, test: @escaping (Application) async throws -> Void) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodManifestModifyRoute(client: client))
+            try await test(app)
+        }
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestModifyRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestModifyRouteTests.swift
@@ -53,8 +53,8 @@ struct LibpodManifestModifyRouteTests {
         }
     }
 
-    @Test("operation=remove removes each listed digest in order")
-    func removeDigests() async throws {
+    @Test("operation=remove removes every listed digest in a single batch call")
+    func removeDigestsInOneBatch() async throws {
         let removedDigests = Box<[String]>([])
         let client = MockManifestClient(
             inspectHandler: { _ in
@@ -63,8 +63,8 @@ struct LibpodManifestModifyRouteTests {
                     Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:bbb", size: 100),
                 ])
             },
-            removeDigestHandler: { _, digest in
-                await removedDigests.set(await removedDigests.get() + [digest])
+            removeDigestsHandler: { _, digests in
+                await removedDigests.set(digests)
                 return "sha256:afterremoval"
             })
 
@@ -89,6 +89,21 @@ struct LibpodManifestModifyRouteTests {
         }
     }
 
+    @Test("a non-sha256 digest is rejected as unsupported, not silently mangled into a malformed sha256 value")
+    func removeWithNonSha256DigestIs400() async throws {
+        let client = MockManifestClient(
+            inspectHandler: { _ in
+                Index(manifests: [Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100)])
+            })
+
+        try await withModifyApp(client: client) { app in
+            try await app.testing().test(.PUT, "/v1.51/libpod/manifests/mylist?operation=remove&images=sha512:abc") { res async throws in
+                #expect(res.status == .badRequest)
+                #expect(res.body.string.contains("not a supported digest"))
+            }
+        }
+    }
+
     @Test("a later invalid digest in a multi-digest remove is rejected before any digest is actually removed")
     func removeRejectsBeforeMutatingWhenADigestIsInvalid() async throws {
         let removedDigests = Box<[String]>([])
@@ -97,8 +112,8 @@ struct LibpodManifestModifyRouteTests {
                 // Only "sha256:aaa" is an actual member — "sha256:bbb" is not.
                 Index(manifests: [Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100)])
             },
-            removeDigestHandler: { _, digest in
-                await removedDigests.set(await removedDigests.get() + [digest])
+            removeDigestsHandler: { _, digests in
+                await removedDigests.set(await removedDigests.get() + digests)
                 return "sha256:afterremoval"
             })
 
@@ -119,8 +134,8 @@ struct LibpodManifestModifyRouteTests {
             inspectHandler: { _ in
                 Index(manifests: [Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:aaa", size: 100)])
             },
-            removeDigestHandler: { _, digest in
-                await removedDigests.set(await removedDigests.get() + [digest])
+            removeDigestsHandler: { _, digests in
+                await removedDigests.set(await removedDigests.get() + digests)
                 return "sha256:afterremoval"
             })
 
@@ -174,7 +189,7 @@ struct LibpodManifestModifyRouteTests {
     func removeFromNonexistentManifestIs404() async throws {
         let client = MockManifestClient(
             inspectHandler: { name in throw ClientManifestError.notFound(name: name) },
-            removeDigestHandler: { name, _ in
+            removeDigestsHandler: { name, _ in
                 throw ClientManifestError.notFound(name: name)
             })
 

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestPushRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestPushRouteTests.swift
@@ -78,6 +78,30 @@ struct LibpodManifestPushRouteTests {
         }
     }
 
+    @Test("a destination that already had its own prior tag forwards that exact descriptor to untagPushDestination unchanged")
+    func differingDestinationWithPriorTagForwardsPriorDescriptor() async throws {
+        let priorDescriptor = Descriptor(mediaType: MediaTypes.imageManifest, digest: "sha256:priorexisting", size: 123)
+        let untaggedState = Box<RetagState?>(nil)
+        let manifestClient = MockManifestClient(
+            digestHandler: { _ in "sha256:finaldigest" },
+            retagForPushHandler: { _, destination in
+                (destination, RetagState(reference: destination, priorDescriptor: priorDescriptor))
+            },
+            untagPushDestinationHandler: { state in await untaggedState.set(state) }
+        )
+        let imageClient = StubImageClient(pushManifestListHandler: { _ in AsyncThrowingStream { $0.finish() } })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/registry/registry.example.com/repo:tag") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+
+        let state = await untaggedState.get()
+        #expect(state?.reference == "registry.example.com/repo:tag")
+        #expect(state?.priorDescriptor?.digest == "sha256:priorexisting")
+    }
+
     @Test("the legacy ?destination= query form behaves the same as the path form")
     func legacyQueryDestinationForm() async throws {
         let pushedReference = Box<String?>(nil)

--- a/Tests/socktainerTests/Routes/Libpod/LibpodManifestPushRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodManifestPushRouteTests.swift
@@ -1,0 +1,234 @@
+import ContainerAPIClient
+import Containerization
+import ContainerizationOCI
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// Route-level coverage for `podman manifest push` (both the current path-destination form and
+/// the legacy query-destination form), and specifically the retag-before-push /
+/// untag-after-push dance `LibpodManifestPushRoute` is responsible for driving.
+@Suite("LibpodManifestPushRoute")
+struct LibpodManifestPushRouteTests {
+    @Test("destination equal to name pushes directly, without retagging or later untagging")
+    func sameDestinationSkipsRetag() async throws {
+        let recorder = CallRecorder()
+        let pushedReference = Box<String?>(nil)
+        let manifestClient = MockManifestClient(
+            recorder: recorder,
+            digestHandler: { _ in "sha256:finaldigest" },
+            retagForPushHandler: { name, _ in (name, nil) }
+        )
+        let imageClient = StubImageClient(pushManifestListHandler: { reference in
+            await pushedReference.set(reference)
+            return AsyncThrowingStream { $0.finish() }
+        })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/registry/mylist") { res async throws in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("sha256:finaldigest"))
+            }
+        }
+        #expect(await pushedReference.get() == "mylist")
+        let calls = await recorder.calls
+        #expect(!calls.contains { $0.hasPrefix("untagPushDestination") })
+    }
+
+    @Test("a differing destination retags first, pushes the retagged reference, then untags")
+    func differingDestinationRetagsPushesUntags() async throws {
+        let recorder = CallRecorder()
+        let pushedReference = Box<String?>(nil)
+        let manifestClient = MockManifestClient(
+            recorder: recorder,
+            digestHandler: { _ in "sha256:finaldigest" },
+            retagForPushHandler: { name, destination in
+                (destination, RetagState(reference: destination, priorDescriptor: nil))
+            },
+            untagPushDestinationHandler: { _ in }
+        )
+        let imageClient = StubImageClient(
+            recorder: recorder,
+            pushManifestListHandler: { reference in
+                await pushedReference.set(reference)
+                return AsyncThrowingStream { $0.finish() }
+            })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/registry/registry.example.com/repo:tag") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+        #expect(await pushedReference.get() == "registry.example.com/repo:tag")
+
+        let calls = await recorder.calls
+        let retagIndex = calls.firstIndex { $0.hasPrefix("retagForPush") }
+        let pushIndex = calls.firstIndex { $0.hasPrefix("pushManifestList") }
+        let untagIndex = calls.firstIndex { $0.hasPrefix("untagPushDestination") }
+        #expect(retagIndex != nil)
+        #expect(pushIndex != nil)
+        #expect(untagIndex != nil)
+        if let retagIndex, let pushIndex, let untagIndex {
+            #expect(retagIndex < pushIndex, "retag must happen before the network push")
+            #expect(pushIndex < untagIndex, "the network push must happen before untag")
+        }
+    }
+
+    @Test("the legacy ?destination= query form behaves the same as the path form")
+    func legacyQueryDestinationForm() async throws {
+        let pushedReference = Box<String?>(nil)
+        let manifestClient = MockManifestClient(
+            digestHandler: { _ in "sha256:finaldigest" },
+            retagForPushHandler: { name, _ in (name, nil) }
+        )
+        let imageClient = StubImageClient(pushManifestListHandler: { reference in
+            await pushedReference.set(reference)
+            return AsyncThrowingStream { $0.finish() }
+        })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/push?destination=mylist") { res async throws in
+                #expect(res.status == .ok)
+            }
+        }
+        #expect(await pushedReference.get() == "mylist")
+    }
+
+    @Test("a missing destination on the legacy query form is a 400")
+    func missingQueryDestinationIs400() async throws {
+        try await withPushApp(manifestClient: MockManifestClient(), imageClient: StubImageClient()) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/push") { res async throws in
+                #expect(res.status == .badRequest)
+            }
+        }
+    }
+
+    @Test("a source manifest list that can't be found is a 404")
+    func retagNotFoundIs404() async throws {
+        let manifestClient = MockManifestClient(retagForPushHandler: { name, _ in
+            throw ClientImageError.notFound(id: name)
+        })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: StubImageClient()) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/ghost/registry/dest") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test("a push failure still untags the destination before surfacing the error")
+    func pushFailureStillUntags() async throws {
+        let recorder = CallRecorder()
+        let manifestClient = MockManifestClient(
+            recorder: recorder,
+            retagForPushHandler: { _, destination in
+                (destination, RetagState(reference: destination, priorDescriptor: nil))
+            },
+            untagPushDestinationHandler: { _ in }
+        )
+        let imageClient = StubImageClient(pushManifestListHandler: { _ in
+            throw ClientImageError.notFound(id: "registry.example.com/repo:tag")
+        })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/registry/registry.example.com/repo:tag") { res async throws in
+                #expect(res.status == .notFound)
+            }
+        }
+        let calls = await recorder.calls
+        #expect(calls.contains { $0.hasPrefix("untagPushDestination") })
+    }
+
+    @Test("a failure mid-stream (after the push started) still untags the destination")
+    func midStreamFailureStillUntags() async throws {
+        let recorder = CallRecorder()
+        let manifestClient = MockManifestClient(
+            recorder: recorder,
+            retagForPushHandler: { _, destination in
+                (destination, RetagState(reference: destination, priorDescriptor: nil))
+            },
+            untagPushDestinationHandler: { _ in }
+        )
+        let imageClient = StubImageClient(
+            recorder: recorder,
+            pushManifestListHandler: { _ in
+                AsyncThrowingStream { continuation in
+                    continuation.finish(throwing: ClientImageError.notFound(id: "registry.example.com/repo:tag"))
+                }
+            })
+
+        try await withPushApp(manifestClient: manifestClient, imageClient: imageClient) { app in
+            try await app.testing().test(.POST, "/v1.51/libpod/manifests/mylist/registry/registry.example.com/repo:tag") { res async throws in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("error"))
+            }
+        }
+
+        // This cleanup runs in its own untied Task (see LibpodManifestPushRoute — deliberately
+        // NOT a structured child of the response-stream Task, so it survives that Task being
+        // cancelled on a client disconnect), so it isn't guaranteed to have completed the
+        // instant the response body finishes draining — poll briefly rather than asserting
+        // immediately.
+        var sawUntag = false
+        for _ in 0..<50 {
+            if await recorder.calls.contains(where: { $0.hasPrefix("untagPushDestination") }) {
+                sawUntag = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(sawUntag)
+    }
+
+    // MARK: - Helpers
+
+    private func withPushApp(
+        manifestClient: MockManifestClient, imageClient: StubImageClient, test: @escaping (Application) async throws -> Void
+    ) async throws {
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodManifestPushRoute(manifestClient: manifestClient, imageClient: imageClient))
+            try await test(app)
+        }
+    }
+}
+
+/// A `ClientImageProtocol` stub exposing only `pushManifestList` as configurable — every other
+/// method is unused by `LibpodManifestPushRoute` and stubbed to a harmless default.
+private struct StubImageClient: ClientImageProtocol {
+    var recorder: CallRecorder?
+    var pushManifestListHandler: (@Sendable (String) async throws -> AsyncThrowingStream<String, Error>)?
+
+    func list(includeSystemImages: Bool) async throws -> [ClientImage] { [] }
+    func delete(id: String) async throws -> ImageDeletionResult { ImageDeletionResult(untagged: id, digest: "sha256:0000", deletedDigest: nil) }
+    func pull(image: String, tag: String?, platform: Platform, logger: Logger) async throws -> AsyncThrowingStream<PullProgress, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        await recorder?.record("pushManifestList(\(reference))")
+        guard let pushManifestListHandler else { return AsyncThrowingStream { $0.finish() } }
+        return try await pushManifestListHandler(reference)
+    }
+    func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
+        ([], 0)
+    }
+    func load(tarballPath: URL, platform: Platform, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> [String] { [] }
+    func save(references: [String], platform: Platform?, appleContainerAppSupportUrl: URL, logger: Logger) async throws -> URL {
+        URL(fileURLWithPath: "/dev/null")
+    }
+    func importImage(
+        tarPath: URL, repo: String?, tag: String?, message: String?, changes: [String], platform: Platform,
+        appleContainerAppSupportUrl: URL, logger: Logger
+    ) async throws -> (reference: String?, digest: String) {
+        (nil, "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/LibpodNetworkParamBindingTests.swift
+++ b/Tests/socktainerTests/Routes/Libpod/LibpodNetworkParamBindingTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Logging
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import socktainer
+
+/// `LibpodNetworkInspectRoute`/`LibpodNetworkDeleteRoute` delegate to the Docker-compat
+/// `NetworkInspectRoute`/`NetworkDeleteRoute` handlers, which read the path parameter under
+/// the key `"id"` — registering the libpod route's own pattern with `{name}` instead of
+/// `{id}` left that key unset for every request, regardless of what network name the
+/// caller actually specified.
+@Suite("LibpodNetworkInspectRoute / LibpodNetworkDeleteRoute — path parameter binding")
+struct LibpodNetworkParamBindingTests {
+    @Test("the network name in the URL reaches the handler as the 'id' parameter, not lost")
+    func inspectResolvesNetworkFromPath() async throws {
+        let client = StubNetworkClient(summary: makeSummary(name: "mynet"))
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodNetworkInspectRoute(client: client))
+
+            try await app.testing().test(.GET, "/v1.51/libpod/networks/mynet/json") { res async throws in
+                #expect(res.status == .ok)
+                let body = try JSONDecoder().decode(RESTNetworkSummary.self, from: Data(buffer: res.body))
+                #expect(body.Name == "mynet")
+            }
+        }
+        #expect(await client.requestedId == "mynet")
+    }
+
+    @Test("the network name in the URL reaches the delete handler as the 'id' parameter, not lost")
+    func deleteResolvesNetworkFromPath() async throws {
+        let client = StubNetworkClient(summary: makeSummary(name: "mynet"))
+
+        try await withApp(configure: { _ in }) { app in
+            let regexRouter = app.regexRouter(with: app.logger)
+            app.setRegexRouter(regexRouter)
+            regexRouter.installMiddleware(on: app)
+            try app.register(collection: LibpodNetworkDeleteRoute(dockerRoute: NetworkDeleteRoute(client: client)))
+
+            try await app.testing().test(.DELETE, "/v1.51/libpod/networks/mynet") { res async throws in
+                #expect(res.status == .noContent)
+            }
+        }
+        #expect(await client.deletedId == "mynet")
+    }
+}
+
+private func makeSummary(name: String) -> RESTNetworkSummary {
+    RESTNetworkSummary(
+        Name: name,
+        Id: name,
+        Created: "",
+        Scope: "local",
+        Driver: "nat",
+        EnableIPv4: true,
+        EnableIPv6: false,
+        Internal: false,
+        Attachable: false,
+        Ingress: false,
+        IPAM: NetworkIPAM(Driver: "default", Config: []),
+        Options: [:],
+        Containers: nil,
+        ConfigFrom: nil,
+        Labels: [:],
+        Subnet: nil,
+        Gateway: nil
+    )
+}
+
+private actor StubNetworkClient: ClientNetworkProtocol {
+    private let summary: RESTNetworkSummary
+    private(set) var requestedId: String?
+    private(set) var deletedId: String?
+
+    init(summary: RESTNetworkSummary) {
+        self.summary = summary
+    }
+
+    func list(filters: String?, logger: Logger) async throws -> [RESTNetworkSummary] { [summary] }
+
+    func getNetwork(id: String, logger: Logger) async throws -> RESTNetworkSummary? {
+        requestedId = id
+        return id == summary.Name ? summary : nil
+    }
+
+    func delete(id: String, logger: Logger) async throws {
+        deletedId = id
+    }
+
+    func create(name: String, labels: [String: String], ipv4Subnet: String?, logger: Logger) async throws -> RESTNetworkCreate {
+        RESTNetworkCreate(Id: name, Warning: "")
+    }
+}

--- a/Tests/socktainerTests/Routes/Libpod/MockManifestClient.swift
+++ b/Tests/socktainerTests/Routes/Libpod/MockManifestClient.swift
@@ -38,6 +38,7 @@ struct MockManifestClient: ClientManifestServiceProtocol {
     var mergeAndTagHandler: (@Sendable (String, [String]) async throws -> String)?
     var addHandler: (@Sendable (String, [String]) async throws -> String)?
     var removeDigestHandler: (@Sendable (String, String) async throws -> String)?
+    var removeDigestsHandler: (@Sendable (String, [String]) async throws -> String)?
     var addBuiltImageHandler: (@Sendable (String, String) async throws -> String)?
     var deleteHandler: (@Sendable (String) async throws -> Void)?
     var retagForPushHandler: (@Sendable (String, String) async throws -> (reference: String, priorState: RetagState?))?
@@ -83,6 +84,12 @@ struct MockManifestClient: ClientManifestServiceProtocol {
         await recorder?.record("removeDigest(\(name), \(digest))")
         guard let removeDigestHandler else { throw Unconfigured(method: "removeDigest") }
         return try await removeDigestHandler(name, digest)
+    }
+
+    func removeDigests(name: String, digests: [String]) async throws -> String {
+        await recorder?.record("removeDigests(\(name), \(digests))")
+        guard let removeDigestsHandler else { throw Unconfigured(method: "removeDigests") }
+        return try await removeDigestsHandler(name, digests)
     }
 
     func addBuiltImage(name: String, builtReference: String, logger: Logger) async throws -> String {

--- a/Tests/socktainerTests/Routes/Libpod/MockManifestClient.swift
+++ b/Tests/socktainerTests/Routes/Libpod/MockManifestClient.swift
@@ -1,0 +1,111 @@
+import ContainerizationOCI
+import Logging
+
+@testable import socktainer
+
+/// Records calls made through a `MockManifestClient` in registration order, so a test can
+/// assert not just the return values but the sequence (e.g. retag happens before push, untag
+/// happens after).
+actor CallRecorder {
+    private(set) var calls: [String] = []
+    func record(_ call: String) { calls.append(call) }
+}
+
+/// A generic mutable box a `@Sendable` mock handler closure can write into and a test can read
+/// back from after the request completes — a plain captured `var` isn't `Sendable` across the
+/// mock's closures, which run in a different isolation context than the test body.
+actor Box<Value: Sendable> {
+    private var value: Value
+    init(_ value: Value) { self.value = value }
+    func set(_ value: Value) { self.value = value }
+    func get() -> Value { value }
+}
+
+/// A `ClientManifestServiceProtocol` mock configured per-test via optional handler closures.
+/// Any method invoked without a handler throws `Unconfigured` — this surfaces an unexpectedly
+/// exercised code path as a test failure instead of a silent default.
+struct MockManifestClient: ClientManifestServiceProtocol {
+    struct Unconfigured: Error, CustomStringConvertible {
+        let method: String
+        var description: String { "MockManifestClient.\(method) was called without a handler configured" }
+    }
+
+    var recorder: CallRecorder?
+    var existsHandler: (@Sendable (String) async throws -> Bool)?
+    var digestHandler: (@Sendable (String) async throws -> String)?
+    var inspectHandler: (@Sendable (String) async throws -> Index)?
+    var createHandler: (@Sendable (String, [String], Bool) async throws -> String)?
+    var mergeAndTagHandler: (@Sendable (String, [String]) async throws -> String)?
+    var addHandler: (@Sendable (String, [String]) async throws -> String)?
+    var removeDigestHandler: (@Sendable (String, String) async throws -> String)?
+    var addBuiltImageHandler: (@Sendable (String, String) async throws -> String)?
+    var deleteHandler: (@Sendable (String) async throws -> Void)?
+    var retagForPushHandler: (@Sendable (String, String) async throws -> (reference: String, priorState: RetagState?))?
+    var untagPushDestinationHandler: (@Sendable (RetagState) async throws -> Void)?
+
+    func exists(name: String) async throws -> Bool {
+        await recorder?.record("exists(\(name))")
+        guard let existsHandler else { throw Unconfigured(method: "exists") }
+        return try await existsHandler(name)
+    }
+
+    func digest(for name: String) async throws -> String {
+        await recorder?.record("digest(\(name))")
+        guard let digestHandler else { throw Unconfigured(method: "digest") }
+        return try await digestHandler(name)
+    }
+
+    func inspect(name: String) async throws -> Index {
+        await recorder?.record("inspect(\(name))")
+        guard let inspectHandler else { throw Unconfigured(method: "inspect") }
+        return try await inspectHandler(name)
+    }
+
+    func create(name: String, images: [String], logger: Logger, amend: Bool) async throws -> String {
+        await recorder?.record("create(\(name), \(images), amend: \(amend))")
+        guard let createHandler else { throw Unconfigured(method: "create") }
+        return try await createHandler(name, images, amend)
+    }
+
+    func mergeAndTag(name: String, images: [String], logger: Logger) async throws -> String {
+        await recorder?.record("mergeAndTag(\(name), \(images))")
+        guard let mergeAndTagHandler else { throw Unconfigured(method: "mergeAndTag") }
+        return try await mergeAndTagHandler(name, images)
+    }
+
+    func add(name: String, images: [String], logger: Logger) async throws -> String {
+        await recorder?.record("add(\(name), \(images))")
+        guard let addHandler else { throw Unconfigured(method: "add") }
+        return try await addHandler(name, images)
+    }
+
+    func removeDigest(name: String, digest: String) async throws -> String {
+        await recorder?.record("removeDigest(\(name), \(digest))")
+        guard let removeDigestHandler else { throw Unconfigured(method: "removeDigest") }
+        return try await removeDigestHandler(name, digest)
+    }
+
+    func addBuiltImage(name: String, builtReference: String, logger: Logger) async throws -> String {
+        await recorder?.record("addBuiltImage(\(name), \(builtReference))")
+        guard let addBuiltImageHandler else { throw Unconfigured(method: "addBuiltImage") }
+        return try await addBuiltImageHandler(name, builtReference)
+    }
+
+    func delete(name: String) async throws {
+        await recorder?.record("delete(\(name))")
+        guard let deleteHandler else { throw Unconfigured(method: "delete") }
+        try await deleteHandler(name)
+    }
+
+    func retagForPush(name: String, destination: String) async throws -> (reference: String, priorState: RetagState?) {
+        await recorder?.record("retagForPush(\(name), \(destination))")
+        guard let retagForPushHandler else { throw Unconfigured(method: "retagForPush") }
+        return try await retagForPushHandler(name, destination)
+    }
+
+    func untagPushDestination(_ state: RetagState) async throws {
+        await recorder?.record("untagPushDestination(\(state.reference))")
+        guard let untagPushDestinationHandler else { throw Unconfigured(method: "untagPushDestination") }
+        try await untagPushDestinationHandler(state)
+    }
+}

--- a/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/InfoRouteTests.swift
@@ -58,6 +58,9 @@ private struct StubImageClient: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
         ([], 0)
     }

--- a/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
+++ b/Tests/socktainerTests/Routes/Server/SystemDFRouteTests.swift
@@ -18,6 +18,9 @@ private struct EmptyImageClient: ClientImageProtocol {
     func push(reference: String, platform: Platform?, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+    func pushManifestList(reference: String, logger: Logger) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
     func prune(filters: [String: [String]], logger: Logger) async throws -> (results: [ImageDeletionResult], spaceReclaimed: Int64) {
         ([], 0)
     }
@@ -39,8 +42,8 @@ private struct EmptyVolumeClient: ClientVolumeProtocol {
 }
 
 private struct EmptyBuilderClient: ClientBuilderProtocol {
-    func ensureReachable(timeout: Duration, retryInterval: Duration, logger: Logger) async throws {}
-    func connect(timeout: Duration, retryInterval: Duration, logger: Logger) async throws -> Builder {
+    func ensureReachable(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws {}
+    func connect(timeout: Duration, retryInterval: Duration, qemu: Bool, logger: Logger) async throws -> Builder {
         fatalError("not exercised when the default (includeAll) query builds an empty BuildCache")
     }
     func prune(_ request: BuilderPruneRequest, logger: Logger) async throws -> BuilderPruneResult {

--- a/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
+++ b/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
@@ -286,6 +286,34 @@ struct ArchiveExtractionSafetyTests {
         #expect(stat(linkedPath, &linkedInfo) == 0)
         #expect(originalInfo.st_ino == linkedInfo.st_ino)
     }
+
+    @Test("A hard-link entry resolving to the extraction root itself is rejected, not linked over the destination directory")
+    func hardLinkEntryAtDestinationRootIsRejected() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("malicious.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "sentinel.txt", fileType: .regular, data: Data("sentinel".utf8)),
+                // A "."/root-path hard-link entry would otherwise `removeItem` the destination
+                // directory itself before re-linking it — reject it instead of processing it.
+                RawTarEntry(path: ".", fileType: .regular, hardlinkTarget: "sentinel.txt"),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        do {
+            try ArchiveUtility.extract(tarPath: tar, to: dest)
+            Issue.record("expected extraction to reject the root hard-link entry")
+        } catch ArchiveUtilityError.rejectedArchiveEntries(let paths) {
+            #expect(paths.contains("."))
+        }
+        // The destination directory itself must have survived, still able to hold the
+        // sentinel entry that was extracted before the malicious root entry was rejected.
+        #expect(FileManager.default.fileExists(atPath: dest.appendingPathComponent("sentinel.txt").path))
+    }
 }
 
 private struct RawTarEntry {

--- a/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
+++ b/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
@@ -245,12 +245,45 @@ struct ArchiveExtractionSafetyTests {
         #expect(lstat(evilPath, &info) == 0)
         #expect((info.st_mode & S_IFMT) == S_IFDIR)
     }
+
+    @Test("A hard-link entry links to its target's real content, not an empty file")
+    func hardLinkEntryLinksToTargetContent() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "original.txt", fileType: .regular, data: Data("hello, hardlink".utf8)),
+                // A hard-link entry surfaces with `fileType == .regular` (see `archive_entry_hardlink`
+                // convention) and no data of its own — the entry itself only carries the linked-to
+                // path.
+                RawTarEntry(path: "linked.txt", fileType: .regular, hardlinkTarget: "original.txt"),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+
+        let originalPath = dest.appendingPathComponent("original.txt").path
+        let linkedPath = dest.appendingPathComponent("linked.txt").path
+        let linkedContent = try String(contentsOfFile: linkedPath, encoding: .utf8)
+        #expect(linkedContent == "hello, hardlink")
+
+        var originalInfo = stat()
+        var linkedInfo = stat()
+        #expect(stat(originalPath, &originalInfo) == 0)
+        #expect(stat(linkedPath, &linkedInfo) == 0)
+        #expect(originalInfo.st_ino == linkedInfo.st_ino)
+    }
 }
 
 private struct RawTarEntry {
     let path: String
     let fileType: URLFileResourceType
     var symlinkTarget: String? = nil
+    var hardlinkTarget: String? = nil
     var data: Data? = nil
     var modificationDate: Date? = nil
 }
@@ -267,6 +300,9 @@ private func writeRawTar(at tarPath: URL, entries: [RawTarEntry]) throws {
         entry.permissions = raw.fileType == .directory ? 0o755 : 0o644
         if let target = raw.symlinkTarget {
             entry.symlinkTarget = target
+        }
+        if let target = raw.hardlinkTarget {
+            entry.hardlink = target
         }
         if let modificationDate = raw.modificationDate {
             entry.modificationDate = modificationDate

--- a/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
+++ b/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
@@ -84,8 +84,11 @@ struct ArchiveExtractionSafetyTests {
             entries: [RawTarEntry(path: "../escape", fileType: .regular, data: Data("pwned".utf8))])
 
         let dest = tmp.appendingPathComponent("out")
-        #expect(throws: ArchiveUtilityError.self) {
+        do {
             try ArchiveUtility.extract(tarPath: tar, to: dest)
+            Issue.record("expected extraction to reject the traversal entry")
+        } catch ArchiveUtilityError.rejectedArchiveEntries(let paths) {
+            #expect(paths.contains("../escape"))
         }
         #expect(!FileManager.default.fileExists(atPath: tmp.appendingPathComponent("escape").path))
     }
@@ -111,8 +114,11 @@ struct ArchiveExtractionSafetyTests {
             ])
 
         let dest = tmp.appendingPathComponent("out")
-        #expect(throws: ArchiveUtilityError.self) {
+        do {
             try ArchiveUtility.extract(tarPath: tar, to: dest)
+            Issue.record("expected extraction to reject the symlink-ancestor traversal entry")
+        } catch ArchiveUtilityError.rejectedArchiveEntries(let paths) {
+            #expect(paths.contains("evil/pwned"))
         }
         #expect(!FileManager.default.fileExists(atPath: outside.appendingPathComponent("pwned").path))
     }
@@ -139,8 +145,11 @@ struct ArchiveExtractionSafetyTests {
             ])
 
         let dest = tmp.appendingPathComponent("out")
-        #expect(throws: ArchiveUtilityError.self) {
+        do {
             try ArchiveUtility.extract(tarPath: tar, to: dest)
+            Issue.record("expected extraction to reject the chained-symlink traversal entry")
+        } catch ArchiveUtilityError.rejectedArchiveEntries(let paths) {
+            #expect(paths.contains("b/x"))
         }
         #expect(!FileManager.default.fileExists(atPath: dest.appendingPathComponent("b/x").path))
     }

--- a/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
+++ b/Tests/socktainerTests/Utilities/ArchiveExtractionTests.swift
@@ -1,0 +1,283 @@
+import ContainerizationArchive
+import Foundation
+import Testing
+
+@testable import socktainer
+
+/// `ArchiveReader.extractContents(to:)` (the vendored Containerization framework) creates
+/// regular files via `open(O_CREAT | O_EXCL | O_WRONLY, entry.permissions)`, using the
+/// entry's own recorded mode as the create mode — which fails with EACCES on macOS for any
+/// entry whose mode has no owner-write bit (e.g. real build contexts containing read-only
+/// vendored/test binaries like kubebuilder's envtest `etcd`). `ArchiveUtility.extract`
+/// reimplements extraction over the framework's public streaming iterator specifically to
+/// avoid this.
+@Suite("ArchiveUtility.extract — read-only entries")
+struct ArchiveExtractionReadOnlyTests {
+    @Test("A tar entry with no owner-write bit extracts instead of failing with EACCES")
+    func readOnlyFileExtracts() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = tmp.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        let readOnlyFile = source.appendingPathComponent("readonly-binary")
+        try "not a real binary, just needs a read-only mode".data(using: .utf8)!.write(to: readOnlyFile)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: readOnlyFile.path)
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try ArchiveUtility.create(tarPath: tar, from: source)
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+
+        let extractedPath = dest.appendingPathComponent("readonly-binary")
+        #expect(FileManager.default.fileExists(atPath: extractedPath.path))
+        let extracted = try String(contentsOf: extractedPath, encoding: .utf8)
+        #expect(extracted == "not a real binary, just needs a read-only mode")
+
+        // The real (read-only) mode is preserved via a post-write chmod, not lost by
+        // creating the file writable to work around the EACCES bug.
+        let attrs = try FileManager.default.attributesOfItem(atPath: extractedPath.path)
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect(mode & 0o200 == 0)  // no owner-write bit
+        #expect(mode & 0o500 == 0o500)  // owner read+execute preserved
+    }
+}
+
+/// `ArchiveUtility.extract` creates regular files via `open(..., O_EXCL | O_NOFOLLOW, ...)`
+/// and rejects any tar member path that resolves outside the destination directory — closing
+/// the path-traversal and symlink-planting attacks a malicious tarball (e.g. one loaded via
+/// `docker load`/`import`) could otherwise use to write outside the extraction directory.
+@Suite("ArchiveUtility.extract — path safety")
+struct ArchiveExtractionSafetyTests {
+    @Test("The archive's own root entry ('./') resolves to the destination itself, not rejected as empty")
+    func rootEntryIsDestination() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = tmp.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "hello".data(using: .utf8)!.write(to: source.appendingPathComponent("file.txt"))
+
+        // ArchiveWriter.archiveDirectory (used internally by ArchiveUtility.create for the
+        // load/import path) emits a leading "./" entry for the archive's own root directory.
+        let tar = tmp.appendingPathComponent("context.tar")
+        try ArchiveUtility.create(tarPath: tar, from: source)
+
+        let dest = tmp.appendingPathComponent("out")
+        // Must not throw .rejectedArchiveEntries(["./"]) or similar.
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+        #expect(FileManager.default.fileExists(atPath: dest.appendingPathComponent("file.txt").path))
+    }
+
+    @Test("A raw '../' traversal path is rejected and nothing is written outside the destination")
+    func traversalPathIsRejected() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("malicious.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [RawTarEntry(path: "../escape", fileType: .regular, data: Data("pwned".utf8))])
+
+        let dest = tmp.appendingPathComponent("out")
+        #expect(throws: ArchiveUtilityError.self) {
+            try ArchiveUtility.extract(tarPath: tar, to: dest)
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmp.appendingPathComponent("escape").path))
+    }
+
+    @Test("A path entry that traverses an already-extracted symlink ancestor is rejected")
+    func symlinkAncestorTraversalIsRejected() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // `evil -> <outside>` is itself a valid, contained symlink entry (an absolute target
+        // is re-rooted under the destination) — but a later entry whose path runs *through*
+        // it (`evil/pwned`) must still be rejected, since normal path resolution would
+        // transparently follow `evil` outside the destination tree.
+        let outside = tmp.appendingPathComponent("outside")
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let tar = tmp.appendingPathComponent("malicious.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "evil", fileType: .symbolicLink, symlinkTarget: outside.path),
+                RawTarEntry(path: "evil/pwned", fileType: .regular, data: Data("pwned".utf8)),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        #expect(throws: ArchiveUtilityError.self) {
+            try ArchiveUtility.extract(tarPath: tar, to: dest)
+        }
+        #expect(!FileManager.default.fileExists(atPath: outside.appendingPathComponent("pwned").path))
+    }
+
+    @Test("A symlink whose target chains through an earlier already-extracted symlink is rejected")
+    func chainedSymlinkTargetTraversalIsRejected() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // `a/link -> /etc` is contained (re-rooted under the destination as `a/link ->
+        // <dest>/etc`). A later symlink `b/x -> ../a/link/passwd` is lexically "contained"
+        // as a string (it never leaves `<dest>` when the `..` is collapsed textually), but
+        // resolving it for real means walking through `a/link`, which redirects outside the
+        // destination the moment something dereferences `b/x`.
+        let tar = tmp.appendingPathComponent("malicious.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "a", fileType: .directory),
+                RawTarEntry(path: "a/link", fileType: .symbolicLink, symlinkTarget: "/etc"),
+                RawTarEntry(path: "b", fileType: .directory),
+                RawTarEntry(path: "b/x", fileType: .symbolicLink, symlinkTarget: "../a/link/passwd"),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        #expect(throws: ArchiveUtilityError.self) {
+            try ArchiveUtility.extract(tarPath: tar, to: dest)
+        }
+        #expect(!FileManager.default.fileExists(atPath: dest.appendingPathComponent("b/x").path))
+    }
+
+    @Test("An absolute symlink target is written to disk as a relative link, not the transient extraction path")
+    func absoluteSymlinkTargetIsWrittenRelative() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "bin", fileType: .directory),
+                RawTarEntry(path: "bin/sh", fileType: .symbolicLink, symlinkTarget: "/bin/busybox"),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+
+        let linkPath = dest.appendingPathComponent("bin/sh").path
+        let onDiskTarget = try FileManager.default.destinationOfSymbolicLink(atPath: linkPath)
+        // Not an absolute path baked to this extraction's own (transient) destination —
+        // that would dangle the moment the extracted tree is moved or copied elsewhere.
+        #expect(!onDiskTarget.hasPrefix("/"))
+        #expect(onDiskTarget == "busybox")
+    }
+
+    @Test("An unsupported entry type (e.g. a FIFO) is skipped without failing the whole extraction")
+    func unsupportedEntryTypeIsNonFatal() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "a-fifo", fileType: .namedPipe),
+                RawTarEntry(path: "file.txt", fileType: .regular, data: Data("hello".utf8)),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        // Must not throw — a FIFO is an unsupported-but-benign tar feature, unlike a
+        // path-traversal/symlink-planting violation.
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+        #expect(FileManager.default.fileExists(atPath: dest.appendingPathComponent("file.txt").path))
+        #expect(!FileManager.default.fileExists(atPath: dest.appendingPathComponent("a-fifo").path))
+    }
+
+    @Test("A regular file's recorded modification time is preserved on extraction")
+    func modificationDateIsPreserved() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Tar mtimes are second-granularity — round to the nearest second so the
+        // round-trip comparison below isn't sensitive to sub-second truncation.
+        let recordedDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded(.down) - 86400)
+        let tar = tmp.appendingPathComponent("context.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "file.txt", fileType: .regular, data: Data("hello".utf8), modificationDate: recordedDate)
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: dest.appendingPathComponent("file.txt").path)
+        let extractedDate = attrs[.modificationDate] as? Date
+        #expect(extractedDate != nil)
+        #expect(abs((extractedDate ?? .distantPast).timeIntervalSince(recordedDate)) < 1)
+    }
+
+    @Test("A directory entry reusing a path a prior symlink entry occupied becomes a real directory, not a dangling symlink")
+    func directoryEntryReplacesPriorSymlink() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let tar = tmp.appendingPathComponent("context.tar")
+        try writeRawTar(
+            at: tar,
+            entries: [
+                RawTarEntry(path: "real_target", fileType: .directory),
+                // "evil" first arrives as a symlink to an existing (contained) directory —
+                // `fileManager.fileExists(atPath:isDirectory:)` would follow it and report
+                // "already a directory," skipping removal; only `lstat` sees the symlink.
+                RawTarEntry(path: "evil", fileType: .symbolicLink, symlinkTarget: "real_target"),
+                // A later entry corrects "evil" to be a real directory — "last entry wins,"
+                // matching the `.regular` case's own semantics.
+                RawTarEntry(path: "evil", fileType: .directory),
+            ])
+
+        let dest = tmp.appendingPathComponent("out")
+        try ArchiveUtility.extract(tarPath: tar, to: dest)
+
+        let evilPath = dest.appendingPathComponent("evil").path
+        var info = stat()
+        #expect(lstat(evilPath, &info) == 0)
+        #expect((info.st_mode & S_IFMT) == S_IFDIR)
+    }
+}
+
+private struct RawTarEntry {
+    let path: String
+    let fileType: URLFileResourceType
+    var symlinkTarget: String? = nil
+    var data: Data? = nil
+    var modificationDate: Date? = nil
+}
+
+/// Writes a tar with entries exactly as specified, bypassing `ArchiveUtility.create`'s
+/// real-directory-archiving convenience — needed to construct entries a real filesystem
+/// could never produce directly (a raw `../` path, or a symlink chain planted deliberately).
+private func writeRawTar(at tarPath: URL, entries: [RawTarEntry]) throws {
+    let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: tarPath)
+    for raw in entries {
+        let entry = WriteEntry(writer)
+        entry.path = raw.path
+        entry.fileType = raw.fileType
+        entry.permissions = raw.fileType == .directory ? 0o755 : 0o644
+        if let target = raw.symlinkTarget {
+            entry.symlinkTarget = target
+        }
+        if let modificationDate = raw.modificationDate {
+            entry.modificationDate = modificationDate
+        }
+        if let data = raw.data {
+            entry.size = Int64(data.count)
+            try writer.writeEntry(entry: entry, data: data)
+        } else {
+            entry.size = 0
+            try writer.writeEntry(entry: entry, data: nil as UnsafeRawBufferPointer?)
+        }
+    }
+    try writer.finishEncoding()
+}

--- a/Tests/socktainerTests/Utilities/PlatformParsingTests.swift
+++ b/Tests/socktainerTests/Utilities/PlatformParsingTests.swift
@@ -1,0 +1,170 @@
+import Testing
+
+@testable import socktainer
+
+@Suite("Platform parsing utilities")
+struct PlatformParsingTests {
+
+    // MARK: – parseMultiPlatformString
+
+    @Test("Single platform is parsed correctly")
+    func parsesSinglePlatform() throws {
+        let platforms = try parseMultiPlatformString("linux/arm64")
+        #expect(platforms.count == 1)
+        #expect(platforms[0].architecture == "arm64")
+        #expect(platforms[0].os == "linux")
+    }
+
+    @Test("Two comma-separated platforms are both parsed")
+    func parsesTwoPlatforms() throws {
+        let platforms = try parseMultiPlatformString("linux/arm64,linux/amd64")
+        #expect(platforms.count == 2)
+        #expect(platforms.map(\.architecture).contains("arm64"))
+        #expect(platforms.map(\.architecture).contains("amd64"))
+    }
+
+    @Test("Three comma-separated platforms are all parsed")
+    func parsesThreePlatforms() throws {
+        let platforms = try parseMultiPlatformString("linux/arm64,linux/amd64,linux/s390x")
+        #expect(platforms.count == 3)
+    }
+
+    @Test("Whitespace around platform tokens is trimmed")
+    func trimsWhitespace() throws {
+        let platforms = try parseMultiPlatformString(" linux/arm64 , linux/s390x ")
+        #expect(platforms.count == 2)
+        #expect(platforms[0].architecture == "arm64")
+        #expect(platforms[1].architecture == "s390x")
+    }
+
+    @Test("ppc64le platform string is parsed")
+    func parsesPpc64le() throws {
+        let platforms = try parseMultiPlatformString("linux/ppc64le")
+        #expect(platforms.count == 1)
+        #expect(platforms[0].architecture == "ppc64le")
+    }
+
+    @Test("Empty string throws an error")
+    func throwsOnEmptyString() {
+        #expect(throws: Error.self) {
+            _ = try parseMultiPlatformString("")
+        }
+    }
+
+    @Test("Whitespace-only string throws an error")
+    func throwsOnWhitespaceOnlyString() {
+        #expect(throws: Error.self) {
+            _ = try parseMultiPlatformString("   ")
+        }
+    }
+
+    @Test("Invalid platform token throws an error")
+    func throwsOnInvalidPlatform() {
+        #expect(throws: Error.self) {
+            _ = try parseMultiPlatformString("not-a-platform")
+        }
+    }
+
+    @Test("Invalid token in a list throws an error")
+    func throwsOnInvalidTokenInList() {
+        #expect(throws: Error.self) {
+            _ = try parseMultiPlatformString("linux/arm64,bad")
+        }
+    }
+
+    // MARK: – platformsRequireQEMU
+
+    @Test("arm64 alone does not require QEMU")
+    func arm64NoQEMU() throws {
+        let platform = try Platform(from: "linux/arm64")
+        #expect(!platformsRequireQEMU([platform]))
+    }
+
+    @Test("amd64 alone does not require QEMU")
+    func amd64NoQEMU() throws {
+        let platform = try Platform(from: "linux/amd64")
+        #expect(!platformsRequireQEMU([platform]))
+    }
+
+    @Test("s390x requires QEMU")
+    func s390xRequiresQEMU() throws {
+        let platform = try Platform(from: "linux/s390x")
+        #expect(platformsRequireQEMU([platform]))
+    }
+
+    @Test("ppc64le requires QEMU")
+    func ppc64leRequiresQEMU() throws {
+        let platform = try Platform(from: "linux/ppc64le")
+        #expect(platformsRequireQEMU([platform]))
+    }
+
+    @Test("riscv64 requires QEMU")
+    func riscv64RequiresQEMU() throws {
+        let platform = try Platform(from: "linux/riscv64")
+        #expect(platformsRequireQEMU([platform]))
+    }
+
+    @Test("Mixed list with s390x requires QEMU")
+    func mixedListWithS390xRequiresQEMU() throws {
+        let arm64 = try Platform(from: "linux/arm64")
+        let s390x = try Platform(from: "linux/s390x")
+        #expect(platformsRequireQEMU([arm64, s390x]))
+    }
+
+    @Test("arm64 + amd64 together do not require QEMU")
+    func nativePlatformsNoQEMU() throws {
+        let arm64 = try Platform(from: "linux/arm64")
+        let amd64 = try Platform(from: "linux/amd64")
+        #expect(!platformsRequireQEMU([arm64, amd64]))
+    }
+
+    @Test("Empty platform list does not require QEMU")
+    func emptyListNoQEMU() {
+        #expect(!platformsRequireQEMU([]))
+    }
+
+    // MARK: – platformRequiresQEMU (per-platform, drives BuildRoute's Rosetta/QEMU split)
+
+    @Test("arm64 does not require QEMU")
+    func perPlatformArm64NoQEMU() throws {
+        #expect(!platformRequiresQEMU(try Platform(from: "linux/arm64")))
+    }
+
+    @Test("aarch64 alias does not require QEMU, same as arm64")
+    func perPlatformAarch64AliasNoQEMU() throws {
+        #expect(!platformRequiresQEMU(try Platform(from: "linux/aarch64")))
+    }
+
+    @Test("amd64 does not require QEMU")
+    func perPlatformAmd64NoQEMU() throws {
+        #expect(!platformRequiresQEMU(try Platform(from: "linux/amd64")))
+    }
+
+    @Test("x86_64 alias does not require QEMU")
+    func perPlatformX86_64AliasNoQEMU() throws {
+        #expect(!platformRequiresQEMU(try Platform(from: "linux/x86_64")))
+    }
+
+    @Test("s390x requires QEMU")
+    func perPlatformS390xRequiresQEMU() throws {
+        #expect(platformRequiresQEMU(try Platform(from: "linux/s390x")))
+    }
+
+    @Test("A request mixing arm64 and amd64 partitions entirely into the Rosetta-eligible group")
+    func mixedRosettaOnlyPlatformsDoNotSplit() throws {
+        let platforms = [try Platform(from: "linux/arm64"), try Platform(from: "linux/amd64")]
+        let rosetta = platforms.filter { !platformRequiresQEMU($0) }
+        let qemu = platforms.filter { platformRequiresQEMU($0) }
+        #expect(rosetta.count == 2)
+        #expect(qemu.isEmpty)
+    }
+
+    @Test("A request mixing arm64 and s390x partitions into both groups, triggering a split build")
+    func mixedRosettaAndQEMUPlatformsSplit() throws {
+        let platforms = [try Platform(from: "linux/arm64"), try Platform(from: "linux/s390x")]
+        let rosetta = platforms.filter { !platformRequiresQEMU($0) }
+        let qemu = platforms.filter { platformRequiresQEMU($0) }
+        #expect(rosetta.map(\.architecture) == ["arm64"])
+        #expect(qemu.map(\.architecture) == ["s390x"])
+    }
+}

--- a/Tests/socktainerTests/Utilities/RegexRouterTests.swift
+++ b/Tests/socktainerTests/Utilities/RegexRouterTests.swift
@@ -227,4 +227,44 @@ import VaporTesting
         }
     }
 
+    /// A greedy `{name:.*}` route (like `manifest create`'s `POST /manifests/{name}`)
+    /// registered BEFORE a more specific sibling sharing the same method and a longer path
+    /// (like `manifest push`'s `POST /manifests/{name}/registry/{destination}`) used to win
+    /// unconditionally — first-match-in-registration-order — silently swallowing the whole
+    /// remainder of the specific route's path (including "/registry/...") as part of "name".
+    /// Routes are now matched in descending specificity order regardless of registration
+    /// order, so the more specific route wins even when registered second.
+    @Test
+    func moreSpecificRouteWinsOverGreedySiblingRegisteredFirst() async throws {
+        try await withRegexRouter { app in
+            // Register the greedy, less-specific route FIRST.
+            try app.registerVersionedRoute(.POST, pattern: "/manifests/{name:.*}") { req in
+                let name = req.parameters.get("name") ?? ""
+                return ["matched": "generic", "name": name]
+            }
+            // Register the more specific sibling SECOND.
+            try app.registerVersionedRoute(.POST, pattern: "/manifests/{name:.*}/registry/{destination:.*}") { req in
+                let name = req.parameters.get("name") ?? ""
+                let destination = req.parameters.get("destination") ?? ""
+                return ["matched": "specific", "name": name, "destination": destination]
+            }
+
+            try await app.testing().test(.POST, "/manifests/mylist/registry/192.168.1.1:5000/repo:tag") { res async throws in
+                #expect(res.status == .ok)
+                let response = try res.content.decode([String: String].self)
+                #expect(response["matched"] == "specific")
+                #expect(response["name"] == "mylist")
+                #expect(response["destination"] == "192.168.1.1:5000/repo:tag")
+            }
+
+            // The generic route should still handle requests that don't match the specific one.
+            try await app.testing().test(.POST, "/manifests/mylist") { res async throws in
+                #expect(res.status == .ok)
+                let response = try res.content.decode([String: String].self)
+                #expect(response["matched"] == "generic")
+                #expect(response["name"] == "mylist")
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds a `/libpod/*` API surface so real podman CLI clients (not just Docker-compat clients) work against socktainer end-to-end — containers, images, networks, volumes, manifest lists, and `build --platform ... --manifest` — plus the multi-platform build and archive-extraction hardening this required underneath. Part of the ongoing libpod API coverage tracked in #201 (a subset, not full parity — see `PODMAN_API_AUDIT.md` and the README for what's covered).

## Related Issue

Progress on #201 (tracking issue for libpod API coverage — not closed by this PR, since coverage remains a subset)

## Changes

- **Archive extraction hardening**: `ArchiveUtility.extract` reimplements extraction over the vendored framework's public streaming iterator (needed to avoid an EACCES bug on read-only entries), so it owns every containment guarantee itself — final-component and intermediate-ancestor symlink checks, a chained-escape check on a symlink's own target, absolute paths/targets re-rooted for containment but written to disk as portable relative links, and correct handling of a path reused across entries ("last entry wins").
- **Multi-platform build with automatic Rosetta/QEMU selection**: comma-separated `--platform` values route to a Rosetta or QEMU builder container as needed; a request mixing both splits into two concurrent builds merged back into one index under the requested tag. Builder VM lifecycle (`ClientBuilderService`) provisions on demand, tolerates a concurrent caller winning the race to create one, and isolates a transient failure on one backend from hiding a successful result on the other.
- **Libpod routes**: native `/libpod/*` endpoints for containers, images, networks, volumes, exec, events, system info/version/df, alongside the existing Docker-compat surface (`PODMAN_API_AUDIT.md` tracks per-endpoint coverage and known gaps). Path parameters and response shapes follow what real podman clients actually send/expect, not a copy-paste of the Docker-compat equivalent.
- **Manifest lists**: `podman manifest create/add/remove/inspect/exists/rm/push`, modeled as an ordinary tagged reference over an OCI index blob (no separate bookkeeping layer) via `ClientManifestService`. `build --platform a,b --manifest <name>` adds a multi-platform build's output to a named list, creating it if needed. Real podman's actual `--amend`/duplicate-name/dedup semantics are followed precisely.
- **Push fixes**: `podman push <image> <destination>` now honors `destination` (previously ignored) and resolves bare-tagged local images correctly; push progress frames use the `stream`/`error`/`Id` keys real podman's client decodes, not Docker-compat's `status`.
- **Routing**: requests are matched by descending template specificity so a more specific route (e.g. `manifest push`) isn't swallowed by a more general sibling's greedy wildcard (e.g. `manifest create`) registered earlier.
- **CI**: `integration-test` now runs real `podman` CLI checks (version, image, ps, manifest CRUD, push, manifest push against ttl.sh) alongside the existing Docker-compat checks. `podman build`/multi-arch build are gated off — GitHub-hosted macOS runners can't boot the BuildKit builder VM (`Error Domain=VZErrorDomain Code=2`), confirmed by a real run.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (977 tests)
- [x] Unit tests added/updated for manifest routes, retag/push error mapping, archive extraction edge cases (symlink chaining, traversal, path reuse), route specificity, platform parsing, and libpod route parameter binding
- [x] Manual testing: real `podman` CLI (version, image ops, manifest create/add/inspect/exists, push, manifest push, multi-platform build split across Rosetta/QEMU) verified live against a running socktainer instance and a real registry (ttl.sh)

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)