### PR TITLE
fix(archive): match Docker's encoding of the path-stat header

### DIFF
--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -71,13 +71,44 @@ enum ClientArchiveError: Error, LocalizedError {
     }
 }
 
+/// POSIX `st_mode` in Go's `os.FileMode` encoding, which is what the Docker API
+/// carries: permission bits are shared, but Go keeps the file type in the high
+/// bits rather than in `S_IFMT`.
+func goFileMode(posixMode: UInt32) -> UInt32 {
+    var mode = posixMode & 0o777
+    switch posixMode & 0o170000 {
+    case 0o040000: mode |= 1 << 31  // ModeDir
+    case 0o120000: mode |= 1 << 27  // ModeSymlink
+    case 0o020000: mode |= (1 << 26) | (1 << 21)  // ModeDevice | ModeCharDevice
+    case 0o060000: mode |= 1 << 26  // ModeDevice
+    case 0o010000: mode |= 1 << 25  // ModeNamedPipe
+    case 0o140000: mode |= 1 << 24  // ModeSocket
+    default: break  // regular files carry no type bit
+    }
+    if posixMode & 0o4000 != 0 { mode |= 1 << 23 }  // ModeSetuid
+    if posixMode & 0o2000 != 0 { mode |= 1 << 22 }  // ModeSetgid
+    if posixMode & 0o1000 != 0 { mode |= 1 << 20 }  // ModeSticky
+    return mode
+}
+
+/// Go's RFC3339Nano in the daemon's own timezone, as Docker reports it. An ext4
+/// inode holds whole seconds and Go omits a zero fraction, so only the offset
+/// differs from RFC3339.
+func dockerPathStatTimestamp(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone.current
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+    return formatter.string(from: date)
+}
+
 /// File stat information for the X-Docker-Container-Path-Stat header
 struct PathStat: Codable {
     let name: String
     let size: Int64
     let mode: UInt32
     let mtime: String
-    let linkTarget: String?
+    let linkTarget: String
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -147,9 +178,9 @@ struct ClientArchiveService: ClientArchiveProtocol {
         return PathStat(
             name: (normalizedPath as NSString).lastPathComponent,
             size: inode.size,
-            mode: UInt32(inode.mode),
-            mtime: ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
-            linkTarget: inode.isSymlink ? (readSymlinkTarget(reader: reader, path: normalizedPath) ?? "") : ""
+            mode: goFileMode(posixMode: UInt32(inode.mode)),
+            mtime: dockerPathStatTimestamp(Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
+            linkTarget: (inode.isSymlink ? readSymlinkTarget(reader: reader, path: normalizedPath) : nil) ?? ""
         )
     }
 
@@ -177,9 +208,9 @@ struct ClientArchiveService: ClientArchiveProtocol {
         let pathStat = PathStat(
             name: (normalizedPath as NSString).lastPathComponent,
             size: inode.size,
-            mode: UInt32(inode.mode),
-            mtime: ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
-            linkTarget: inode.isSymlink ? (readSymlinkTarget(reader: reader, path: normalizedPath) ?? "") : ""
+            mode: goFileMode(posixMode: UInt32(inode.mode)),
+            mtime: dockerPathStatTimestamp(Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
+            linkTarget: (inode.isSymlink ? readSymlinkTarget(reader: reader, path: normalizedPath) : nil) ?? ""
         )
 
         // Create temporary directory for tar creation

--- a/Tests/socktainerTests/Clients/ClientArchiveServicePathStatTests.swift
+++ b/Tests/socktainerTests/Clients/ClientArchiveServicePathStatTests.swift
@@ -1,0 +1,113 @@
+import ContainerizationEXT4
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+@Suite("ClientArchiveService path-stat header")
+struct ClientArchiveServicePathStatTests {
+
+    @Test("a directory carries the ModeDir bit clients test with IsDir()")
+    func directoryCarriesModeDir() async throws {
+        let fixture = PathStatFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/etc/hostname": "web\n"])
+
+        let (_, stat) = try await fixture.service.getArchive(containerId: "web", path: "/etc")
+
+        #expect(stat.mode & (1 << 31) != 0)
+        #expect(stat.mode & 0o777 == 0o755)
+    }
+
+    @Test("a regular file carries permission bits and no type bit")
+    func regularFileCarriesNoTypeBit() async throws {
+        let fixture = PathStatFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/hello.txt": "hi\n"])
+
+        let (_, stat) = try await fixture.service.getArchive(containerId: "web", path: "/hello.txt")
+
+        #expect(stat.mode == 0o644)
+    }
+
+    @Test("every POSIX file type maps to the bit Go uses for it")
+    func translatesEveryFileType() {
+        #expect(goFileMode(posixMode: 0o040755) == (1 << 31) | 0o755)
+        #expect(goFileMode(posixMode: 0o120777) == (1 << 27) | 0o777)
+        #expect(goFileMode(posixMode: 0o020600) == (1 << 26) | (1 << 21) | 0o600)
+        #expect(goFileMode(posixMode: 0o060600) == (1 << 26) | 0o600)
+        #expect(goFileMode(posixMode: 0o010600) == (1 << 25) | 0o600)
+        #expect(goFileMode(posixMode: 0o140777) == (1 << 24) | 0o777)
+        #expect(goFileMode(posixMode: 0o100644) == 0o644)
+    }
+
+    @Test("setuid, setgid and sticky survive the translation")
+    func translatesPermissionModifiers() {
+        #expect(goFileMode(posixMode: 0o104755) == (1 << 23) | 0o755)
+        #expect(goFileMode(posixMode: 0o102755) == (1 << 22) | 0o755)
+        #expect(goFileMode(posixMode: 0o041777) == (1 << 31) | (1 << 20) | 0o777)
+    }
+
+    @Test("a non-symlink reports an empty link target rather than null")
+    func nonSymlinkReportsEmptyLinkTarget() async throws {
+        let fixture = PathStatFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/hello.txt": "hi\n"])
+
+        let (_, stat) = try await fixture.service.getArchive(containerId: "web", path: "/hello.txt")
+
+        #expect(stat.linkTarget == "")
+        let encoded = try #require(String(data: try JSONEncoder().encode(stat), encoding: .utf8))
+        #expect(!encoded.contains("null"))
+    }
+
+    @Test("the timestamp reports the daemon's own offset, not Z")
+    func timestampUsesLocalOffset() {
+        let moment = Date(timeIntervalSince1970: 1_747_098_109)
+        let formatted = dockerPathStatTimestamp(moment)
+
+        if TimeZone.current.secondsFromGMT(for: moment) == 0 {
+            #expect(formatted.hasSuffix("Z") || formatted.hasSuffix("+00:00"))
+        } else {
+            #expect(!formatted.hasSuffix("Z"))
+        }
+    }
+
+    @Test("a whole-second timestamp carries no fraction, as Go omits a zero one")
+    func wholeSecondsCarryNoFraction() {
+        #expect(!dockerPathStatTimestamp(Date(timeIntervalSince1970: 1_747_098_109)).contains("."))
+    }
+}
+
+private struct PathStatFixture {
+    let appSupport: URL
+    let service: ClientArchiveService
+
+    init() {
+        appSupport = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "path-stat-test-\(UUID().uuidString)")
+        service = ClientArchiveService(appSupportPath: appSupport)
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: appSupport)
+    }
+
+    func writeExt4Rootfs(containerId: String, files: [String: String]) throws {
+        let formatter = try EXT4.Formatter(FilePath(rootfs(containerId).path))
+        for (path, contents) in files {
+            let stream = InputStream(data: Data(contents.utf8))
+            stream.open()
+            try formatter.create(
+                path: FilePath(path), mode: EXT4.Inode.Mode(.S_IFREG, 0o644), buf: stream, recursion: true)
+        }
+        try formatter.close()
+    }
+
+    private func rootfs(_ containerId: String) -> URL {
+        let dir = appSupport.appendingPathComponent("containers/\(containerId)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("rootfs.ext4")
+    }
+}


### PR DESCRIPTION
## Summary

I'm trying to get a local Supabase stack running on Apple `container` through socktainer, and ran into the `mode` delta that @ninja18 listed in [this comment](https://github.com/socktainer/socktainer/pull/372#issuecomment-5327409566) on #372. This fixes the three deltas he found there.

Credit for finding these goes to @ninja18 — he measured all three against Docker 26.1.1 and wrote them up in that comment. I've only implemented them.

## Related Issue

No issue for this one — the three deltas are in that comment. He mentioned they could be folded into #372 or landed separately, so I've put them here separately to keep that PR focused on its own change. If you'd rather have them in #372, please just close this.

The `mode` one turned out not to be cosmetic — it stops `docker cp`. On #372's branch, `supabase start -x studio` gets past the archive 404 and then fails here:

```
failed to copy secret file into container:
destination "88ae2170...:/" must be a directory
```

The client does a HEAD on `/`, gets back `{"mode":16877}` (`0o40755`), and asks `IsDir()`. Go keeps the file type in the high bits rather than in `S_IFMT`, so that comes back false. Docker reports `2147484141` for the same path.

## Changes

- `mode`: converted to Go's `os.FileMode` encoding, including the other file types and setuid/setgid/sticky.
- `mtime`: formatted in the daemon's own offset instead of UTC. An ext4 inode only holds whole seconds and Go drops a zero fraction, so the offset is the only difference in practice.
- `linkTarget`: now a non-optional `String` with the default applied where the stat is built. I followed how `RESTImageInspect` and `RESTImageHistory` already do this for `Comment` / `Author` / `CreatedBy` — please tell me if there's a better place for it.

Both archive headers read the stat from the same place, so `GET` and `HEAD` are both covered.

## Rebased onto #377

#377 landed while this was open and added `statPath`, a second place that builds a
`PathStat` — HEAD now goes through it instead of building a tar. Rebasing brought that
into scope: left alone, the two paths would report `mode` and `mtime` differently, which
is the disagreement #377's own test asserts must not happen. `statPath` now uses the same
two helpers, so this PR touches one file more than it did before.

## Behaviour change

`linkTarget` now goes out as `""` instead of `null` when the path isn't a symlink. I don't think anything can be depending on `null` here, since Docker's own field is a plain string and can't encode as null, but I wanted to flag it rather than slip it in.

## Conflict with #372

Worth knowing before this is sequenced: it conflicts with #372 in `ClientArchiveService.swift`, and 4 `linkTarget: nil` lines in that PR's tests would need updating (1 in `ContainerArchiveEventTests`, 3 in `ContainerArchiveRouteTests`).

#372 needs a rebase of its own now that #377 has landed, and when it does its `statPath`
has to move to `resolveRootfsPath` or a HEAD against a never-started container starts
failing again. I've put a branch carrying that resolution on #372 for whoever picks it up.

## Testing

- [x] `make fmt` passes, no drift
- [x] `make test` passes — 896 tests, 7 of them new for these three cases
- [x] Checked by hand on `container` 1.2.2: `docker cp` into a container root no longer fails the destination check

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)

---

This is my first PR here, so apologies if I've got any of the process wrong — happy to change whatever needs changing.

