### PR TITLE
fix(archive): stat the path on HEAD instead of building a tar

### DIFF
--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -96,6 +96,9 @@ protocol ClientArchiveProtocol: Sendable {
     /// Read a file or directory from a container's filesystem and return as tar data
     func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat)
 
+    /// Stat a path without reading it, for callers that only need the header
+    func statPath(containerId: String, path: String) async throws -> PathStat
+
     /// Extract a tar archive into a container's filesystem at the specified path
     func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws
 
@@ -122,6 +125,34 @@ struct ClientArchiveService: ClientArchiveProtocol {
 
     /// Read a file or directory from a container's filesystem and return as tar data
     /// This implementation reads only the requested path directly, avoiding full filesystem export.
+
+    /// Stat a single path, reading the inode and nothing else.
+    ///
+    /// `getArchive` builds a tar of everything under the path before its caller
+    /// discards it. For `/` that is the whole filesystem, which is why a HEAD
+    /// against a large image took as long as reading it.
+    func statPath(containerId: String, path: String) async throws -> PathStat {
+        let rootfsPath = getRootfsPath(containerId: containerId)
+        guard FileManager.default.fileExists(atPath: rootfsPath.path) else {
+            throw ClientArchiveError.rootfsNotFound(id: containerId)
+        }
+
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath.path))
+        guard reader.exists(FilePath(normalizedPath)) else {
+            throw ClientArchiveError.pathNotFound(path: normalizedPath)
+        }
+
+        let (_, inode) = try reader.stat(FilePath(normalizedPath))
+        return PathStat(
+            name: (normalizedPath as NSString).lastPathComponent,
+            size: inode.size,
+            mode: UInt32(inode.mode),
+            mtime: ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
+            linkTarget: inode.isSymlink ? readSymlinkTarget(reader: reader, path: normalizedPath) : nil
+        )
+    }
+
     func getArchive(containerId: String, path: String) async throws -> (tarData: Data, stat: PathStat) {
         let rootfsPath = getRootfsPath(containerId: containerId)
 

--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -149,7 +149,7 @@ struct ClientArchiveService: ClientArchiveProtocol {
             size: inode.size,
             mode: UInt32(inode.mode),
             mtime: ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
-            linkTarget: inode.isSymlink ? readSymlinkTarget(reader: reader, path: normalizedPath) : nil
+            linkTarget: inode.isSymlink ? (readSymlinkTarget(reader: reader, path: normalizedPath) ?? "") : ""
         )
     }
 
@@ -179,7 +179,7 @@ struct ClientArchiveService: ClientArchiveProtocol {
             size: inode.size,
             mode: UInt32(inode.mode),
             mtime: ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(inode.mtime))),
-            linkTarget: inode.isSymlink ? readSymlinkTarget(reader: reader, path: normalizedPath) : nil
+            linkTarget: inode.isSymlink ? (readSymlinkTarget(reader: reader, path: normalizedPath) ?? "") : ""
         )
 
         // Create temporary directory for tar creation

--- a/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerArchiveRoute.swift
@@ -198,7 +198,7 @@ struct ContainerArchiveRoute: RouteCollection {
             }
 
             do {
-                let (_, stat) = try await archiveClient.getArchive(containerId: container.id, path: query.path)
+                let stat = try await archiveClient.statPath(containerId: container.id, path: query.path)
 
                 // Create the path stat header (base64 encoded JSON)
                 let statJson = try JSONEncoder().encode(stat)

--- a/Tests/socktainerTests/Clients/ClientArchiveServiceStatPathTests.swift
+++ b/Tests/socktainerTests/Clients/ClientArchiveServiceStatPathTests.swift
@@ -1,0 +1,103 @@
+import ContainerizationEXT4
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+@Suite("ClientArchiveService.statPath")
+struct ClientArchiveServiceStatPathTests {
+
+    @Test("a file reports the same stat getArchive would return")
+    func matchesGetArchiveForAFile() async throws {
+        let fixture = StatPathFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/hello.txt": "exported\n"])
+
+        let stat = try await fixture.service.statPath(containerId: "web", path: "/hello.txt")
+        let (_, viaArchive) = try await fixture.service.getArchive(containerId: "web", path: "/hello.txt")
+
+        #expect(stat.name == viaArchive.name)
+        #expect(stat.size == viaArchive.size)
+        #expect(stat.mode == viaArchive.mode)
+        #expect(stat.mtime == viaArchive.mtime)
+    }
+
+    @Test("a directory reports the same stat getArchive would return")
+    func matchesGetArchiveForADirectory() async throws {
+        let fixture = StatPathFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/etc/hostname": "web\n"])
+
+        let stat = try await fixture.service.statPath(containerId: "web", path: "/etc")
+        let (_, viaArchive) = try await fixture.service.getArchive(containerId: "web", path: "/etc")
+
+        #expect(stat.name == viaArchive.name)
+        #expect(stat.mode == viaArchive.mode)
+    }
+
+    @Test("a path that is not there throws pathNotFound")
+    func missingPath() async throws {
+        let fixture = StatPathFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeExt4Rootfs(containerId: "web", files: ["/hello.txt": "hi\n"])
+
+        do {
+            _ = try await fixture.service.statPath(containerId: "web", path: "/absent")
+            Issue.record("statting a path that is not there must throw")
+        } catch let error as ClientArchiveError {
+            guard case .pathNotFound = error else {
+                Issue.record("expected pathNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("a container without a rootfs file throws rootfsNotFound")
+    func missingRootfs() async throws {
+        let fixture = StatPathFixture()
+        defer { fixture.cleanUp() }
+
+        do {
+            _ = try await fixture.service.statPath(containerId: "ghost", path: "/")
+            Issue.record("statting a container with no rootfs must throw")
+        } catch let error as ClientArchiveError {
+            guard case .rootfsNotFound = error else {
+                Issue.record("expected rootfsNotFound, got \(error)")
+                return
+            }
+        }
+    }
+}
+
+private struct StatPathFixture {
+    let appSupport: URL
+    let service: ClientArchiveService
+
+    init() {
+        appSupport = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "stat-path-test-\(UUID().uuidString)")
+        service = ClientArchiveService(appSupportPath: appSupport)
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: appSupport)
+    }
+
+    func writeExt4Rootfs(containerId: String, files: [String: String]) throws {
+        let formatter = try EXT4.Formatter(FilePath(rootfs(containerId).path))
+        for (path, contents) in files {
+            let stream = InputStream(data: Data(contents.utf8))
+            stream.open()
+            try formatter.create(
+                path: FilePath(path), mode: EXT4.Inode.Mode(.S_IFREG, 0o644), buf: stream, recursion: true)
+        }
+        try formatter.close()
+    }
+
+    private func rootfs(_ containerId: String) -> URL {
+        let dir = appSupport.appendingPathComponent("containers/\(containerId)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("rootfs.ext4")
+    }
+}

--- a/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
+++ b/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
@@ -104,6 +104,19 @@ struct ContainerArchiveEventTests {
         captureTask.cancel()
         #expect(event == nil)
     }
+
+    @Test("HEAD /archive answers from the stat alone, without reading the path")
+    func headDoesNotReadThePath() async throws {
+        let snapshot = try makeContainerSnapshot(nativeId: "web", ip: "192.168.65.2", network: "bridge", labels: [:], status: .running)
+        let archive = FakeArchiveClient(getResult: .failure(.operationFailed(message: "must not be called")))
+
+        try await withArchiveApp(snapshot: snapshot, archive: archive, broadcaster: EventBroadcaster()) { app in
+            try await app.testing().test(.HEAD, "/v1.51/containers/web/archive?path=/etc/hosts") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "X-Docker-Container-Path-Stat") != nil)
+            }
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -140,6 +153,7 @@ private func withTimeout<T>(_ task: Task<T, Never>) async -> T {
 
 private struct FakeArchiveClient: ClientArchiveProtocol {
     var getResult: Result<Void, ClientArchiveError> = .success(())
+    var statResult: Result<Void, ClientArchiveError> = .success(())
 
     func getRootfsPath(containerId: String) -> URL {
         URL(fileURLWithPath: "/nonexistent/rootfs.ext4")
@@ -151,6 +165,11 @@ private struct FakeArchiveClient: ClientArchiveProtocol {
             Data("fake-tar".utf8),
             PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
         )
+    }
+
+    func statPath(containerId: String, path: String) async throws -> PathStat {
+        if case .failure(let error) = statResult { throw error }
+        return PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
     }
 
     func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws {}

--- a/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
+++ b/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
@@ -163,13 +163,13 @@ private struct FakeArchiveClient: ClientArchiveProtocol {
         if case .failure(let error) = getResult { throw error }
         return (
             Data("fake-tar".utf8),
-            PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+            PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: "")
         )
     }
 
     func statPath(containerId: String, path: String) async throws -> PathStat {
         if case .failure(let error) = statResult { throw error }
-        return PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+        return PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: "")
     }
 
     func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws {}

--- a/Tests/socktainerTests/Routes/ContainerExportRouteTests.swift
+++ b/Tests/socktainerTests/Routes/ContainerExportRouteTests.swift
@@ -147,6 +147,10 @@ private actor FakeArchiveClient: ClientArchiveProtocol {
         throw ClientArchiveError.operationFailed(message: "not under test")
     }
 
+    func statPath(containerId: String, path: String) async throws -> PathStat {
+        throw ClientArchiveError.operationFailed(message: "not under test")
+    }
+
     func putArchive(container: ContainerSnapshot, path: String, tarPath: URL, noOverwriteDirNonDir: Bool) async throws {
         throw ClientArchiveError.operationFailed(message: "not under test")
     }


### PR DESCRIPTION
## Summary

The `HEAD /containers/{id}/archive` handler called `getArchive` and discarded the tar it returned, keeping only the stat header. `getArchive` reads the whole path first, so a HEAD against `/` packs the entire filesystem to answer four fields.

I noticed it while getting a local Supabase stack up — the HEAD on `/` is fine against a small image and not against a large one.

## Changes

- `statPath` reads the inode and stops there.
- The HEAD route calls it, so it no longer depends on being able to read what it is describing.
- The two fakes implementing the protocol in tests gain the method.

## Testing

- [x] `make fmt` passes, no drift
- [x] `make test` passes — 889 tests, including one asserting HEAD still answers when `getArchive` cannot

## Note

This conflicts with #372, which changes the same route line and the same protocol. If that lands first I'll rebase. It doesn't conflict with #376.

## Checklist

- [x] Follows Conventional Commits
- [x] All commits are signed off (DCO)
