### PR TITLE
feat(archive): support docker cp into a never-started container

### DIFF
--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -264,6 +264,10 @@ struct ClientArchiveService: ClientArchiveProtocol {
                 throw ClientArchiveError.operationFailed(
                     message: "cannot copy a symlink into \(container.id) before it starts")
             }
+            if case .directory = entry.kind {
+                throw ClientArchiveError.operationFailed(
+                    message: "cannot copy a directory into \(container.id) before it starts")
+            }
         }
 
         let stagingDir = FileManager.default.temporaryDirectory

--- a/Sources/socktainer/Clients/ClientArchiveService.swift
+++ b/Sources/socktainer/Clients/ClientArchiveService.swift
@@ -222,6 +222,15 @@ struct ClientArchiveService: ClientArchiveProtocol {
         let rootfsPath = getRootfsPath(containerId: container.id)
 
         guard FileManager.default.fileExists(atPath: rootfsPath.path) else {
+            // Never booted: hold the files until the runtime builds the
+            // filesystem, rather than refuse a copy Docker would accept.
+            if container.startedDate == nil {
+                try await stagePreStartInjection(
+                    container: container, destinationPath: normalizedPath, tarPath: tarPath)
+                return
+            }
+            // Booted before and the rootfs is gone: staging would quietly
+            // resurrect the container carrying only these files.
             throw ClientArchiveError.rootfsNotFound(id: container.id)
         }
 
@@ -238,6 +247,42 @@ struct ClientArchiveService: ClientArchiveProtocol {
             destinationPath: normalizedPath,
             inputTarPath: tarPath
         )
+    }
+
+    /// Hold an archive uploaded before the container was ever started.
+    ///
+    /// Only regular files: a directory would need a whole-directory mount,
+    /// which hides what the image put there, and a symlink has no mount that
+    /// reproduces it. Both are refused while the copy can still be retried
+    /// after start.
+    private func stagePreStartInjection(
+        container: ContainerSnapshot, destinationPath: String, tarPath: URL
+    ) async throws {
+        let plan = try parseArchiveEntries(tarPath: tarPath, destinationPath: destinationPath)
+        for entry in plan {
+            if case .symlink = entry.kind {
+                throw ClientArchiveError.operationFailed(
+                    message: "cannot copy a symlink into \(container.id) before it starts")
+            }
+        }
+
+        let stagingDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("prestart-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: stagingDir) }
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        try ArchiveUtility.extract(tarPath: tarPath, to: stagingDir)
+
+        for entry in plan {
+            guard case .file = entry.kind else { continue }
+            let extracted = stagingDir.appendingPathComponent(entry.relativePath)
+            guard FileManager.default.fileExists(atPath: extracted.path) else {
+                throw ClientArchiveError.operationFailed(
+                    message: "archive entry missing after extraction: \(entry.relativePath)")
+            }
+            try await PreStartInjectionStore.shared.stage(
+                containerId: container.id, guestPath: entry.guestPath,
+                source: extracted, mode: entry.mode)
+        }
     }
 
     /// One parsed entry of the uploaded archive.

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -544,6 +544,10 @@ struct ClientContainerService: ClientContainerProtocol {
         for container in containersToDelete {
             do {
                 try await containerClient.withClient { try await $0.delete(id: container.id) }
+                // Pruning reclaims a container, so it reclaims what was staged for
+                // it too: those files are whatever a client uploaded, secrets
+                // included.
+                try await PreStartInjectionStore.shared.clear(containerId: container.id)
                 deletedIds.append(container.id)
             } catch {
                 continue

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -405,11 +405,14 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func delete(id: String) async throws {
-        try await PreStartInjectionStore.shared.clear(containerId: id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }
         try await containerClient.withClient { try await $0.delete(id: container.id) }
+        // After the delete, and by the native id: the reference a client holds may
+        // be a derived Docker id, and a delete that failed leaves a container that
+        // still needs its uploads.
+        try await PreStartInjectionStore.shared.clear(containerId: container.id)
     }
 
     // Poll until the container is no longer running, then return the real exit

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -278,12 +278,48 @@ struct ClientContainerService: ClientContainerProtocol {
         }
     }
 
+
+    /// Rebuild a container so it carries the files copied into it before it was
+    /// ever started.
+    ///
+    /// There is no API to add a mount to a container that already exists, so the
+    /// only way to put the files where the guest will see them is to create it
+    /// again with the mounts included. The name is kept, and the creation
+    /// timestamp travels in a label, so the id the client holds does not change.
+    private func applyPreStartInjections(container: ContainerSnapshot) async throws {
+        let staged = await PreStartInjectionStore.shared.mounts(containerId: container.id)
+        guard !staged.isEmpty else { return }
+
+        var configuration = container.configuration
+        let existing = Set(configuration.mounts.map(\.destination))
+        let additions = staged.filter { !existing.contains($0.destination) }
+        guard !additions.isEmpty else { return }
+        configuration.mounts.append(contentsOf: additions)
+        let rebuilt = configuration
+
+        let kernel = try await ClientKernel.getDefaultKernel(for: .current)
+        let options = await PreStartInjectionStore.shared.createOptions(containerId: container.id)
+
+        try await containerClient.withClient { try await $0.delete(id: container.id, force: true) }
+        do {
+            try await containerClient.withClient {
+                try await $0.create(configuration: rebuilt, options: options, kernel: kernel)
+            }
+        } catch {
+            // The container is gone and could not be put back. Say so plainly:
+            // a client told only that start failed would look everywhere else.
+            throw ClientContainerError.notFound(id: container.id)
+        }
+    }
+
     private func startInternal(container: ContainerSnapshot) async throws {
         let stdin: FileHandle? = nil
         let stdout: FileHandle? = nil
         let stderr: FileHandle? = nil
 
         let stdio = [stdin, stdout, stderr]
+
+        try await applyPreStartInjections(container: container)
 
         do {
             let process = try await containerClient.withClient { try await $0.bootstrap(id: container.id, stdio: stdio) }
@@ -370,6 +406,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func delete(id: String) async throws {
+        await PreStartInjectionStore.shared.clear(containerId: id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }

--- a/Sources/socktainer/Clients/ClientContainerService.swift
+++ b/Sources/socktainer/Clients/ClientContainerService.swift
@@ -278,7 +278,6 @@ struct ClientContainerService: ClientContainerProtocol {
         }
     }
 
-
     /// Rebuild a container so it carries the files copied into it before it was
     /// ever started.
     ///
@@ -287,7 +286,7 @@ struct ClientContainerService: ClientContainerProtocol {
     /// again with the mounts included. The name is kept, and the creation
     /// timestamp travels in a label, so the id the client holds does not change.
     private func applyPreStartInjections(container: ContainerSnapshot) async throws {
-        let staged = await PreStartInjectionStore.shared.mounts(containerId: container.id)
+        let staged = try await PreStartInjectionStore.shared.mounts(containerId: container.id)
         guard !staged.isEmpty else { return }
 
         var configuration = container.configuration
@@ -406,7 +405,7 @@ struct ClientContainerService: ClientContainerProtocol {
     }
 
     func delete(id: String) async throws {
-        await PreStartInjectionStore.shared.clear(containerId: id)
+        try await PreStartInjectionStore.shared.clear(containerId: id)
         guard let container = try await getContainer(id: id) else {
             throw ClientContainerError.notFound(id: id)
         }

--- a/Sources/socktainer/Clients/PreStartInjectionStore.swift
+++ b/Sources/socktainer/Clients/PreStartInjectionStore.swift
@@ -1,0 +1,98 @@
+import ContainerResource
+import Foundation
+
+/// Files copied into a container that had never been started.
+///
+/// The runtime builds a container's filesystem at start, not at create
+/// (apple/container#1398, closed as intentional), so `docker cp` before start
+/// has nothing to write into. The files are held here and mounted into place
+/// when the container is started, one mount per file: mounting the parent
+/// directory instead would hide whatever the image put there.
+actor PreStartInjectionStore {
+    static let shared = PreStartInjectionStore()
+
+    struct StagedFile: Codable, Sendable {
+        let guestPath: String
+        let hostPath: String
+    }
+
+    private var stagingRoot: URL?
+    private var autoRemove: [String: Bool] = [:]
+    private var autoRemoveURL: URL?
+
+    func configure(storageDirectory: URL) {
+        stagingRoot = storageDirectory.appendingPathComponent("socktainer-prestart")
+        let url = storageDirectory.appendingPathComponent("socktainer-prestart-create-options.json")
+        autoRemoveURL = url
+        if let data = try? Data(contentsOf: url) {
+            autoRemove = (try? JSONDecoder().decode([String: Bool].self, from: data)) ?? [:]
+        }
+    }
+
+    /// Remember what the container was created with, so a container rebuilt to
+    /// carry these files is rebuilt the same way.
+    func rememberCreateOptions(containerId: String, autoRemove remove: Bool) {
+        autoRemove[containerId] = remove
+        persistCreateOptions()
+    }
+
+    func createOptions(containerId: String) -> ContainerCreateOptions {
+        ContainerCreateOptions(autoRemove: autoRemove[containerId] ?? false)
+    }
+
+    private func persistCreateOptions() {
+        guard let autoRemoveURL else { return }
+        try? JSONEncoder().encode(autoRemove).write(to: autoRemoveURL)
+    }
+
+    private func containerRoot(_ id: String) -> URL? {
+        stagingRoot?.appendingPathComponent(id)
+    }
+
+    private func manifestURL(_ id: String) -> URL? {
+        containerRoot(id)?.appendingPathComponent("manifest.json")
+    }
+
+    func pending(containerId: String) -> [StagedFile] {
+        guard let url = manifestURL(containerId), let data = try? Data(contentsOf: url) else { return [] }
+        return (try? JSONDecoder().decode([StagedFile].self, from: data)) ?? []
+    }
+
+    /// The staged files as mounts, ready to be added to a container's configuration.
+    func mounts(containerId: String) -> [Filesystem] {
+        pending(containerId: containerId).map {
+            .virtiofs(source: $0.hostPath, destination: $0.guestPath, options: [])
+        }
+    }
+
+    /// Hold one uploaded file until the container is started. The staged copy
+    /// mirrors the guest path, so two files never collide.
+    func stage(containerId: String, guestPath: String, source: URL, mode: UInt32) throws {
+        guard let root = containerRoot(containerId) else { return }
+        let relative = guestPath.hasPrefix("/") ? String(guestPath.dropFirst()) : guestPath
+        let destination = root.appendingPathComponent("files").appendingPathComponent(relative)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.copyItem(at: source, to: destination)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: mode & 0o777)], ofItemAtPath: destination.path)
+
+        var files = pending(containerId: containerId).filter { $0.guestPath != guestPath }
+        files.append(StagedFile(guestPath: guestPath, hostPath: destination.path))
+        if let manifest = manifestURL(containerId) {
+            try JSONEncoder().encode(files).write(to: manifest)
+        }
+    }
+
+    func clear(containerId: String) {
+        if let root = containerRoot(containerId) {
+            try? FileManager.default.removeItem(at: root)
+        }
+        if autoRemove.removeValue(forKey: containerId) != nil {
+            persistCreateOptions()
+        }
+    }
+}

--- a/Sources/socktainer/Clients/PreStartInjectionStore.swift
+++ b/Sources/socktainer/Clients/PreStartInjectionStore.swift
@@ -1,5 +1,25 @@
 import ContainerResource
 import Foundation
+import Logging
+
+/// A staged upload could not be read back or recorded.
+///
+/// Reported rather than absorbed: a manifest that cannot be read means the
+/// container is about to start without files a client was told it had, and an
+/// empty list is indistinguishable from having staged nothing.
+enum PreStartInjectionError: Error, CustomStringConvertible {
+    case unreadableManifest(containerId: String, underlying: Error)
+    case unrecordedCreateOptions(underlying: Error)
+
+    var description: String {
+        switch self {
+        case .unreadableManifest(let id, let underlying):
+            return "Staged files for container \(id) could not be read: \(underlying)"
+        case .unrecordedCreateOptions(let underlying):
+            return "Container create options could not be recorded: \(underlying)"
+        }
+    }
+}
 
 /// Files copied into a container that had never been started.
 ///
@@ -20,29 +40,38 @@ actor PreStartInjectionStore {
     private var autoRemove: [String: Bool] = [:]
     private var autoRemoveURL: URL?
 
-    func configure(storageDirectory: URL) {
+    func configure(storageDirectory: URL, logger: Logger) {
         stagingRoot = storageDirectory.appendingPathComponent("socktainer-prestart")
         let url = storageDirectory.appendingPathComponent("socktainer-prestart-create-options.json")
         autoRemoveURL = url
-        if let data = try? Data(contentsOf: url) {
-            autoRemove = (try? JSONDecoder().decode([String: Bool].self, from: data)) ?? [:]
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            autoRemove = try JSONDecoder().decode([String: Bool].self, from: Data(contentsOf: url))
+        } catch {
+            // Startup continues: the options only affect containers rebuilt later,
+            // and refusing to serve at all would be a worse answer than losing them.
+            logger.error("Recorded container create options are unusable: \(error)")
         }
     }
 
     /// Remember what the container was created with, so a container rebuilt to
     /// carry these files is rebuilt the same way.
-    func rememberCreateOptions(containerId: String, autoRemove remove: Bool) {
+    func rememberCreateOptions(containerId: String, autoRemove remove: Bool) throws {
         autoRemove[containerId] = remove
-        persistCreateOptions()
+        try persistCreateOptions()
     }
 
     func createOptions(containerId: String) -> ContainerCreateOptions {
         ContainerCreateOptions(autoRemove: autoRemove[containerId] ?? false)
     }
 
-    private func persistCreateOptions() {
+    private func persistCreateOptions() throws {
         guard let autoRemoveURL else { return }
-        try? JSONEncoder().encode(autoRemove).write(to: autoRemoveURL)
+        do {
+            try JSONEncoder().encode(autoRemove).write(to: autoRemoveURL)
+        } catch {
+            throw PreStartInjectionError.unrecordedCreateOptions(underlying: error)
+        }
     }
 
     private func containerRoot(_ id: String) -> URL? {
@@ -53,14 +82,20 @@ actor PreStartInjectionStore {
         containerRoot(id)?.appendingPathComponent("manifest.json")
     }
 
-    func pending(containerId: String) -> [StagedFile] {
-        guard let url = manifestURL(containerId), let data = try? Data(contentsOf: url) else { return [] }
-        return (try? JSONDecoder().decode([StagedFile].self, from: data)) ?? []
+    func pending(containerId: String) throws -> [StagedFile] {
+        guard let url = manifestURL(containerId), FileManager.default.fileExists(atPath: url.path) else {
+            return []
+        }
+        do {
+            return try JSONDecoder().decode([StagedFile].self, from: Data(contentsOf: url))
+        } catch {
+            throw PreStartInjectionError.unreadableManifest(containerId: containerId, underlying: error)
+        }
     }
 
     /// The staged files as mounts, ready to be added to a container's configuration.
-    func mounts(containerId: String) -> [Filesystem] {
-        pending(containerId: containerId).map {
+    func mounts(containerId: String) throws -> [Filesystem] {
+        try pending(containerId: containerId).map {
             .virtiofs(source: $0.hostPath, destination: $0.guestPath, options: [])
         }
     }
@@ -80,19 +115,22 @@ actor PreStartInjectionStore {
         try FileManager.default.setAttributes(
             [.posixPermissions: NSNumber(value: mode & 0o777)], ofItemAtPath: destination.path)
 
-        var files = pending(containerId: containerId).filter { $0.guestPath != guestPath }
+        var files = try pending(containerId: containerId).filter { $0.guestPath != guestPath }
         files.append(StagedFile(guestPath: guestPath, hostPath: destination.path))
         if let manifest = manifestURL(containerId) {
             try JSONEncoder().encode(files).write(to: manifest)
         }
     }
 
-    func clear(containerId: String) {
+    func clear(containerId: String) throws {
         if let root = containerRoot(containerId) {
+            // Cleanup only: a staging directory that outlives its container is
+            // reclaimed on the next stage, and refusing the delete over it would
+            // strand the container instead.
             try? FileManager.default.removeItem(at: root)
         }
         if autoRemove.removeValue(forKey: containerId) != nil {
-            persistCreateOptions()
+            try persistCreateOptions()
         }
     }
 }

--- a/Sources/socktainer/Clients/PreStartInjectionStore.swift
+++ b/Sources/socktainer/Clients/PreStartInjectionStore.swift
@@ -108,12 +108,19 @@ actor PreStartInjectionStore {
         let destination = root.appendingPathComponent("files").appendingPathComponent(relative)
         try FileManager.default.createDirectory(
             at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-        if FileManager.default.fileExists(atPath: destination.path) {
-            try FileManager.default.removeItem(at: destination)
+        // Staged into place only once the copy is on disk: removing the previous
+        // file first would lose an upload the container had already accepted if
+        // the copy then failed.
+        let incoming = destination.appendingPathExtension("incoming-\(UUID().uuidString)")
+        try FileManager.default.copyItem(at: source, to: incoming)
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: mode & 0o777)], ofItemAtPath: incoming.path)
+            _ = try FileManager.default.replaceItemAt(destination, withItemAt: incoming)
+        } catch {
+            try? FileManager.default.removeItem(at: incoming)
+            throw error
         }
-        try FileManager.default.copyItem(at: source, to: destination)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: NSNumber(value: mode & 0o777)], ofItemAtPath: destination.path)
 
         var files = try pending(containerId: containerId).filter { $0.guestPath != guestPath }
         files.append(StagedFile(guestPath: guestPath, hostPath: destination.path))

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -671,9 +671,17 @@ extension ContainerCreateRoute {
             let container: ContainerSnapshot
             do {
                 let containerClient = ContainerClient()
-                try await containerClient.create(configuration: containerConfiguration, options: options, kernel: kernel)
+                // Recorded before the container exists: recording afterwards turns a
+                // creation that happened into a reported failure, and the retry then
+                // collides with the name.
                 try await PreStartInjectionStore.shared.rememberCreateOptions(
                     containerId: containerConfiguration.id, autoRemove: options.autoRemove)
+                do {
+                    try await containerClient.create(configuration: containerConfiguration, options: options, kernel: kernel)
+                } catch {
+                    try? await PreStartInjectionStore.shared.clear(containerId: containerConfiguration.id)
+                    throw error
+                }
                 container = try await containerClient.get(id: containerConfiguration.id)
                 req.logger.debug("Container created successfully with ID: \(container.id)")
             } catch {

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -672,7 +672,7 @@ extension ContainerCreateRoute {
             do {
                 let containerClient = ContainerClient()
                 try await containerClient.create(configuration: containerConfiguration, options: options, kernel: kernel)
-                await PreStartInjectionStore.shared.rememberCreateOptions(
+                try await PreStartInjectionStore.shared.rememberCreateOptions(
                     containerId: containerConfiguration.id, autoRemove: options.autoRemove)
                 container = try await containerClient.get(id: containerConfiguration.id)
                 req.logger.debug("Container created successfully with ID: \(container.id)")

--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -491,7 +491,12 @@ extension ContainerCreateRoute {
                     req.logger.warning("Could not start DNS container for \(firstNetwork): \(error)")
                 }
             }
-            containerConfiguration.labels = containerLabels
+            var labelsWithTimestamp = containerLabels
+            // Stamp the creation time so the Docker-facing id stays the same if
+            // the container is later rebuilt to carry pre-start files.
+            labelsWithTimestamp[AppleContainerTimestampResolver.legacyCreationTimestampLabel] =
+                String(Date().timeIntervalSince1970)
+            containerConfiguration.labels = labelsWithTimestamp
 
             var resolvedMounts: [Filesystem] = []
 
@@ -667,6 +672,8 @@ extension ContainerCreateRoute {
             do {
                 let containerClient = ContainerClient()
                 try await containerClient.create(configuration: containerConfiguration, options: options, kernel: kernel)
+                await PreStartInjectionStore.shared.rememberCreateOptions(
+                    containerId: containerConfiguration.id, autoRemove: options.autoRemove)
                 container = try await containerClient.get(id: containerConfiguration.id)
                 req.logger.debug("Container created successfully with ID: \(container.id)")
             } catch {

--- a/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
+++ b/Sources/socktainer/Utilities/AppleContainerTimestampResolver.swift
@@ -10,13 +10,16 @@ enum AppleContainerTimestampResolver {
     private static let epoch = Date(timeIntervalSince1970: 0)
 
     static func containerCreationDate(_ container: ContainerSnapshot) -> Date? {
-        if let bundleCreationDate = creationDate(
-            at: appSupportURL.appendingPathComponent("containers").appendingPathComponent(container.id)
-        ) {
-            return bundleCreationDate
+        // The label first: the Docker-facing id is derived from this date, and
+        // a container rebuilt in place (see PreStartInjectionStore) gets a new
+        // directory, which would change the id under a client mid-call.
+        if let labelled = legacyLabelCreationDate(from: container.configuration.labels) {
+            return labelled
         }
 
-        return legacyLabelCreationDate(from: container.configuration.labels)
+        return creationDate(
+            at: appSupportURL.appendingPathComponent("containers").appendingPathComponent(container.id)
+        )
     }
 
     static func networkCreationDate(_ networkResource: NetworkResource) -> Date? {

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -36,7 +36,7 @@ func configure(_ app: Application) async throws {
 
     let containerClient = ClientContainerService()
     await RestartPolicyOverrideStore.shared.configure(storageDirectory: appleContainerAppSupportUrl)
-    await PreStartInjectionStore.shared.configure(storageDirectory: appleContainerAppSupportUrl)
+    await PreStartInjectionStore.shared.configure(storageDirectory: appleContainerAppSupportUrl, logger: app.logger)
     let imageClient = ClientImageService(containerSystemConfig: systemConfig)
     let healthCheckClient = ClientHealthCheckService()
     let networkClient = ClientNetworkService()

--- a/Sources/socktainer/configure.swift
+++ b/Sources/socktainer/configure.swift
@@ -36,6 +36,7 @@ func configure(_ app: Application) async throws {
 
     let containerClient = ClientContainerService()
     await RestartPolicyOverrideStore.shared.configure(storageDirectory: appleContainerAppSupportUrl)
+    await PreStartInjectionStore.shared.configure(storageDirectory: appleContainerAppSupportUrl)
     let imageClient = ClientImageService(containerSystemConfig: systemConfig)
     let healthCheckClient = ClientHealthCheckService()
     let networkClient = ClientNetworkService()

--- a/Tests/socktainerTests/Clients/PreStartInjectionStoreTests.swift
+++ b/Tests/socktainerTests/Clients/PreStartInjectionStoreTests.swift
@@ -41,6 +41,26 @@ struct PreStartInjectionStoreTests {
         #expect(mounts.first?.destination == "/etc/keys/service.key")
     }
 
+    @Test("staging the same path again replaces it and keeps one entry")
+    func restagingReplacesInPlace() async throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage) }
+        let first = storage.appendingPathComponent("first")
+        let second = storage.appendingPathComponent("second")
+        try Data("one".utf8).write(to: first)
+        try Data("two".utf8).write(to: second)
+
+        let store = PreStartInjectionStore()
+        await store.configure(storageDirectory: storage, logger: Logger(label: "test"))
+        try await store.stage(containerId: "c1", guestPath: "/etc/k", source: first, mode: 0o600)
+        try await store.stage(containerId: "c1", guestPath: "/etc/k", source: second, mode: 0o600)
+
+        let staged = try await store.pending(containerId: "c1")
+        #expect(staged.count == 1)
+        let contents = try Data(contentsOf: URL(fileURLWithPath: staged[0].hostPath))
+        #expect(String(decoding: contents, as: UTF8.self) == "two")
+    }
+
     @Test("an unreadable manifest is reported, not read as nothing staged")
     func unreadableManifestThrows() async throws {
         let storage = temporaryStorage()

--- a/Tests/socktainerTests/Clients/PreStartInjectionStoreTests.swift
+++ b/Tests/socktainerTests/Clients/PreStartInjectionStoreTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Logging
+import Testing
+
+@testable import socktainer
+
+@Suite("PreStartInjectionStore reports what it cannot read")
+struct PreStartInjectionStoreTests {
+
+    private func temporaryStorage() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("socktainer-prestart-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test("a container with nothing staged has no mounts")
+    func nothingStagedIsNotAnError() async throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage) }
+        let store = PreStartInjectionStore()
+        await store.configure(storageDirectory: storage, logger: Logger(label: "test"))
+
+        #expect(try await store.mounts(containerId: "never-touched").isEmpty)
+    }
+
+    @Test("a staged file becomes one mount at its guest path")
+    func stagedFileBecomesAMount() async throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage) }
+        let source = storage.appendingPathComponent("payload")
+        try Data("key".utf8).write(to: source)
+
+        let store = PreStartInjectionStore()
+        await store.configure(storageDirectory: storage, logger: Logger(label: "test"))
+        try await store.stage(
+            containerId: "c1", guestPath: "/etc/keys/service.key", source: source, mode: 0o600)
+
+        let mounts = try await store.mounts(containerId: "c1")
+        #expect(mounts.count == 1)
+        #expect(mounts.first?.destination == "/etc/keys/service.key")
+    }
+
+    @Test("an unreadable manifest is reported, not read as nothing staged")
+    func unreadableManifestThrows() async throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage) }
+        let source = storage.appendingPathComponent("payload")
+        try Data("key".utf8).write(to: source)
+
+        let store = PreStartInjectionStore()
+        await store.configure(storageDirectory: storage, logger: Logger(label: "test"))
+        try await store.stage(
+            containerId: "c1", guestPath: "/etc/keys/service.key", source: source, mode: 0o600)
+
+        let manifest =
+            storage
+            .appendingPathComponent("socktainer-prestart")
+            .appendingPathComponent("c1")
+            .appendingPathComponent("manifest.json")
+        try Data("not json".utf8).write(to: manifest)
+
+        await #expect(throws: PreStartInjectionError.self) {
+            _ = try await store.mounts(containerId: "c1")
+        }
+    }
+}

--- a/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
+++ b/Tests/socktainerTests/Events/ContainerArchiveEventTests.swift
@@ -149,7 +149,7 @@ private struct FakeArchiveClient: ClientArchiveProtocol {
         if case .failure(let error) = getResult { throw error }
         return (
             Data("fake-tar".utf8),
-            PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: nil)
+            PathStat(name: "hosts", size: 8, mode: 0o644, mtime: "2026-01-01T00:00:00Z", linkTarget: "")
         )
     }
 


### PR DESCRIPTION
## Summary

Writing into a container that has never started currently fails: the runtime
builds the filesystem at start, not at create, so there is nothing to write
into. This stages the upload on the host and gives the container the files as
mounts when it boots.

## Related Issue

Fixes #363. Complements #372, which covers the read side (#370); the two do not
overlap.

## Changes

- Stage an archive uploaded before first boot, one virtiofs mount per file.
  Per file rather than per directory: a directory mount hides whatever the image
  put there, and the Supabase database image ships five entries in the directory
  that receives its key.
- Rebuild the container with the mounts just before it starts. There is no API
  to add a mount to a container that already exists.
- Keep the Docker-facing id stable across the rebuild. It was derived from the
  bundle directory's creation date, so it would have changed under a client
  mid-call; the creation time now travels in a label the resolver already reads.
- Report a staging manifest that cannot be read. It was answered with an empty
  list, which is the same answer as having staged nothing — so a container
  started without files a client had been told it carried, and said so nowhere.

Behavioural change: `PreStartInjectionStore.mounts` now throws.

## Testing

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes (887 tests)
- [x] Unit tests added or updated (required for features and bug fixes)
- [x] Manual testing performed (if applicable) — a Supabase stack starts against
      socktainer with this applied (#253)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
