### PR TITLE
build(deps): bump apple/container to 1.2.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2a9f8437985bebbb675b90124115451d6e2ef5fd91c3cba5f859ecb8a9520173",
+  "originHash" : "230d774d1da00a0f2f3f43409add67a2a468f5fff45788399fa55e4a03e6f999",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "6e65319fe476ffe8db8ddaf828a537ed36fe2859",
-        "version" : "1.2.0"
+        "revision" : "0190097d06df0b9065f4c2d2c7873c649d81d493",
+        "version" : "1.2.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/container.git", exact: "1.2.0"),
+        .package(url: "https://github.com/apple/container.git", exact: "1.2.2"),
         .package(url: "https://github.com/apple/containerization.git", exact: "0.40.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),

--- a/Sources/socktainer/Routes/Images/BuildRoute.swift
+++ b/Sources/socktainer/Routes/Images/BuildRoute.swift
@@ -444,6 +444,9 @@ extension BuildRoute {
             buildArgs: buildArgs,
             // TODO: Implement secrets once integration with buildkit materializes
             secrets: [:],
+            // Same as secrets: the Docker API's SSH forwarding for builds is not
+            // wired through yet, so nothing is offered to the builder.
+            ssh: "",
             contextDir: contextDir,
             dockerfile: dockerfileData,
             dockerignore: nil,


### PR DESCRIPTION
# Pull Request

## Summary

Takes apple/container to 1.2.2 and passes the argument the new build API requires, so the
bump compiles. This is #352 with that one addition; #352 can be closed in favour of it, or
this closed if you would rather apply the line there.

## Related Issue

Supersedes #352.

## Changes

- `Package.swift` / `Package.resolved`: apple/container 1.2.0 → 1.2.2 (as #352).
- `BuildRoute.swift`: pass `ssh: ""` to `BuildConfig`, which gained the parameter in 1.2.2.
  Nothing offers SSH agents to the builder yet, so it is empty for the same reason
  `secrets` already is. Without it the build fails with
  `missing argument for parameter 'ssh' in call`.

## Testing

Built and run against Apple Container 1.2.2 on macOS 26.5.2 (arm64).

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes — 884 tests in 155 suites
- [ ] Unit tests added or updated — none; a dependency bump with no behaviour change
- [x] Manual testing performed — with the bump the version check reports
      `client 1.2.2 == server 1.2.2`; without it the binary warns it needs 1.2.0 at every
      start.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))
