### PR TITLE
feat(volumes): copy the image's directory into an empty named volume

### DIFF
--- a/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
+++ b/Sources/socktainer/Routes/Containers/ContainerCreateRoute.swift
@@ -494,6 +494,9 @@ extension ContainerCreateRoute {
             containerConfiguration.labels = containerLabels
 
             var resolvedMounts: [Filesystem] = []
+            // Named volumes worth a copy-up, collected here and populated once the
+            // container exists: the image's contents are only reachable from it.
+            var copyUpCandidates: [(source: String, destination: String)] = []
 
             // Docker creates missing bind-mount source directories on the host automatically.
             // Parser.mounts() validates that the source path exists and throws if not, so we
@@ -619,9 +622,12 @@ extension ContainerCreateRoute {
                     // Strip /lost+found when PGDATA is set (any value) — that
                     // reliably signals a Postgres container, and named volumes are
                     // always mounted at their root so /lost+found is always reachable.
+                    // An empty volume is rebuilt by the copy-up below, which drops
+                    // /lost+found as part of it; reformatting here would be undone.
                     if VolumeImageCleaner.isPostgresDataVolume(mergedEnv: mergedEnv),
                         volume.format == "ext4",
-                        VolumeImageCleaner.isEnabled(labels: volume.labels)
+                        VolumeImageCleaner.isEnabled(labels: volume.labels),
+                        !VolumeCopyUp.isEmpty(volumeImagePath: volume.source)
                     {
                         VolumeImageCleaner.removeLostFound(imagePath: volume.source, logger: req.logger)
                     }
@@ -640,6 +646,9 @@ extension ContainerCreateRoute {
                         options: parsed.options,
                         sync: syncMode
                     )
+                    if volume.format == "ext4" {
+                        copyUpCandidates.append((source: volume.source, destination: parsed.destination))
+                    }
                     resolvedMounts.append(volumeMount)
                 }
             }
@@ -669,6 +678,7 @@ extension ContainerCreateRoute {
                 try await containerClient.create(configuration: containerConfiguration, options: options, kernel: kernel)
                 container = try await containerClient.get(id: containerConfiguration.id)
                 req.logger.debug("Container created successfully with ID: \(container.id)")
+                ContainerCreateRoute.populateEmptyVolumes(copyUpCandidates, for: container, logger: req.logger)
             } catch {
                 req.logger.error("Failed to create container: \(error)")
                 throw Abort(.internalServerError, reason: "Failed to create container: \(error)")
@@ -782,6 +792,37 @@ extension ContainerCreateRoute {
                 )
             }
             return result
+        }
+    }
+
+    /// Docker's copy-up: an empty named volume mounted over a path the image
+    /// populates takes that path's contents, ownership and permissions. Runs once
+    /// the container exists, which is when the image's filesystem can be read, and
+    /// always before it starts. Best-effort: a volume that cannot be prepared is
+    /// left as it was rather than failing the creation.
+    static func populateEmptyVolumes(
+        _ candidates: [(source: String, destination: String)],
+        for container: ContainerSnapshot,
+        logger: Logger
+    ) {
+        guard !candidates.isEmpty else { return }
+        let appSupport = URL(fileURLWithPath: "\(NSHomeDirectory())/Library/Application Support/com.apple.container")
+        guard
+            let rootfs = VolumeCopyUp.imageFilesystem(
+                containerId: container.id, appSupportPath: appSupport)
+        else { return }
+
+        for candidate in candidates where VolumeCopyUp.isEmpty(volumeImagePath: candidate.source) {
+            do {
+                try VolumeCopyUp.populate(
+                    volumeImagePath: candidate.source,
+                    fromRootfs: rootfs.path,
+                    sourcePath: candidate.destination,
+                    logger: logger
+                )
+            } catch {
+                logger.warning("[volume-copyup] \(candidate.destination) left empty: \(error)")
+            }
         }
     }
 

--- a/Sources/socktainer/Utilities/VolumeCopyUp.swift
+++ b/Sources/socktainer/Utilities/VolumeCopyUp.swift
@@ -1,0 +1,204 @@
+import ContainerizationArchive
+import ContainerizationEXT4
+import Foundation
+import Logging
+import SystemPackage
+
+/// Docker's copy-up: a named volume mounted over a path that exists in the image
+/// starts out holding that path's contents, ownership and permissions, so an
+/// image shipping a data directory owned by a non-root user can write to it.
+///
+/// A freshly formatted EXT4 volume is empty, root-owned and carries `/lost+found`
+/// instead, which is why an image like Postgres cannot initialise its own data
+/// directory on a new volume.
+enum VolumeCopyUp {
+    /// True when the volume holds nothing but what a freshly formatted EXT4 image
+    /// always carries. Copy-up applies to empty volumes only: Docker leaves a
+    /// volume that already has contents alone.
+    static func isEmpty(volumeImagePath: String) -> Bool {
+        guard let reader = try? EXT4.EXT4Reader(blockDevice: FilePath(volumeImagePath)),
+            let entries = try? reader.listDirectory(FilePath("/"))
+        else {
+            return false
+        }
+        return entries.allSatisfy { $0 == "." || $0 == ".." || $0 == "lost+found" }
+    }
+
+    /// Where the image's filesystem lives for a container that has been created
+    /// but never started. Apple Container writes the reference at create time;
+    /// until the container runs there is no per-container rootfs to read.
+    static func imageFilesystem(containerId: String, appSupportPath: URL) -> URL? {
+        struct RuntimeConfiguration: Decodable {
+            struct Filesystem: Decodable { let source: String }
+            let containerRootFilesystem: Filesystem
+        }
+        let configURL =
+            appSupportPath
+            .appendingPathComponent("containers")
+            .appendingPathComponent(containerId)
+            .appendingPathComponent("runtime-configuration.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let config = try? JSONDecoder().decode(RuntimeConfiguration.self, from: data),
+            !config.containerRootFilesystem.source.isEmpty
+        else {
+            return nil
+        }
+        let source = URL(fileURLWithPath: config.containerRootFilesystem.source)
+        return FileManager.default.fileExists(atPath: source.path) ? source : nil
+    }
+
+    /// Rebuilds the volume image so its root carries what the image holds at
+    /// `sourcePath`. Runs even when the image has nothing there, because the
+    /// rebuild is also what drops `/lost+found` — a Docker volume never has one,
+    /// and Postgres refuses a data directory that does.
+    static func populate(
+        volumeImagePath: String,
+        fromRootfs rootfsPath: String,
+        sourcePath: String,
+        logger: Logger
+    ) throws {
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(rootfsPath))
+        let source = FilePath(sourcePath.hasPrefix("/") ? sourcePath : "/\(sourcePath)")
+
+        var rootInode: EXT4.Inode?
+        if reader.exists(source, followSymlinks: true) {
+            let (_, inode) = try reader.stat(source)
+            if inode.isDirectory { rootInode = inode }
+        }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: volumeImagePath)
+        let currentSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let destination = URL(fileURLWithPath: volumeImagePath)
+        let staging = destination.deletingLastPathComponent()
+            .appendingPathComponent("copyup-\(UUID().uuidString).img")
+
+        var completed = false
+        defer { if !completed { try? FileManager.default.removeItem(at: staging) } }
+
+        let formatter = try EXT4.Formatter(
+            FilePath(staging.path),
+            blockSize: 4096,
+            minDiskSize: max(currentSize, 4 * 1024 * 1024)
+        )
+        if let rootInode {
+            // The mount root carries ownership of its own: a directory the image
+            // hands to a non-root user is unusable if only its children are copied.
+            try formatter.create(
+                path: FilePath("/"),
+                mode: rootInode.mode,
+                ts: timestamps(of: rootInode),
+                uid: rootInode.fullUid,
+                gid: rootInode.fullGid
+            )
+            var linkedInodes: [EXT4.InodeNumber: FilePath] = [:]
+            try copyChildren(
+                of: source, from: reader, into: formatter,
+                at: FilePath("/"), linked: &linkedInodes, logger: logger)
+        }
+        try formatter.unlink(path: FilePath("/lost+found"))
+        try formatter.close()
+
+        _ = try FileManager.default.replaceItemAt(destination, withItemAt: staging)
+        completed = true
+    }
+
+    private static func copyChildren(
+        of source: FilePath,
+        from reader: EXT4.EXT4Reader,
+        into formatter: EXT4.Formatter,
+        at target: FilePath,
+        linked: inout [EXT4.InodeNumber: FilePath],
+        logger: Logger
+    ) throws {
+        for name in try reader.listDirectory(source) where name != "." && name != ".." {
+            let child = source.join(name)
+            let childTarget = target.join(name)
+            let (inodeNumber, inode) = try reader.stat(child, followSymlinks: false)
+
+            // A second name for an inode already written is a hard link, not a copy.
+            if !inode.isDirectory, inode.linksCount > 1, let first = linked[inodeNumber] {
+                try formatter.link(link: childTarget, target: first)
+                continue
+            }
+
+            if inode.isDirectory {
+                try formatter.create(
+                    path: childTarget, mode: inode.mode, ts: timestamps(of: inode),
+                    uid: inode.fullUid, gid: inode.fullGid)
+                try copyChildren(
+                    of: child, from: reader, into: formatter,
+                    at: childTarget, linked: &linked, logger: logger)
+            } else if inode.isSymlink {
+                guard let link = symlinkTarget(of: inode, at: child, from: reader) else {
+                    logger.warning("[volume-copyup] unreadable symlink skipped: \(child)")
+                    continue
+                }
+                try formatter.create(
+                    path: childTarget, link: FilePath(link), mode: inode.mode,
+                    ts: timestamps(of: inode), uid: inode.fullUid, gid: inode.fullGid)
+            } else if inode.isRegularFile {
+                let contents = EXT4FileStream(reader: reader, path: child, size: UInt64(inode.size))
+                try formatter.create(
+                    path: childTarget, mode: inode.mode, ts: timestamps(of: inode),
+                    buf: contents, uid: inode.fullUid, gid: inode.fullGid)
+            } else {
+                // Device nodes, FIFOs and sockets carry a device number the
+                // formatter has no way to set, so they are reported rather than
+                // written as something they are not.
+                logger.warning("[volume-copyup] unsupported file type not copied: \(child)")
+                continue
+            }
+            if inode.linksCount > 1 { linked[inodeNumber] = childTarget }
+        }
+    }
+
+    /// A short target is stored in the inode's block array rather than in a data
+    /// block, and only the longer form can be read back as file contents.
+    private static func symlinkTarget(
+        of inode: EXT4.Inode, at path: FilePath, from reader: EXT4.EXT4Reader
+    ) -> String? {
+        if inode.size < 60 {
+            var block = inode.block
+            let bytes = withUnsafeBytes(of: &block) { Array($0.prefix(Int(inode.size))) }
+            return String(bytes: bytes, encoding: .utf8)
+        }
+        guard let data = try? reader.readFile(at: path, followSymlinks: false) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func timestamps(of inode: EXT4.Inode) -> FileTimestamps {
+        FileTimestamps(
+            access: Date(timeIntervalSince1970: TimeInterval(inode.atime)),
+            modification: Date(timeIntervalSince1970: TimeInterval(inode.mtime)),
+            creation: Date(timeIntervalSince1970: TimeInterval(inode.ctime))
+        )
+    }
+}
+
+/// Streams a file out of an EXT4 image so a copy never holds the whole file in
+/// memory — an image's data directory can carry files of any size.
+private final class EXT4FileStream: ReadableStream {
+    private let reader: EXT4.EXT4Reader
+    private let path: FilePath
+    private let size: UInt64
+    private var offset: UInt64 = 0
+
+    init(reader: EXT4.EXT4Reader, path: FilePath, size: UInt64) {
+        self.reader = reader
+        self.path = path
+        self.size = size
+    }
+
+    func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength: Int) -> Int {
+        guard offset < size, maxLength > 0 else { return 0 }
+        let want = min(UInt64(maxLength), size - offset)
+        let raw = UnsafeMutableRawBufferPointer(start: buffer, count: Int(want))
+        do {
+            let read = try reader.readFile(at: path, into: raw, offset: offset, followSymlinks: false)
+            offset += UInt64(read)
+            return read
+        } catch {
+            return -1
+        }
+    }
+}

--- a/Sources/socktainer/Utilities/VolumeCopyUp.swift
+++ b/Sources/socktainer/Utilities/VolumeCopyUp.swift
@@ -167,10 +167,13 @@ enum VolumeCopyUp {
     }
 
     private static func timestamps(of inode: EXT4.Inode) -> FileTimestamps {
+        // ext4 keeps creation time in crtime; ctime is the inode's own change
+        // time and would be the wrong answer here. An image that never recorded
+        // one leaves it at zero, where the formatter's default is better.
         FileTimestamps(
             access: Date(timeIntervalSince1970: TimeInterval(inode.atime)),
             modification: Date(timeIntervalSince1970: TimeInterval(inode.mtime)),
-            creation: Date(timeIntervalSince1970: TimeInterval(inode.ctime))
+            creation: inode.crtime == 0 ? nil : Date(timeIntervalSince1970: TimeInterval(inode.crtime))
         )
     }
 }

--- a/Tests/socktainerTests/Utilities/VolumeCopyUpTests.swift
+++ b/Tests/socktainerTests/Utilities/VolumeCopyUpTests.swift
@@ -1,0 +1,189 @@
+import ContainerizationEXT4
+import Foundation
+import Logging
+import SystemPackage
+import Testing
+
+@testable import socktainer
+
+@Suite("VolumeCopyUp — Docker's copy-up onto an empty named volume")
+final class VolumeCopyUpTests {
+    private let logger = Logger(label: "test")
+
+    @Test("a fresh volume counts as empty, one with contents does not")
+    func recognisesAnEmptyVolume() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.makeVolume()
+        #expect(VolumeCopyUp.isEmpty(volumeImagePath: fixture.volume.path))
+
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+            try fixture.writeFile(formatter, "/data/seed.txt", "hello\n", mode: 0o640)
+        }
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        #expect(!VolumeCopyUp.isEmpty(volumeImagePath: fixture.volume.path))
+    }
+
+    @Test("contents, ownership and permissions arrive at the volume root")
+    func copiesOwnershipAndPermissions() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        try fixture.makeRootfs { formatter in
+            try formatter.create(
+                path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o750),
+                uid: 1000, gid: 1000)
+            try fixture.writeFile(formatter, "/data/seed.txt", "hello\n", mode: 0o640, uid: 1000, gid: 1000)
+        }
+
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+        let (_, root) = try reader.stat(FilePath("/"))
+        #expect(root.fullUid == 1000)
+        #expect(root.fullGid == 1000)
+        #expect(root.mode & 0o777 == 0o750)
+
+        let (_, file) = try reader.stat(FilePath("/seed.txt"))
+        #expect(file.fullUid == 1000)
+        #expect(file.mode & 0o777 == 0o640)
+        #expect(try reader.readFile(at: FilePath("/seed.txt")) == Data("hello\n".utf8))
+    }
+
+    @Test("the rebuild leaves no /lost+found behind")
+    func dropsLostAndFound() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        #expect(
+            try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+                .listDirectory(FilePath("/")).contains("lost+found"))
+
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+        }
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let entries = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+            .listDirectory(FilePath("/"))
+        #expect(!entries.contains("lost+found"))
+    }
+
+    @Test("nested directories and symlinks survive the copy")
+    func copiesTreeAndSymlinks() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+            try formatter.create(path: FilePath("/data/nested"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+            try fixture.writeFile(formatter, "/data/nested/deep.txt", "deep\n", mode: 0o644)
+            try formatter.create(
+                path: FilePath("/data/link"), link: FilePath("/nested/deep.txt"),
+                mode: EXT4.Inode.Mode(.S_IFLNK, 0o777))
+        }
+
+        // The fixture has to hold a symlink before the copy can be blamed for one.
+        let sourceReader = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.rootfs.path))
+        #expect(try sourceReader.listDirectory(FilePath("/data")).contains("link"))
+
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+        #expect(try reader.readFile(at: FilePath("/nested/deep.txt")) == Data("deep\n".utf8))
+        let (_, link) = try reader.stat(FilePath("/link"), followSymlinks: false)
+        #expect(link.isSymlink)
+    }
+
+    @Test("a file larger than one read buffer arrives whole")
+    func copiesLargeFileInChunks() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        let payload = String(repeating: "abcdefgh", count: 200_000)  // 1.6 MB
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+            try fixture.writeFile(formatter, "/data/big.bin", payload, mode: 0o644)
+        }
+
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+        #expect(try reader.readFile(at: FilePath("/big.bin")) == Data(payload.utf8))
+    }
+
+    @Test("an image with nothing at the mount path still yields a usable volume")
+    func handlesMissingSourcePath() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/other"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+        }
+
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let entries = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+            .listDirectory(FilePath("/"))
+        #expect(!entries.contains("lost+found"))
+    }
+}
+
+// MARK: - Fixture
+
+private struct CopyUpFixture {
+    let directory: URL
+    let volume: URL
+    let rootfs: URL
+
+    init() {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("copyup-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        volume = directory.appendingPathComponent("volume.img")
+        rootfs = directory.appendingPathComponent("rootfs.ext4")
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// A volume as Apple Container hands it over: empty apart from /lost+found.
+    func makeVolume() throws {
+        let formatter = try EXT4.Formatter(FilePath(volume.path), blockSize: 4096, minDiskSize: 8 * 1024 * 1024)
+        try formatter.close()
+    }
+
+    func makeRootfs(_ build: (EXT4.Formatter) throws -> Void) throws {
+        let formatter = try EXT4.Formatter(FilePath(rootfs.path), blockSize: 4096, minDiskSize: 32 * 1024 * 1024)
+        try build(formatter)
+        try formatter.close()
+    }
+
+    func writeFile(
+        _ formatter: EXT4.Formatter, _ path: String, _ contents: String,
+        mode: UInt16, uid: UInt32 = 0, gid: UInt32 = 0
+    ) throws {
+        let stream = InputStream(data: Data(contents.utf8))
+        stream.open()
+        defer { stream.close() }
+        try formatter.create(
+            path: FilePath(path), mode: EXT4.Inode.Mode(.S_IFREG, mode),
+            buf: stream, uid: uid, gid: gid)
+    }
+}

--- a/Tests/socktainerTests/Utilities/VolumeCopyUpTests.swift
+++ b/Tests/socktainerTests/Utilities/VolumeCopyUpTests.swift
@@ -125,6 +125,29 @@ final class VolumeCopyUpTests {
         #expect(try reader.readFile(at: FilePath("/big.bin")) == Data(payload.utf8))
     }
 
+    @Test("a second name for a file stays a hard link, not a second copy")
+    func copiesHardLinksAsLinks() throws {
+        let fixture = CopyUpFixture()
+        defer { fixture.cleanUp() }
+        try fixture.makeVolume()
+        try fixture.makeRootfs { formatter in
+            try formatter.create(path: FilePath("/data"), mode: EXT4.Inode.Mode(.S_IFDIR, 0o755))
+            try fixture.writeFile(formatter, "/data/original.txt", "shared\n", mode: 0o644)
+            try formatter.link(link: FilePath("/data/second.txt"), target: FilePath("/data/original.txt"))
+        }
+
+        try VolumeCopyUp.populate(
+            volumeImagePath: fixture.volume.path, fromRootfs: fixture.rootfs.path,
+            sourcePath: "/data", logger: logger)
+
+        let reader = try EXT4.EXT4Reader(blockDevice: FilePath(fixture.volume.path))
+        let (firstNumber, first) = try reader.stat(FilePath("/original.txt"))
+        let (secondNumber, _) = try reader.stat(FilePath("/second.txt"))
+        #expect(firstNumber == secondNumber)
+        #expect(first.linksCount == 2)
+        #expect(try reader.readFile(at: FilePath("/second.txt")) == Data("shared\n".utf8))
+    }
+
     @Test("an image with nothing at the mount path still yields a usable volume")
     func handlesMissingSourcePath() throws {
         let fixture = CopyUpFixture()


### PR DESCRIPTION
# Pull Request

## Summary

A named volume mounted over a path that exists in the image comes up empty and root-owned,
so an image that ships a data directory owned by its non-root user cannot write to it.
Docker copies that directory into the volume when the volume is empty — contents, ownership
and permissions — and this does the same.

## Related Issue

Fixes #380.

## Changes

- `VolumeCopyUp`: rebuilds an empty EXT4 volume from the image's filesystem, preserving
  ownership, permissions and timestamps, following the same rules `EXT4Reader.export` uses
  (short symlink targets read from the inode, longer ones from their block; sockets, FIFOs
  and device nodes reported and skipped, as export skips them too). Files are streamed
  rather than held in memory, and a second name for an inode becomes a hard link.
- The mount root's own ownership is copied, not just its children — a directory the image
  hands to a non-root user is unusable otherwise.
- The rebuild drops `/lost+found`, which a Docker volume never carries.
- `ContainerCreateRoute`: runs the copy-up once the container exists, which is when the
  image's filesystem can be read, and always before it starts.

### On the existing Postgres path

`VolumeImageCleaner` removes `/lost+found` when `PGDATA` is set (#240, #241). That is one
symptom of this general gap: it never gave the volume the image's ownership, so a fresh
volume still failed. This PR skips that reformat when the volume is empty, since the
rebuild below would undo it, and leaves it in place for volumes that already have contents.
If you would rather retire the heuristic now that the general case is covered, that seems
reasonable to me, but it is your call and I have not touched it.

## Testing

Built and run against Apple Container 1.2.2 on macOS 26.5.2 (arm64).

- [x] `make fmt` passes (no formatting drift)
- [x] `make test` passes — 895 tests in 157 suites, 6 of them new for this
- [x] Unit tests added — empty detection, ownership and permissions, `/lost+found` removal,
      nested directories and symlinks, a file larger than one read buffer, and an image with
      nothing at the mount path
- [x] Manual testing performed — the reproduction in #380 now behaves as Docker does:
      `/data/git` comes up `1000:1000` and the write succeeds. A Supabase `postgres` image
      on a fresh volume reaches `database system is ready to accept connections`, where it
      previously failed on `pg_internal.init`.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off ([DCO](https://probot.github.io/apps/dco/))

## Note

There is an overlap worth flagging: #372 adds `resolveRootfsPath`, which answers the same
question this needs — where a never-started container's filesystem lives. This PR reads
`runtime-configuration.json` itself so it does not depend on that PR landing. If #372 goes
in first, folding the two together would be an improvement and I am happy to do it.
